### PR TITLE
feat: registries/ — kind 判別ユニオン スキーマ＋v1 発効時点の登録現物（W0a stage2）

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NeNe フリート・フロント統一規約の**配布物（versioned 実行可
 | `packages/nene2-tokens` | Core Token Contract v1（color 28＋shadow 4）・CONTRACT_TOKENS export・validate:themes・themegen・codemod 写像表 v1 | **v1.0.0-rc.1 実装済**（W0a stage1・凍結レビュー資料 = `docs/contract-freeze-review-2026-07-18.md`・マージ/publish は施主承認後） |
 | `packages/nene2-standards` | ESLint flat config 配布（合成規律=ルール単位1定義・plugin 同梱）・Stylelint 2枚組・known-utility lint・`nene2-check`（conformance skeleton・fail-closed）・`init --scan` | 未実装 |
 | `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | 未実装（W0a では骨格まで可） |
-| `registries/` | 構造レジストリ（恒久公認差異）＋負債台帳（lint-baseline / legacy-manifest）＋waiver — kind 判別ユニオン jsonc | 未実装 |
+| `packages/nene2-standards/registries/` | 構造レジストリ（恒久公認差異）＋負債台帳（lint-baseline / legacy-manifest）＋waiver — kind 判別ユニオン jsonc（スキーマ = `src/registries/schema.ts`・配置は 05 §1.1 準拠でパッケージ同梱＝製品は pinned 版で消費） | **v1 発効時点の現物 登録済**（経過措置2件は kind=transition・批准レビュー送り） |
 | `fleet-baseline.json` | 基盤4パッケージ semver の単一マニフェスト | 未作成（版が確定済みなのは nene2-client ^1.1.0 のみ） |
 
 ## 規律

--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -21,7 +21,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "registries"
   ],
   "scripts": {
     "build": "tsc --build"

--- a/packages/nene2-standards/registries/fleet.jsonc
+++ b/packages/nene2-standards/registries/fleet.jsonc
@@ -1,0 +1,123 @@
+// registries/fleet.jsonc — 公認差異レジストリ（規約 v1 発効時点の登録現物）
+//
+// 正本表: 規約 README §5（= 02 §11 の運用分類）・スキーマ: src/registries/schema.ts
+// （kind 判別ユニオン — 会議R5(5)決定）。
+// 追加経路は fleet-tooling への PR のみ（REG-2 — 製品リポ側追記は gate-integrity FAIL）。
+// 負債台帳（legacy-manifest / lint-baseline）は縮小単調（REG-3）・ratchet は fleet-tooling CI。
+// waiver: v1 発効時点の登録なし（README §5）。
+// fonts / widget-entry / testid-allowlist / identical-allowlist: 各リポの init --scan 時に
+// 初期化（05 §8.2 末尾注記）— v1 発効時点のエントリなし。
+{
+  "schema": "nene2-registries/1",
+  "entries": [
+    // ---- 構造レジストリ（恒久・外部制約由来のみ・蒸し返し禁止） ----
+    {
+      "kind": "authorized-divergence",
+      "id": "records-cookie-auth",
+      "repo": "nene-records",
+      "overrides": "nene2.overrides.recordsCookieAuth",
+      // 外部制約: トークンを JS に持たせない設計（HttpOnly cookie＋X-Requested-With CSRF）
+      "reasonRef": "adr:records#cookie-csrf",
+      "review": "認証方式の全面改訂時"
+    },
+    {
+      "kind": "authorized-divergence",
+      "id": "corpus-widget-session-token",
+      "repo": "nene-corpus",
+      "overrides": "nene2.overrides.corpusWidgetSessionToken",
+      // 外部制約: 匿名利用者 widget と admin JWT の分離（#340 が正運用 exemplar — R3④A-7）
+      "reasonRef": "council:minutes#R3-4-A-7",
+      "review": "widget 認証方式の全面改訂時"
+    },
+    {
+      "kind": "authorized-divergence",
+      "id": "vault-json-catalog",
+      "repo": "nene-vault",
+      "overrides": "nene2.overrides.vaultJsonCatalog",
+      // 外部制約: バックエンドと locale カタログを JSON で共有（ADR 0005・DotPaths 型生成）
+      "reasonRef": "adr:vault#0005",
+      "review": "バックエンド locale 共有の解消時"
+    },
+    {
+      "kind": "scoped-theme",
+      "id": "corpus-widget-scoped-theme",
+      "repo": "nene-corpus",
+      "variant": "widget",
+      // テーマ・lang スコープ = マウントルート要素（<html> 非所有。I18nProvider の lang scope も
+      // 同一要素 — AM-18）。validate:themes は --container フラグで検査
+      "selector": "(widget mount root)",
+      "reasonRef": "council:minutes#R2-6-widget-scope"
+    },
+    {
+      "kind": "scoped-theme",
+      "id": "concierge-widget-scoped-theme",
+      "repo": "nene-concierge",
+      "variant": "widget",
+      "selector": "(widget mount root)",
+      "reasonRef": "council:minutes#R2-6-widget-scope"
+    },
+    {
+      "kind": "scoped-theme",
+      "id": "records-public-scoped-theme",
+      "repo": "nene-records",
+      "variant": "local",
+      // 31テーマ公開面＋テーマプレビュー。参照クロージャ検査は局所スコープとして FAIL 判定・
+      // fill 領域で充足（AM-1）
+      "selector": ".nene-public[data-theme]",
+      "reasonRef": "council:minutes#R2-6-records-local-scope"
+    },
+    {
+      "kind": "injector",
+      "id": "records-theme-injector",
+      "repo": "nene-records",
+      // DB 由来テーマのランタイム注入 —「違反者ではなく生きた exemplar」（AM-5）。
+      // 注入可能トークンは CONTRACT_TOKENS から導出（depcruise required の対象列挙元）
+      "files": [
+        "src/shared/ui/theme/theme-customization.ts",
+        "src/shared/ui/theme/theme-from-customization.ts"
+      ],
+      "reasonRef": "council:minutes#R4-AM-5"
+    },
+
+    // ---- 負債台帳（縮小単調・green にはエントリ 0 / frozenCount 0 が必要 — AM-14） ----
+    {
+      "kind": "lint-baseline",
+      "id": "concierge-jp-baseline",
+      "repo": "nene-concierge",
+      "rule": "no-restricted-syntax (noHardcodedJapanese 3ノード)",
+      // frozenCount: null = W0b ゲート導入 PR の init --scan で実測生成（T-3 — 手書き MUST NOT）
+      "frozenCount": null,
+      "initializedBy": "init --scan (W0b ゲート導入 PR)"
+    },
+    {
+      "kind": "lint-baseline",
+      "id": "corpus-jp-baseline",
+      "repo": "nene-corpus",
+      "rule": "no-restricted-syntax (noHardcodedJapanese 3ノード)",
+      "frozenCount": null,
+      "initializedBy": "init --scan (W0b ゲート導入 PR)"
+    },
+
+    // ---- 経過措置2件（kind ラベル未決 → transition 扱い・批准レビュー送り） ----
+    // 05 §8.2 #7/#8 は kind=authorized-divergence 表記（起草時ドラフト）だが、用語集
+    // 「公認差異＝恒久」・会議⑤⑨「登録理由は外部制約由来のみ」と衝突するため、運用分類の
+    // 正本（02 §11・README §5「経過措置」）に従い transition として登録する。
+    // kind ラベルの最終確定（transition 系 kind の要否）は批准レビュー（README §8 未解消リスト）。
+    {
+      "kind": "transition",
+      "id": "invoice-recover-auth-seam",
+      "repo": "nene-invoice",
+      "summary": "silent refresh（httpOnly refresh cookie＋CSRF）— 単純 sessionStorage 置換は機能後退につき禁止。recoverAuth seam＋ADR＋demo ゲートを前提に transport 移行",
+      "wave": "W2b",
+      "reasonRef": "council:minutes#R3-4-A-8"
+    },
+    {
+      "kind": "transition",
+      "id": "concierge-widget-anonymous-transport",
+      "repo": "nene-concierge",
+      "summary": "widget は匿名 transport（tokenStore を渡さない createNene2Transport({ baseUrl })）",
+      "wave": "W2a",
+      "reasonRef": "council:minutes#R3-4-A-8"
+    }
+  ]
+}

--- a/packages/nene2-standards/src/index.ts
+++ b/packages/nene2-standards/src/index.ts
@@ -30,6 +30,22 @@ export {
   TESTING_SYNTAX,
 } from './selectors.js';
 export { I18N_JP_SYNTAX } from './configs/restrictions.js';
+export {
+  ALL_KINDS,
+  DEBT_KINDS,
+  STRUCTURAL_KINDS,
+  REGISTRIES_SCHEMA_ID,
+  WAIVER_MAX_DAYS,
+  parseRegistries,
+  stripJsonc,
+  validateRegistries,
+} from './registries/schema.js';
+export type {
+  RegistriesDocument,
+  RegistryDiagnostic,
+  RegistryEntry,
+  RegistryKind,
+} from './registries/schema.js';
 
 /** 全断片の正準合成（gate-integrity の canonical 表・パッケージテストの検出プローブが使用）。 */
 export function composedConfig(): Linter.Config[] {

--- a/packages/nene2-standards/src/registries/registries.test.ts
+++ b/packages/nene2-standards/src/registries/registries.test.ts
@@ -1,0 +1,178 @@
+/**
+ * registries スキーマ検査 — v1 発効時点の現物（fleet.jsonc）green＋故意 fail 両方向。
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALL_KINDS,
+  parseRegistries,
+  REGISTRIES_SCHEMA_ID,
+  stripJsonc,
+  validateRegistries,
+} from './schema.js';
+
+const fleetPath = fileURLToPath(new URL('../../registries/fleet.jsonc', import.meta.url));
+const fleetSource = readFileSync(fleetPath, 'utf8');
+
+const NOW = new Date('2026-07-14T00:00:00Z');
+
+function doc(entries: unknown[]): string {
+  return JSON.stringify({ schema: REGISTRIES_SCHEMA_ID, entries });
+}
+
+describe('v1 発効時点の登録現物（fleet.jsonc）', () => {
+  it('形式検査 green・パース可能', () => {
+    expect(validateRegistries(fleetSource, NOW)).toEqual([]);
+    const parsed = parseRegistries(fleetSource, NOW);
+    expect(parsed.schema).toBe(REGISTRIES_SCHEMA_ID);
+  });
+
+  it('規約 README §5 の表と同型（恒久3・scoped-theme 3・injector 1・lint-baseline 2・経過措置2・waiver 0）', () => {
+    const parsed = parseRegistries(fleetSource, NOW);
+    const byKind = new Map<string, number>();
+    for (const e of parsed.entries) byKind.set(e.kind, (byKind.get(e.kind) ?? 0) + 1);
+    expect(byKind.get('authorized-divergence')).toBe(3);
+    expect(byKind.get('scoped-theme')).toBe(3);
+    expect(byKind.get('injector')).toBe(1);
+    expect(byKind.get('lint-baseline')).toBe(2);
+    expect(byKind.get('transition')).toBe(2);
+    expect(byKind.get('waiver')).toBeUndefined();
+  });
+
+  it('経過措置2件（invoice seam / concierge widget）は transition・批准レビュー送りの注記付き', () => {
+    const parsed = parseRegistries(fleetSource, NOW);
+    const transitions = parsed.entries.filter((e) => e.kind === 'transition');
+    expect(new Set(transitions.map((e) => e.repo))).toEqual(
+      new Set(['nene-invoice', 'nene-concierge']),
+    );
+    expect(fleetSource).toContain('批准レビュー');
+  });
+
+  it('恒久差異は overrides 実行可能登録名を持つ（散文登録 MUST NOT — R1⑨）', () => {
+    const parsed = parseRegistries(fleetSource, NOW);
+    for (const e of parsed.entries) {
+      if (e.kind === 'authorized-divergence') {
+        expect(e.overrides).toMatch(/^nene2\.overrides\./);
+      }
+    }
+  });
+});
+
+describe('故意 fail（fail-closed の両方向確認）', () => {
+  it('スキーマ外 kind は FAIL', () => {
+    const diags = validateRegistries(
+      doc([{ kind: 'my-new-exception', id: 'x', repo: 'nene-x' }]),
+      NOW,
+    );
+    expect(diags.some((d) => d.message.includes('スキーマ外'))).toBe(true);
+  });
+
+  it('authorized-divergence の reasonRef 欠落は FAIL（REG-4(a)）', () => {
+    const diags = validateRegistries(
+      doc([{ kind: 'authorized-divergence', id: 'x', repo: 'nene-x', review: 'r' }]),
+      NOW,
+    );
+    expect(diags.some((d) => d.message.includes('reasonRef'))).toBe(true);
+  });
+
+  it('waiver の until >90日は FAIL（REG-4(b)）', () => {
+    const diags = validateRegistries(
+      doc([
+        {
+          kind: 'waiver',
+          id: 'x',
+          repo: 'nene-x',
+          key: 'styling.utilities',
+          issuedOn: '2026-07-14',
+          until: '2026-11-01',
+          reasonRef: 'issue:x#1',
+        },
+      ]),
+      NOW,
+    );
+    expect(diags.some((d) => d.message.includes('90日'))).toBe(true);
+  });
+
+  it('waiver ≤90日は green・失効済みは FAIL 報告', () => {
+    const ok = validateRegistries(
+      doc([
+        {
+          kind: 'waiver',
+          id: 'x',
+          repo: 'nene-deal',
+          key: 'styling.utilities',
+          issuedOn: '2026-07-14',
+          until: '2026-09-04',
+          reasonRef: 'issue:deal#calm-design-decision',
+        },
+      ]),
+      NOW,
+    );
+    expect(ok).toEqual([]);
+    const expired = validateRegistries(
+      doc([
+        {
+          kind: 'waiver',
+          id: 'x',
+          repo: 'nene-deal',
+          key: 'styling.utilities',
+          issuedOn: '2026-04-01',
+          until: '2026-06-01',
+          reasonRef: 'issue:deal#calm-design-decision',
+        },
+      ]),
+      NOW,
+    );
+    expect(expired.some((d) => d.message.includes('失効'))).toBe(true);
+  });
+
+  it("legacy-manifest の maxLines/maxBytes 0 プレースホルダは FAIL（AM-25'）", () => {
+    const diags = validateRegistries(
+      doc([
+        {
+          kind: 'legacy-manifest',
+          id: 'x',
+          repo: 'nene-profile',
+          path: 'src/shared/ui/profile-ds.css',
+          maxLines: 2921,
+          maxBytes: 0,
+        },
+      ]),
+      NOW,
+    );
+    expect(diags.some((d) => d.message.includes('maxBytes'))).toBe(true);
+  });
+
+  it('id 重複・schema 不一致・パース不能は FAIL', () => {
+    const dup = validateRegistries(
+      doc([
+        { kind: 'transition', id: 'x', repo: 'a', summary: 's', wave: 'W2a', reasonRef: 'r' },
+        { kind: 'transition', id: 'x', repo: 'b', summary: 's', wave: 'W2b', reasonRef: 'r' },
+      ]),
+      NOW,
+    );
+    expect(dup.some((d) => d.message.includes('重複'))).toBe(true);
+    expect(
+      validateRegistries(JSON.stringify({ schema: 'nene2-registries/2', entries: [] }), NOW).length,
+    ).toBeGreaterThan(0);
+    expect(validateRegistries('{ broken', NOW)[0]?.message).toContain('パース不能');
+  });
+});
+
+describe('stripJsonc', () => {
+  it('コメント・末尾カンマを除去し、文字列中の // は保持する', () => {
+    const src = `{
+      // line comment
+      "a": "http://example.com", /* block */
+      "b": [1, 2,],
+    }`;
+    expect(JSON.parse(stripJsonc(src))).toEqual({ a: 'http://example.com', b: [1, 2] });
+  });
+
+  it('kind 列挙は 9種＋scoped-theme＋transition＋waiver', () => {
+    expect(ALL_KINDS).toHaveLength(11);
+  });
+});

--- a/packages/nene2-standards/src/registries/schema.ts
+++ b/packages/nene2-standards/src/registries/schema.ts
@@ -1,0 +1,382 @@
+/**
+ * registries スキーマ — kind 判別ユニオン（規約 05 §8.1 REG-1〜4・会議R5(5)決定）。
+ *
+ * - 単一スキーマ・1検査器・エントリ種ごとの宣言的政策表（REG-1）
+ * - 2クラス政策（REG-3）: 負債台帳（legacy-manifest / lint-baseline）= 縮小単調／
+ *   構造レジストリ（それ以外）= 中央 PR＋reason-ref 付きで追加可
+ * - waiver は第4のエントリ種: until ≤90日・reason-ref 実在アンカー必須（REG-4(b)）
+ * - kind 全列挙（会議R5(5)の9種＋scoped-theme）＋ transition（kind ラベル未決の経過措置 —
+ *   規約 README §8 未解消リスト・批准レビュー送り。02 §11 の運用分類を保持するための仮 kind）
+ *
+ * 縮小単調検査（ratchet）自体は fleet-tooling CI の管轄（#17）— 本モジュールは
+ * 形式検査（スキーマ・政策の静的条件）のみを提供する。
+ */
+
+export const REGISTRIES_SCHEMA_ID = 'nene2-registries/1';
+
+/** 負債台帳 kind（縮小単調 — 追加・変更 FAIL・削除のみ可。green にはエントリ 0 が必要） */
+export const DEBT_KINDS = ['legacy-manifest', 'lint-baseline'] as const;
+
+/** 構造レジストリ kind（恒久・中央 PR＋reason-ref で追加可・蒸し返し禁止） */
+export const STRUCTURAL_KINDS = [
+  'authorized-divergence',
+  'injector',
+  'widget-entry',
+  'fonts',
+  'testid-allowlist',
+  'identical-allowlist',
+  'scoped-theme',
+] as const;
+
+/** 経過措置（kind ラベル未決 — 批准レビュー送り。恒久登録ではない・due は board.txt 管理） */
+export const TRANSITION_KIND = 'transition' as const;
+export const WAIVER_KIND = 'waiver' as const;
+
+export const ALL_KINDS = [
+  ...DEBT_KINDS,
+  ...STRUCTURAL_KINDS,
+  TRANSITION_KIND,
+  WAIVER_KIND,
+] as const;
+
+export type RegistryKind = (typeof ALL_KINDS)[number];
+
+interface EntryBase {
+  kind: RegistryKind;
+  id: string;
+  repo: string;
+}
+
+export interface AuthorizedDivergenceEntry extends EntryBase {
+  kind: 'authorized-divergence';
+  /** 実行可能登録の override 名（nene2.overrides.* — 散文登録 MUST NOT） */
+  overrides?: string;
+  /** 外部制約の出典（REG-4(a): 理由は外部制約由来のみ） */
+  reasonRef: string;
+  /** 再審トリガー（外部制約が消えた時点で削除する） */
+  review: string;
+}
+
+export interface WaiverEntry extends EntryBase {
+  kind: 'waiver';
+  key: string;
+  /** ≤90日（REG-4(b)）。失効判定は中央 rollup・リポ CI はスキーマ検査＋T-7 警告のみ */
+  until: string;
+  issuedOn: string;
+  reasonRef: string;
+}
+
+export interface LegacyManifestEntry extends EntryBase {
+  kind: 'legacy-manifest';
+  path: string;
+  /** pinned prettier 整形後の行数（AM-25': 初期値は init --scan 実測値・0 プレースホルダ MUST NOT） */
+  maxLines: number;
+  maxBytes: number;
+}
+
+export interface LintBaselineEntry extends EntryBase {
+  kind: 'lint-baseline';
+  rule: string;
+  /** 凍結違反の件数（init --scan / ゲート導入 PR で実測生成。green には 0 が必要 — AM-14） */
+  frozenCount: number | null;
+  /** null = ゲート導入時に init --scan で生成（T-3）。生成前の座席登録を明示する */
+  initializedBy: string;
+}
+
+export interface InjectorEntry extends EntryBase {
+  kind: 'injector';
+  files: string[];
+  reasonRef: string;
+}
+
+export interface ScopedThemeEntry extends EntryBase {
+  kind: 'scoped-theme';
+  variant: 'widget' | 'local';
+  /** widget: マウントルート要素／local: 局所スコープセレクタ */
+  selector: string;
+  reasonRef: string;
+}
+
+export interface WidgetEntryEntry extends EntryBase {
+  kind: 'widget-entry';
+  files: string[];
+  reasonRef: string;
+}
+
+export interface FontsEntry extends EntryBase {
+  kind: 'fonts';
+  families: string[];
+  reasonRef: string;
+}
+
+export interface TestidAllowlistEntry extends EntryBase {
+  kind: 'testid-allowlist';
+  testids: string[];
+  reasonRef: string;
+}
+
+export interface IdenticalAllowlistEntry extends EntryBase {
+  kind: 'identical-allowlist';
+  keys: string[];
+  reasonRef: string;
+}
+
+export interface TransitionEntry extends EntryBase {
+  kind: 'transition';
+  /** 経過措置の内容（02 §11 の分類が正本） */
+  summary: string;
+  /** 解消 Wave（due の正本は board.txt — M-4） */
+  wave: string;
+  reasonRef: string;
+}
+
+export type RegistryEntry =
+  | AuthorizedDivergenceEntry
+  | WaiverEntry
+  | LegacyManifestEntry
+  | LintBaselineEntry
+  | InjectorEntry
+  | ScopedThemeEntry
+  | WidgetEntryEntry
+  | FontsEntry
+  | TestidAllowlistEntry
+  | IdenticalAllowlistEntry
+  | TransitionEntry;
+
+export interface RegistriesDocument {
+  schema: typeof REGISTRIES_SCHEMA_ID;
+  entries: RegistryEntry[];
+}
+
+export interface RegistryDiagnostic {
+  entryId: string;
+  message: string;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+export const WAIVER_MAX_DAYS = 90;
+
+/** jsonc（行コメント・ブロックコメント・末尾カンマ）を JSON.parse 可能な文字列へ落とす。 */
+export function stripJsonc(source: string): string {
+  let out = '';
+  let inString = false;
+  let inLine = false;
+  let inBlock = false;
+  for (let i = 0; i < source.length; i++) {
+    const c = source[i];
+    const next = source[i + 1];
+    if (inLine) {
+      if (c === '\n') {
+        inLine = false;
+        out += c;
+      }
+      continue;
+    }
+    if (inBlock) {
+      if (c === '*' && next === '/') {
+        inBlock = false;
+        i++;
+      }
+      continue;
+    }
+    if (inString) {
+      out += c;
+      if (c === '\\') {
+        out += next ?? '';
+        i++;
+      } else if (c === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      out += c;
+      continue;
+    }
+    if (c === '/' && next === '/') {
+      inLine = true;
+      i++;
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      inBlock = true;
+      i++;
+      continue;
+    }
+    out += c;
+  }
+  // 末尾カンマの除去（] } の直前）
+  return out.replace(/,(\s*[}\]])/g, '$1');
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function requireString(
+  entry: Record<string, unknown>,
+  field: string,
+  id: string,
+  diags: RegistryDiagnostic[],
+): void {
+  const v = entry[field];
+  if (typeof v !== 'string' || v.trim() === '') {
+    diags.push({ entryId: id, message: `${field} は非空文字列 MUST` });
+  }
+}
+
+function requireStringArray(
+  entry: Record<string, unknown>,
+  field: string,
+  id: string,
+  diags: RegistryDiagnostic[],
+): void {
+  const v = entry[field];
+  if (!Array.isArray(v) || v.length === 0 || !v.every((x) => typeof x === 'string')) {
+    diags.push({ entryId: id, message: `${field} は非空の文字列配列 MUST` });
+  }
+}
+
+/**
+ * 形式検査（fail-closed: パース不能・スキーマ外は全て diagnostics）。
+ * 参照日 now は waiver の ≤90日検査に使う（未指定は現在時刻）。
+ */
+export function validateRegistries(source: string, now = new Date()): RegistryDiagnostic[] {
+  const diags: RegistryDiagnostic[] = [];
+  let doc: unknown;
+  try {
+    doc = JSON.parse(stripJsonc(source));
+  } catch (e) {
+    return [{ entryId: '(document)', message: `jsonc パース不能: ${(e as Error).message}` }];
+  }
+  if (!isRecord(doc))
+    return [{ entryId: '(document)', message: 'ドキュメントはオブジェクト MUST' }];
+  if (doc['schema'] !== REGISTRIES_SCHEMA_ID) {
+    diags.push({ entryId: '(document)', message: `schema は "${REGISTRIES_SCHEMA_ID}" MUST` });
+  }
+  const entries = doc['entries'];
+  if (!Array.isArray(entries)) {
+    diags.push({ entryId: '(document)', message: 'entries は配列 MUST' });
+    return diags;
+  }
+  const seen = new Set<string>();
+  for (const raw of entries) {
+    if (!isRecord(raw)) {
+      diags.push({ entryId: '(unknown)', message: 'エントリはオブジェクト MUST' });
+      continue;
+    }
+    const id = typeof raw['id'] === 'string' ? raw['id'] : '(no id)';
+    requireString(raw, 'id', id, diags);
+    requireString(raw, 'repo', id, diags);
+    if (seen.has(id)) diags.push({ entryId: id, message: 'id 重複 MUST NOT' });
+    seen.add(id);
+    const kind = raw['kind'];
+    if (typeof kind !== 'string' || !(ALL_KINDS as readonly string[]).includes(kind)) {
+      diags.push({
+        entryId: id,
+        message: `kind "${String(kind)}" はスキーマ外（列挙: ${ALL_KINDS.join(', ')}）`,
+      });
+      continue;
+    }
+    switch (kind as RegistryKind) {
+      case 'authorized-divergence':
+        requireString(raw, 'reasonRef', id, diags);
+        requireString(raw, 'review', id, diags);
+        break;
+      case 'waiver': {
+        requireString(raw, 'key', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        requireString(raw, 'until', id, diags);
+        requireString(raw, 'issuedOn', id, diags);
+        const until = Date.parse(String(raw['until']));
+        const issuedOn = Date.parse(String(raw['issuedOn']));
+        if (Number.isNaN(until) || Number.isNaN(issuedOn)) {
+          diags.push({ entryId: id, message: 'until / issuedOn は ISO 日付 MUST' });
+        } else {
+          if ((until - issuedOn) / DAY_MS > WAIVER_MAX_DAYS) {
+            diags.push({
+              entryId: id,
+              message: `waiver は until ≤ 発行から${WAIVER_MAX_DAYS}日 MUST（REG-4(b)）`,
+            });
+          }
+          if (until < now.getTime()) {
+            // 失効の blocking 判定は中央 rollup（R5(5)分業）— ここでは形式違反として報告のみ
+            diags.push({
+              entryId: id,
+              message: 'waiver は失効済み（中央 rollup が red＋是正 issue 起票）',
+            });
+          }
+        }
+        break;
+      }
+      case 'legacy-manifest': {
+        requireString(raw, 'path', id, diags);
+        for (const f of ['maxLines', 'maxBytes'] as const) {
+          const v = raw[f];
+          if (typeof v !== 'number' || !Number.isInteger(v) || v <= 0) {
+            diags.push({
+              entryId: id,
+              message: `${f} は正の整数 MUST（AM-25': 0/プレースホルダ運用 MUST NOT・初期値は init --scan 実測）`,
+            });
+          }
+        }
+        break;
+      }
+      case 'lint-baseline': {
+        requireString(raw, 'rule', id, diags);
+        requireString(raw, 'initializedBy', id, diags);
+        const fc = raw['frozenCount'];
+        if (fc !== null && (typeof fc !== 'number' || !Number.isInteger(fc) || fc < 0)) {
+          diags.push({ entryId: id, message: 'frozenCount は null（未走査）か非負整数 MUST' });
+        }
+        break;
+      }
+      case 'injector':
+        requireStringArray(raw, 'files', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        break;
+      case 'scoped-theme': {
+        requireString(raw, 'selector', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        if (raw['variant'] !== 'widget' && raw['variant'] !== 'local') {
+          diags.push({ entryId: id, message: "variant は 'widget' | 'local' MUST" });
+        }
+        break;
+      }
+      case 'widget-entry':
+        requireStringArray(raw, 'files', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        break;
+      case 'fonts':
+        requireStringArray(raw, 'families', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        break;
+      case 'testid-allowlist':
+        requireStringArray(raw, 'testids', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        break;
+      case 'identical-allowlist':
+        requireStringArray(raw, 'keys', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        break;
+      case 'transition':
+        requireString(raw, 'summary', id, diags);
+        requireString(raw, 'wave', id, diags);
+        requireString(raw, 'reasonRef', id, diags);
+        break;
+    }
+  }
+  return diags;
+}
+
+/** パース＋検査（診断ゼロのときのみ返す — fail-closed）。 */
+export function parseRegistries(source: string, now = new Date()): RegistriesDocument {
+  const diags = validateRegistries(source, now);
+  if (diags.length > 0) {
+    throw new Error(
+      `registries が形式検査 FAIL:\n${diags.map((d) => `- [${d.entryId}] ${d.message}`).join('\n')}`,
+    );
+  }
+  return JSON.parse(stripJsonc(source)) as RegistriesDocument;
+}


### PR DESCRIPTION
## 概要（W0a stage2 — 論点3: registries）

**base = #2**（nene2-standards パッケージに同梱するため。#2 マージ後に本 PR の base が main に自動切替）

- **スキーマ**（`src/registries/schema.ts`）: kind 判別ユニオン（会議 R5(5) の9種 = authorized-divergence / waiver / legacy-manifest / lint-baseline / injector / widget-entry / fonts / testid-allowlist / identical-allowlist ＋ scoped-theme ＋ transition）
- **政策の形式検査**（fail-closed）: REG-4(a) reason-ref 必須／REG-4(b) waiver until ≤90日／AM-25' の maxLines・maxBytes 0 プレースホルダ拒否／id 重複／スキーマ外 kind 拒否
- **v1 発効時点の登録現物**（`registries/fleet.jsonc`・規約 README §5 の表を転記）: 恒久3・scoped-theme 3・injector 1・lint-baseline 2・経過措置2・waiver 0

## 経過措置2件の kind（指示どおり）

invoice recoverAuth seam（W2b）・concierge widget 匿名 transport（W2a）は **kind ラベル未決のまま `transition` 扱いで登録**し、jsonc 内コメントで**批准レビュー送り**を明記（05 §8.2 #7/#8 の `authorized-divergence` 表記 vs 用語集「公認差異＝恒久」の衝突 — README §8 未解消リスト）。

## 起草判断（批准レビュー対象）

- **配置**: 05 §1.1（packages/nene2-standards/registries/ — パッケージ同梱）を採用。リポ README の旧表記（トップレベル registries/）は追随更新。製品は pinned 版で消費（#12 hermetic と整合）
- **reasonRef の綴り**: 実在アンカー解決（check:exemplars 同一機構）の配線前につき、ADR 実在分は `adr:<repo>#<slug>`・会議決定由来は `council:minutes#<決定ID>` の暫定スキーム。解決検査は AI-21（check:exemplars）スコープ
- **lint-baseline の frozenCount: null** = 「W0b の init --scan で実測生成する座席」の明示（手書き初期値 MUST NOT — T-3/AM-10 と整合）
- **transition に summary/wave/reasonRef を必須化**（due の正本は board.txt — M-4）

## テスト（12本・故意 fail 確認込み）

現物 green ＋ 故意 fail 7方向（スキーマ外 kind / reasonRef 欠落 / waiver >90日 / 失効 waiver / 0 プレースホルダ / id 重複 / パース不能）。

## 未実施

- ratchet（縮小単調の diff 検査 — merge-base 基底）は fleet-tooling CI ゲート #17 のスコープ（W0a 行外）— 本 PR は形式検査まで
- reasonRef アンカーの実在解決（check:exemplars 機構）— AI-21

CI: ローカル `npm run check` 全 green（test 113）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)