### PR TITLE
feat: nene2-check — conformance skeleton（5状態・fail-closed・gate-integrity・init --scan）（W0a stage2）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4768,7 +4768,6 @@
       "version": "3.3.16",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5035,7 +5034,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -5063,7 +5061,6 @@
       "version": "8.5.19",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
       "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
-      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5156,7 +5153,6 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -6711,7 +6707,12 @@
         "eslint-plugin-import-x": "^4.16.1",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-testing-library": "^7.6.1",
+        "postcss": "^8.5.6",
+        "prettier": "3.6.2",
         "typescript-eslint": "^8.35.0"
+      },
+      "bin": {
+        "nene2-check": "dist/checks/cli.js"
       },
       "peerDependencies": {
         "eslint": ">=9",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "vitest run",
     "build": "tsc --build packages/*",
     "check:cli": "node packages/nene2-tokens/dist/cli.js validate packages/nene2-tokens/themes/reference.css",
-    "check": "npm run type-check && npm run lint && npm run format:check && npm run test && npm run check:cli"
+    "check": "npm run type-check && npm run lint && npm run format:check && npm run test && npm run check:cli && npm run check:nene2-check",
+    "check:nene2-check": "cd packages/nene2-standards/tests/fixtures/check-app && node ../../../dist/checks/cli.js conformance --repo nene-check-smoke"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.0",

--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -35,6 +35,8 @@
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-testing-library": "^7.6.1",
+    "postcss": "^8.5.6",
+    "prettier": "3.6.2",
     "typescript-eslint": "^8.35.0"
   },
   "peerDependencies": {
@@ -45,5 +47,8 @@
     "stylelint": {
       "optional": true
     }
+  },
+  "bin": {
+    "nene2-check": "./dist/checks/cli.js"
   }
 }

--- a/packages/nene2-standards/src/checks/cli.ts
+++ b/packages/nene2-standards/src/checks/cli.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * nene2-check CLI（規約 05 §5.1 C-1 — 製品側 package.json は "check": "nene2-check"）。
+ *
+ * W0a skeleton のサブコマンド:
+ *   nene2-check conformance [--repo <name>] [--registries <path>] [--out <file>]
+ *   nene2-check gate-integrity
+ *   nene2-check init --scan [--out <file>] / init --check
+ *
+ * 正準シーケンス（type-check → eslint → … → build — 05 §5.1）の駆動は W0b/W1 配線
+ * （検査器の空虚合格を出荷しないため、未配線工程は conformance で unknown を出力する）。
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { validateConformance } from './conformance.js';
+import { checkGateIntegrity } from './gate-integrity.js';
+import { initCheck, initScan, ledgersAlreadyInitialized } from './init-scan.js';
+import { loadRegistries, runConformance } from './run.js';
+
+interface Args {
+  command: string;
+  flags: Map<string, string | true>;
+}
+
+function parseArgs(argv: string[]): Args {
+  const [command = 'conformance', ...rest] = argv;
+  const flags = new Map<string, string | true>();
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a?.startsWith('--')) {
+      const key = a.slice(2);
+      const next = rest[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags.set(key, next);
+        i++;
+      } else {
+        flags.set(key, true);
+      }
+    }
+  }
+  return { command, flags };
+}
+
+function detectRepo(cwd: string): string {
+  try {
+    const pkg = JSON.parse(readFileSync(path.join(cwd, 'package.json'), 'utf8')) as {
+      name?: string;
+    };
+    if (pkg.name) return pkg.name.replace(/^@[^/]+\//, '');
+  } catch {
+    // fall through
+  }
+  return path.basename(cwd);
+}
+
+async function main(): Promise<number> {
+  const { command, flags } = parseArgs(process.argv.slice(2));
+  const cwd = process.cwd();
+  const registriesPath =
+    typeof flags.get('registries') === 'string' ? String(flags.get('registries')) : undefined;
+  const repo = typeof flags.get('repo') === 'string' ? String(flags.get('repo')) : detectRepo(cwd);
+
+  switch (command) {
+    case 'conformance': {
+      const vector = await runConformance({ cwd, repo, registriesPath });
+      const schemaErrors = validateConformance(vector);
+      if (schemaErrors.length > 0) {
+        // 自分の出力が schema 違反 = 実装バグ。fail-closed で異常終了
+        console.error('conformance 出力が schema 違反:');
+        for (const e of schemaErrors) console.error(`- ${e}`);
+        return 2;
+      }
+      const json = JSON.stringify(vector, null, 2);
+      const out = flags.get('out');
+      if (typeof out === 'string') writeFileSync(out, json + '\n');
+      console.log(json);
+      const reds = Object.entries(vector.keys).filter(([, v]) => v.state === 'red');
+      const unknowns = Object.entries(vector.keys).filter(([, v]) => v.state === 'unknown');
+      console.error(
+        `\nconformance: red ${reds.length} / unknown ${unknowns.length} / ` +
+          `green ${Object.values(vector.keys).filter((v) => v.state === 'green').length}` +
+          '（出力自体は非 blocker — 該当キー green が Wave 検収の完了条件・M-3）',
+      );
+      return reds.length > 0 ? 1 : 0;
+    }
+
+    case 'gate-integrity': {
+      const result = await checkGateIntegrity({ cwd });
+      console.log(JSON.stringify(result, null, 2));
+      return result.state === 'green' ? 0 : 1;
+    }
+
+    case 'init': {
+      const { registries, error } = loadRegistries(registriesPath);
+      if (registries === null) {
+        console.error(`registries が読めない（fail-closed で中止）: ${error ?? 'unknown'}`);
+        return 2;
+      }
+      if (flags.has('check')) {
+        const report = await initCheck(cwd, repo, registries);
+        console.log(JSON.stringify(report, null, 2));
+        const count = report.unregisteredClasses.length + report.unregisteredLegacyFiles.length;
+        console.error(`init --check: 未分類 ${count} 件（styling green 条件は 0 件 — AM-10）`);
+        return count > 0 ? 1 : 0;
+      }
+      if (!flags.has('scan')) {
+        console.error('init は --scan（生成）か --check（読み取り専用再走査）を指定する');
+        return 2;
+      }
+      // T-3: 対象台帳が既存なら実行拒否（生成はゲート導入 PR の一度きり）
+      const already = ledgersAlreadyInitialized(registries, repo);
+      if (already.legacyManifest) {
+        console.error(
+          `実行拒否: repo "${repo}" の legacy-manifest は台帳に既存（T-3 — 再走査は --check 読み取り専用のみ。` +
+            'ラチェット一周リセット MUST NOT）',
+        );
+        return 2;
+      }
+      const out = flags.get('out');
+      if (typeof out === 'string' && existsSync(out)) {
+        console.error(`実行拒否: 出力先 ${out} が既存（上書きによる再凍結 MUST NOT）`);
+        return 2;
+      }
+      const result = await initScan(cwd);
+      const payload = JSON.stringify(
+        {
+          repo,
+          generatedBy: 'nene2-check init --scan',
+          allowedClasses: result.allowedClasses,
+          legacyManifest: result.legacyManifest.map((e) => ({
+            kind: 'legacy-manifest',
+            repo,
+            ...e,
+          })),
+        },
+        null,
+        2,
+      );
+      if (typeof out === 'string') writeFileSync(out, payload + '\n');
+      console.log(payload);
+      for (const a of result.advisories) console.error(`advisory: ${a}`);
+      return 0;
+    }
+
+    default:
+      console.error(`未知のコマンド: ${command}（conformance / gate-integrity / init）`);
+      return 2;
+  }
+}
+
+main().then(
+  (code) => process.exit(code),
+  (e: unknown) => {
+    console.error((e as Error).stack ?? String(e));
+    process.exit(2);
+  },
+);

--- a/packages/nene2-standards/src/checks/conformance.ts
+++ b/packages/nene2-standards/src/checks/conformance.ts
@@ -1,0 +1,132 @@
+/**
+ * conformance skeleton — 適合ベクトル（規約 05 §7 CF-1〜4・会議R3⑩M-3・R4 AM-11・R5(5)決定）。
+ *
+ * 状態機械の分界（CF-2）:
+ * - リポ側 nene2-check の出力語彙は **5状態**（green/red/unknown/frozen/waived）まで。
+ * - `n/a(reason-ref)` は中央 rollup が pinned registries を参照して写像・表示する —
+ *   リポ出力 JSON に "n/a" が現れたら schema 違反（validateConformance が拒否）。
+ * - unknown の腕は reason 判別 `not-installed | crashed | unsupported-schema`。
+ *
+ * fail-closed（G-6）: 検査が実行できない・対象が見つからない = unknown（≠green）。
+ * green は「検査が走り正の証拠を得た」場合のみ。空虚合格 MUST NOT。
+ */
+
+export type UnknownReason = 'not-installed' | 'crashed' | 'unsupported-schema';
+
+export type KeyState =
+  | { state: 'green' }
+  | { state: 'red'; details: string[] }
+  | { state: 'unknown'; reason: UnknownReason; details?: string[] }
+  | { state: 'frozen'; remaining: number }
+  | { state: 'waived'; until: string; reasonRef: string };
+
+export const CONFORMANCE_SCHEMA_ID = 'nene2-conformance/1';
+
+/**
+ * 適合ベクトルのキー名列挙（05 §7.1 の起草ドラフトを W0a skeleton で確定 — 起草判断 D-f）。
+ * DoD ベクトルは styling / i18n / a11y / api の全ゲートを含む（CF-3）。
+ */
+export const CONFORMANCE_KEYS = [
+  'fsd.boundaries',
+  'styling.utilities',
+  'styling.scan-coverage',
+  'styling.no-legacy-token-names',
+  'tokens.contract',
+  'tokens.contrast',
+  'i18n.parity',
+  'i18n.hardcoded',
+  'a11y.jsx-strict',
+  'api.transport',
+  'api.fleet-baseline',
+  'testing.required-set',
+  'gate-integrity',
+  'e2e.axe-smoke',
+] as const;
+
+export type ConformanceKey = (typeof CONFORMANCE_KEYS)[number];
+
+export interface ConformanceMeta {
+  standardsVersion: string | null;
+  tokensVersion: string | null;
+  i18nVersion: string | null;
+  clientVersion: string | null;
+  /** 全テーマファイルのプラグマの最小値（CF-4・AM-11(v)） */
+  contractVersion: string | null;
+  manifestSha: string | null;
+  commitSha: string | null;
+}
+
+export interface ConformanceVector {
+  schema: typeof CONFORMANCE_SCHEMA_ID;
+  repo: string;
+  meta: ConformanceMeta;
+  keys: Record<ConformanceKey, KeyState>;
+}
+
+const UNKNOWN_REASONS: readonly string[] = ['not-installed', 'crashed', 'unsupported-schema'];
+
+/**
+ * リポ出力スキーマの検査（fail-closed）。中央 rollup は違反ベクトルを unknown 扱いにする
+ * （CF-2(iv) と同処理）— ここでは違反の列挙を返す。
+ */
+export function validateConformance(doc: unknown): string[] {
+  const errors: string[] = [];
+  if (typeof doc !== 'object' || doc === null) return ['ベクトルはオブジェクト MUST'];
+  const d = doc as Record<string, unknown>;
+  if (d['schema'] !== CONFORMANCE_SCHEMA_ID) {
+    errors.push(`schema は "${CONFORMANCE_SCHEMA_ID}" MUST`);
+  }
+  if (typeof d['repo'] !== 'string' || d['repo'] === '') errors.push('repo は非空文字列 MUST');
+  const keys = d['keys'];
+  if (typeof keys !== 'object' || keys === null) {
+    errors.push('keys はオブジェクト MUST');
+    return errors;
+  }
+  for (const [key, raw] of Object.entries(keys)) {
+    if (!(CONFORMANCE_KEYS as readonly string[]).includes(key)) {
+      errors.push(`キー "${key}" は列挙外`);
+      continue;
+    }
+    if (typeof raw !== 'object' || raw === null) {
+      errors.push(`${key}: 状態はオブジェクト MUST（boolean MUST NOT — AM-11(vi)）`);
+      continue;
+    }
+    const s = (raw as Record<string, unknown>)['state'];
+    switch (s) {
+      case 'green':
+        break;
+      case 'red':
+        if (!Array.isArray((raw as Record<string, unknown>)['details'])) {
+          errors.push(`${key}: red は details（証拠列挙）MUST`);
+        }
+        break;
+      case 'unknown': {
+        const reason = (raw as Record<string, unknown>)['reason'];
+        if (typeof reason !== 'string' || !UNKNOWN_REASONS.includes(reason)) {
+          errors.push(`${key}: unknown は reason ∈ {${UNKNOWN_REASONS.join(', ')}} MUST（R5(5)）`);
+        }
+        break;
+      }
+      case 'frozen':
+        if (typeof (raw as Record<string, unknown>)['remaining'] !== 'number') {
+          errors.push(`${key}: frozen は remaining（残 n 件）MUST`);
+        }
+        break;
+      case 'waived': {
+        const w = raw as Record<string, unknown>;
+        if (typeof w['until'] !== 'string' || typeof w['reasonRef'] !== 'string') {
+          errors.push(`${key}: waived は until / reasonRef MUST`);
+        }
+        break;
+      }
+      case 'n/a':
+        errors.push(
+          `${key}: "n/a" のリポ出力は schema 違反（中央レジストリでのみ宣言可 — CF-2・G-7）`,
+        );
+        break;
+      default:
+        errors.push(`${key}: 未知の state "${String(s)}"（5状態列挙外）`);
+    }
+  }
+  return errors;
+}

--- a/packages/nene2-standards/src/checks/gate-integrity.ts
+++ b/packages/nene2-standards/src/checks/gate-integrity.ts
@@ -1,0 +1,200 @@
+/**
+ * gate-integrity 検査（規約 05 §5.2 #15・会議R4 AM-11(iii)決定）:
+ * 実効 severity / effective ignores を canonical 表と照合し、差異登録なき緩和を FAIL にする。
+ *
+ * canonical 表は配布 config（composedConfig）自身から機械導出する — 手書き二重管理 MUST NOT
+ * （G-7 と同旨: 正本は配布物）。照合は ESLint.calculateConfigForFile の実効値
+ * （05 §10.2 で「実測未実施」だった方式 — 本実装＋パッケージテストが実測）。
+ *
+ * fail-closed（G-6）:
+ * - 製品 eslint.config.js が無い / ESLint が解決できない → unknown(not-installed)
+ * - config 読み込みがクラッシュ → unknown(crashed)
+ * - 適用ファイル数 0（src 直下に *.ts(x) が1つも無い）→ unknown（§1.2 の G-6 適用）
+ */
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { ESLint, type Linter } from 'eslint';
+
+import { composedConfig } from '../index.js';
+import type { KeyState } from './conformance.js';
+
+/**
+ * 照合マトリクス: 「(仮想パス, ルール) → canonical 実効 severity」。
+ * パスは §2.2 の互いに素な集合それぞれの代表点（統合ミス・緩和が最も隠れやすい座席）。
+ */
+export const GATE_INTEGRITY_MATRIX: ReadonlyArray<{ path: string; rules: string[] }> = [
+  {
+    path: 'src/features/probe/file.tsx',
+    rules: [
+      'no-restricted-syntax',
+      'no-restricted-imports',
+      'no-restricted-globals',
+      '@typescript-eslint/no-restricted-imports',
+      'import-x/no-restricted-paths',
+      'better-tailwindcss/no-unknown-classes',
+      'nene2/style-prop-css-vars-only',
+      'eslint-comments/no-restricted-disable',
+    ],
+  },
+  {
+    path: 'src/shared/ui/probe/file.tsx',
+    rules: ['no-restricted-syntax', 'no-restricted-imports', 'no-restricted-globals'],
+  },
+  {
+    path: 'src/shared/api/client.ts',
+    rules: ['no-restricted-syntax', 'no-restricted-imports', 'no-restricted-globals'],
+  },
+  {
+    path: 'src/shared/i18n/messages/ja.ts',
+    rules: ['no-restricted-syntax'],
+  },
+  {
+    path: 'tests/probe.test.ts',
+    rules: ['no-restricted-syntax'],
+  },
+];
+
+type SeverityCell = {
+  path: string;
+  rule: string;
+  /** 0=off / 1=warn / 2=error。null = ルール定義なし */
+  severity: number | null;
+  /** no-restricted-syntax のセレクタ本数（後勝ち全置換による欠落の検出 — severity では見えない） */
+  optionCount: number | null;
+};
+
+function normalizeSeverity(entry: Linter.RuleEntry | undefined): {
+  severity: number | null;
+  optionCount: number | null;
+} {
+  if (entry === undefined) return { severity: null, optionCount: null };
+  const arr = Array.isArray(entry) ? entry : [entry];
+  const sevRaw = arr[0];
+  const map: Record<string, number> = { off: 0, warn: 1, error: 2 };
+  const severity = typeof sevRaw === 'number' ? sevRaw : (map[String(sevRaw)] ?? null);
+  return { severity, optionCount: Array.isArray(entry) ? entry.length - 1 : 0 };
+}
+
+async function severityTable(eslint: ESLint, cwd: string): Promise<SeverityCell[]> {
+  const cells: SeverityCell[] = [];
+  for (const { path: p, rules } of GATE_INTEGRITY_MATRIX) {
+    const abs = path.join(cwd, p);
+    const cfg = (await eslint.calculateConfigForFile(abs)) as
+      | { rules?: Record<string, Linter.RuleEntry> }
+      | undefined;
+    for (const rule of rules) {
+      const { severity, optionCount } = normalizeSeverity(cfg?.rules?.[rule]);
+      cells.push({ path: p, rule, severity, optionCount });
+    }
+  }
+  return cells;
+}
+
+/** canonical 表（配布 config から導出）。 */
+export async function canonicalSeverityTable(cwd: string): Promise<SeverityCell[]> {
+  const eslint = new ESLint({ cwd, overrideConfigFile: true, overrideConfig: composedConfig() });
+  return severityTable(eslint, cwd);
+}
+
+export interface GateIntegrityOptions {
+  cwd: string;
+  /** テスト用: 製品 config の代わりに直接評価する config（ファイル読込経路を迂回） */
+  productConfigOverride?: Linter.Config[];
+}
+
+/** 実効 severity 照合の結果を conformance の KeyState で返す。 */
+export async function checkGateIntegrity(options: GateIntegrityOptions): Promise<KeyState> {
+  const { cwd, productConfigOverride } = options;
+
+  // G-6: 適用ファイル数 0 = unknown（glob 不一致による静かな非適用は green ではない — §1.2）
+  const applied = await countAppliedFiles(cwd);
+  if (applied === 0) {
+    return {
+      state: 'unknown',
+      reason: 'not-installed',
+      details: ['適用ファイル数 0（src/**/*.{ts,tsx} 不在）— G-6 により green ではなく unknown'],
+    };
+  }
+
+  let productEslint: ESLint;
+  if (productConfigOverride) {
+    productEslint = new ESLint({
+      cwd,
+      overrideConfigFile: true,
+      overrideConfig: productConfigOverride,
+    });
+  } else {
+    if (!existsSync(path.join(cwd, 'eslint.config.js'))) {
+      return {
+        state: 'unknown',
+        reason: 'not-installed',
+        details: ['eslint.config.js が正準配置（§1.2）に存在しない'],
+      };
+    }
+    productEslint = new ESLint({ cwd });
+  }
+
+  let productTable: SeverityCell[];
+  let canonTable: SeverityCell[];
+  try {
+    [productTable, canonTable] = await Promise.all([
+      severityTable(productEslint, cwd),
+      canonicalSeverityTable(cwd),
+    ]);
+  } catch (e) {
+    return { state: 'unknown', reason: 'crashed', details: [(e as Error).message] };
+  }
+
+  const details: string[] = [];
+  for (let i = 0; i < canonTable.length; i++) {
+    const canon = canonTable[i];
+    const prod = productTable[i];
+    if (!canon || !prod) continue;
+    const sevCanon = canon.severity ?? -1;
+    const sevProd = prod.severity ?? -1;
+    // 緩和（canonical より弱い severity）= FAIL。強化は oracle 正本（O-5）に反し得るが
+    // gate-integrity の管轄は「差異登録なき緩和」— 強化の是非は check:tw-oracle 側。
+    if (sevProd < sevCanon) {
+      details.push(
+        `${canon.path} / ${canon.rule}: 実効 severity ${sevProd} < canonical ${sevCanon}（差異登録なき緩和）`,
+      );
+    }
+    // 後勝ち全置換によるオプション欠落（severity 照合では検出できない — §2.2 冒頭）
+    if (
+      canon.optionCount !== null &&
+      prod.optionCount !== null &&
+      sevProd >= 1 &&
+      prod.optionCount < canon.optionCount
+    ) {
+      details.push(
+        `${canon.path} / ${canon.rule}: 実効オプション数 ${prod.optionCount} < canonical ${canon.optionCount}（後勝ち全置換の疑い）`,
+      );
+    }
+  }
+
+  return details.length === 0 ? { state: 'green' } : { state: 'red', details };
+}
+
+/** src/**' の適用ファイル数（G-6 の空虚合格検査）。 */
+export async function countAppliedFiles(cwd: string): Promise<number> {
+  const { readdirSync, statSync } = await import('node:fs');
+  let count = 0;
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (name === 'node_modules' || name === 'dist' || name.startsWith('.')) continue;
+      const full = path.join(dir, name);
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full);
+      else if (/\.(ts|tsx)$/.test(name)) count++;
+    }
+  };
+  walk(path.join(cwd, 'src'));
+  return count;
+}

--- a/packages/nene2-standards/src/checks/init-scan.ts
+++ b/packages/nene2-standards/src/checks/init-scan.ts
@@ -1,0 +1,119 @@
+/**
+ * `nene2-check init --scan` — 許可リスト / legacy manifest 初期値の走査生成
+ * （規約 05 §6.6 T-3・会議R4 AM-10・R5 決定 = AM-10 の「人間の記憶力で列挙値を決めない」）。
+ *
+ * - 生成はゲート導入 PR の一度きり: 対象台帳（同一 repo・同一 kind のエントリ）が既存なら
+ *   **実行拒否**（R5: ラチェット一周リセットの禁止）。
+ * - `--check` は読み取り専用の再走査 — 未分類 selector / 未登録ファイルを報告する
+ *   （conformance styling green 条件「再走査で未分類 selector 0」の入力）。
+ * - maxLines は pinned prettier 整形後の行数（AM-14/AM-25' — 整形非決定下の行数に正準性はない）・
+ *   maxBytes はソース実バイト数。
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { classTokens, layerParamsInclude } from '../stylelint/helpers.js';
+import type { RegistriesDocument } from '../registries/schema.js';
+import { enumerateStyleSources } from './scan-coverage.js';
+
+export interface InitScanResult {
+  /** @layer components 内の class トークン（完全一致列挙の初期値） */
+  allowedClasses: string[];
+  /** legacy manifest 初期値（テーマ正準配置・index.css 以外の css） */
+  legacyManifest: Array<{ path: string; maxLines: number; maxBytes: number }>;
+  /** 500行超の助言 warning（AM-25' — MUST ではない） */
+  advisories: string[];
+}
+
+const CANONICAL_NON_LEGACY = [/^src\/shared\/ui\/theme\//, /^src\/index\.css$/];
+const ADVISORY_LINES = 500;
+
+async function formattedLineCount(source: string): Promise<number> {
+  // pinned prettier（workspace 同梱）で整形してから数える
+  const prettier = await import('prettier');
+  const formatted = await prettier.format(source, { parser: 'css' });
+  return formatted.split('\n').filter((l) => l !== '').length;
+}
+
+export async function initScan(cwd: string): Promise<InitScanResult> {
+  const postcss = (await import('postcss')).default;
+  const sources = enumerateStyleSources(cwd).filter((p) => p.endsWith('.css'));
+  const allowed = new Set<string>();
+  const legacyManifest: InitScanResult['legacyManifest'] = [];
+  const advisories: string[] = [];
+
+  for (const rel of sources) {
+    const abs = path.join(cwd, rel);
+    const raw = readFileSync(abs);
+    const text = raw.toString('utf8');
+
+    // @layer components の class トークン収集（許可リスト初期値）
+    try {
+      const root = postcss.parse(text, { from: abs });
+      root.walkAtRules('layer', (at) => {
+        if (!layerParamsInclude(at.params, 'components')) return;
+        at.walkRules((rule) => {
+          for (const token of classTokens(rule.selector)) allowed.add(token);
+        });
+      });
+    } catch (e) {
+      advisories.push(`${rel}: CSS パース不能（手動確認が必要）: ${(e as Error).message}`);
+      continue;
+    }
+
+    // legacy manifest 初期値（テーマ正準配置・エントリ css 以外）
+    if (!CANONICAL_NON_LEGACY.some((re) => re.test(rel))) {
+      const maxLines = await formattedLineCount(text);
+      const entry = { path: rel, maxLines, maxBytes: raw.byteLength };
+      legacyManifest.push(entry);
+      if (maxLines > ADVISORY_LINES) {
+        advisories.push(
+          `${rel}: ${maxLines} 行 > ${ADVISORY_LINES}（助言的閾値 — AM-25'。ゲートではない）`,
+        );
+      }
+    }
+  }
+
+  return {
+    allowedClasses: [...allowed].sort(),
+    legacyManifest,
+    advisories,
+  };
+}
+
+/** 対象台帳が既存かどうか（既存なら init --scan は実行拒否 — T-3/R5）。 */
+export function ledgersAlreadyInitialized(
+  registries: RegistriesDocument,
+  repo: string,
+): { legacyManifest: boolean } {
+  return {
+    legacyManifest: registries.entries.some((e) => e.kind === 'legacy-manifest' && e.repo === repo),
+  };
+}
+
+export interface InitCheckReport {
+  unregisteredClasses: string[];
+  unregisteredLegacyFiles: string[];
+}
+
+/** `--check`（読み取り専用再走査）: 台帳との差分を報告する。 */
+export async function initCheck(
+  cwd: string,
+  repo: string,
+  registries: RegistriesDocument,
+): Promise<InitCheckReport> {
+  const scan = await initScan(cwd);
+  const manifestPaths = new Set(
+    registries.entries
+      .filter((e) => e.kind === 'legacy-manifest' && e.repo === repo)
+      .map((e) => (e as { path: string }).path),
+  );
+  // 許可リストの正本台帳は W1 配線（gen:registered-classes と同一系）— skeleton では
+  // testid 同様の中央台帳が未定義のため、@layer components トークンは全て「要分類」として報告
+  return {
+    unregisteredClasses: scan.allowedClasses,
+    unregisteredLegacyFiles: scan.legacyManifest
+      .map((e) => e.path)
+      .filter((p) => !manifestPaths.has(p)),
+  };
+}

--- a/packages/nene2-standards/src/checks/run.ts
+++ b/packages/nene2-standards/src/checks/run.ts
@@ -1,0 +1,133 @@
+/**
+ * conformance skeleton の実行部 — リポの適合ベクトル JSON を組み立てる（CF-1）。
+ *
+ * W0a skeleton の実装状況（誠実性ガード — 空虚合格 MUST NOT）:
+ * - gate-integrity: 実装（calculateConfigForFile 照合）
+ * - styling.scan-coverage: 実装（補集合検査）
+ * - 他キー: 検査器未配線につき **unknown(not-installed)** を出力する。
+ *   green を返す経路は「検査が走り正の証拠を得た」実装のみ（G-6）。
+ */
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+import { parseRegistries, type RegistriesDocument } from '../registries/schema.js';
+import {
+  CONFORMANCE_KEYS,
+  CONFORMANCE_SCHEMA_ID,
+  type ConformanceKey,
+  type ConformanceMeta,
+  type ConformanceVector,
+  type KeyState,
+} from './conformance.js';
+import { checkGateIntegrity } from './gate-integrity.js';
+import { checkScanCoverage } from './scan-coverage.js';
+
+const FLEET_PACKAGES = [
+  ['standardsVersion', '@hideyukimori/nene2-standards'],
+  ['tokensVersion', '@hideyukimori/nene2-tokens'],
+  ['i18nVersion', '@hideyukimori/nene2-i18n'],
+  ['clientVersion', '@hideyukimori/nene2-client'],
+] as const;
+
+function resolveVersion(cwd: string, pkg: string): string | null {
+  try {
+    const require = createRequire(path.join(cwd, 'package.json'));
+    const pkgJson = require(`${pkg}/package.json`) as { version?: string };
+    return pkgJson.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** 全テーマファイルのプラグマ最小値（CF-4/AM-11(v) — 版比較は semver 単純比較で足りる範囲のみ） */
+function contractVersionFromThemes(cwd: string): string | null {
+  const themesDir = path.join(cwd, 'src/shared/ui/theme/themes');
+  if (!existsSync(themesDir)) return null;
+  const versions: string[] = [];
+  for (const name of readdirSync(themesDir)) {
+    if (!name.endsWith('.css')) continue;
+    const text = readFileSync(path.join(themesDir, name), 'utf8');
+    const m = /@nene2-contract\s+([\w.-]+)/.exec(text);
+    if (m?.[1]) versions.push(m[1]);
+  }
+  if (versions.length === 0) return null;
+  return versions.sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }),
+  )[0] as string;
+}
+
+function gitCommitSha(cwd: string): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export interface RunOptions {
+  cwd: string;
+  repo: string;
+  /** pinned registries jsonc のパス（パッケージ同梱の registries/fleet.jsonc が既定） */
+  registriesPath?: string | undefined;
+}
+
+export function loadRegistries(registriesPath: string | undefined): {
+  registries: RegistriesDocument | null;
+  manifestSha: string | null;
+  error?: string;
+} {
+  const defaultPath = new URL('../../registries/fleet.jsonc', import.meta.url);
+  const p = registriesPath ?? defaultPath;
+  try {
+    const source = readFileSync(p, 'utf8');
+    return {
+      registries: parseRegistries(source),
+      manifestSha: createHash('sha256').update(source).digest('hex'),
+    };
+  } catch (e) {
+    return { registries: null, manifestSha: null, error: (e as Error).message };
+  }
+}
+
+export async function runConformance(options: RunOptions): Promise<ConformanceVector> {
+  const { cwd, repo } = options;
+  const { registries, manifestSha, error } = loadRegistries(options.registriesPath);
+
+  const meta: ConformanceMeta = {
+    standardsVersion: null,
+    tokensVersion: null,
+    i18nVersion: null,
+    clientVersion: null,
+    contractVersion: contractVersionFromThemes(cwd),
+    manifestSha,
+    commitSha: gitCommitSha(cwd),
+  };
+  for (const [field, pkg] of FLEET_PACKAGES) {
+    meta[field] = resolveVersion(cwd, pkg);
+  }
+
+  const notWired = (what: string): KeyState => ({
+    state: 'unknown',
+    reason: 'not-installed',
+    details: [`検査器未配線（W0a skeleton）: ${what}`],
+  });
+
+  const keys = {} as Record<ConformanceKey, KeyState>;
+  for (const key of CONFORMANCE_KEYS) keys[key] = notWired(key);
+
+  // 実装済みの検査（green は正の証拠を得た場合のみ）
+  keys['gate-integrity'] = await checkGateIntegrity({ cwd });
+  keys['styling.scan-coverage'] = checkScanCoverage({ cwd, repo, registries });
+  if (error && registries === null) {
+    keys['styling.scan-coverage'] = {
+      state: 'unknown',
+      reason: 'unsupported-schema',
+      details: [`registries 読込失敗: ${error}`],
+    };
+  }
+
+  return { schema: CONFORMANCE_SCHEMA_ID, repo, meta, keys };
+}

--- a/packages/nene2-standards/src/checks/scan-coverage.ts
+++ b/packages/nene2-standards/src/checks/scan-coverage.ts
@@ -1,0 +1,91 @@
+/**
+ * scan-coverage 検査（規約 05 §5.2 #14・会議R4 AM-11(ii)・R5(5)決定）:
+ * style ソース（css/scss/sass/less/styl/html）の全量列挙 − {themes 列挙 ∪ 許可リスト ∪ legacy manifest}
+ * = 空 を検査する（補集合検査 — 台帳の外に style ソースを密輸させない）。
+ *
+ * - css/html 以外の拡張子（scss/sass/less/styl）のヒットは即 red。
+ * - manifest 記載ファイルの不存在も red（台帳腐敗防止 — §7.2）。
+ * - 台帳（registries）が与えられない場合は unknown(not-installed) — fail-closed（G-6）。
+ */
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import type { RegistriesDocument } from '../registries/schema.js';
+import type { KeyState } from './conformance.js';
+
+const STYLE_EXT = /\.(css|scss|sass|less|styl|html)$/;
+const BANNED_EXT = /\.(scss|sass|less|styl)$/;
+
+/** テーマ列挙の正準 glob（05 §1.2 正準配置）＋アプリエントリ。 */
+const CANONICAL_ALLOWED = [/^src\/shared\/ui\/theme\//, /^src\/index\.css$/, /^index\.html$/];
+
+export function enumerateStyleSources(cwd: string): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      return;
+    }
+    for (const name of entries) {
+      if (name === 'node_modules' || name === 'dist' || name.startsWith('.')) continue;
+      const full = path.join(dir, name);
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full);
+      else if (STYLE_EXT.test(name)) found.push(path.relative(cwd, full).replaceAll('\\', '/'));
+    }
+  };
+  walk(cwd);
+  return found.sort();
+}
+
+export interface ScanCoverageOptions {
+  cwd: string;
+  repo: string;
+  registries: RegistriesDocument | null;
+}
+
+export function checkScanCoverage(options: ScanCoverageOptions): KeyState {
+  const { cwd, repo, registries } = options;
+  if (registries === null) {
+    return {
+      state: 'unknown',
+      reason: 'not-installed',
+      details: ['registries（pinned 台帳）が与えられていない — 補集合検査は台帳なしに定義できない'],
+    };
+  }
+
+  const manifestPaths = registries.entries
+    .filter((e) => e.kind === 'legacy-manifest' && e.repo === repo)
+    .map((e) => (e as { path: string }).path);
+  const widgetEntryFiles = registries.entries
+    .filter((e) => e.kind === 'widget-entry' && e.repo === repo)
+    .flatMap((e) => (e as { files: string[] }).files);
+
+  const details: string[] = [];
+
+  // 台帳腐敗防止: manifest 記載ファイルの不存在は FAIL
+  for (const p of manifestPaths) {
+    if (!existsSync(path.join(cwd, p))) {
+      details.push(`legacy manifest 記載ファイルが存在しない（台帳腐敗）: ${p}`);
+    }
+  }
+
+  const sources = enumerateStyleSources(cwd);
+  for (const rel of sources) {
+    if (BANNED_EXT.test(rel)) {
+      details.push(`css/html 以外の style 拡張子は即 red（R5(5)）: ${rel}`);
+      continue;
+    }
+    const allowed =
+      CANONICAL_ALLOWED.some((re) => re.test(rel)) ||
+      manifestPaths.includes(rel) ||
+      widgetEntryFiles.includes(rel);
+    if (!allowed) {
+      details.push(`台帳外の style ソース（themes ∪ 許可リスト ∪ legacy manifest に不在）: ${rel}`);
+    }
+  }
+
+  return details.length === 0 ? { state: 'green' } : { state: 'red', details };
+}

--- a/packages/nene2-standards/src/index.ts
+++ b/packages/nene2-standards/src/index.ts
@@ -54,3 +54,14 @@ export function composedConfig(): Linter.Config[] {
 
 const nene2 = { base, fsd, api, styling, i18n, testing, overrides };
 export default nene2;
+
+export {
+  CONFORMANCE_KEYS,
+  CONFORMANCE_SCHEMA_ID,
+  validateConformance,
+} from './checks/conformance.js';
+export type { ConformanceKey, ConformanceVector, KeyState } from './checks/conformance.js';
+export { checkGateIntegrity, canonicalSeverityTable } from './checks/gate-integrity.js';
+export { checkScanCoverage } from './checks/scan-coverage.js';
+export { initScan, initCheck } from './checks/init-scan.js';
+export { runConformance } from './checks/run.js';

--- a/packages/nene2-standards/tests/fixtures/check-app-bad/src/app.tsx
+++ b/packages/nene2-standards/tests/fixtures/check-app-bad/src/app.tsx
@@ -1,0 +1,1 @@
+export const app = 1;

--- a/packages/nene2-standards/tests/fixtures/check-app-bad/src/legacy.scss
+++ b/packages/nene2-standards/tests/fixtures/check-app-bad/src/legacy.scss
@@ -1,0 +1,1 @@
+.nope { color: red; }

--- a/packages/nene2-standards/tests/fixtures/check-app-bad/src/styles/extra.css
+++ b/packages/nene2-standards/tests/fixtures/check-app-bad/src/styles/extra.css
@@ -1,0 +1,3 @@
+.stray {
+  color: var(--color-accent);
+}

--- a/packages/nene2-standards/tests/fixtures/check-app-empty/docs/README.md
+++ b/packages/nene2-standards/tests/fixtures/check-app-empty/docs/README.md
@@ -1,0 +1,1 @@
+placeholder (src なし — G-6 プローブ)

--- a/packages/nene2-standards/tests/fixtures/check-app/index.html
+++ b/packages/nene2-standards/tests/fixtures/check-app/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<title>probe</title>

--- a/packages/nene2-standards/tests/fixtures/check-app/src/app.tsx
+++ b/packages/nene2-standards/tests/fixtures/check-app/src/app.tsx
@@ -1,0 +1,1 @@
+export const app = 1;

--- a/packages/nene2-standards/tests/fixtures/check-app/src/index.css
+++ b/packages/nene2-standards/tests/fixtures/check-app/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/packages/nene2-standards/tests/fixtures/check-app/src/shared/ui/theme/themes/corporate.css
+++ b/packages/nene2-standards/tests/fixtures/check-app/src/shared/ui/theme/themes/corporate.css
@@ -1,0 +1,4 @@
+/* @nene2-contract 1.0 @themegen 1.0.0-rc.1 */
+[data-theme='corporate'] {
+  --color-accent: oklch(0.55 0.15 250);
+}

--- a/packages/nene2-standards/tests/fixtures/init-app/src/index.css
+++ b/packages/nene2-standards/tests/fixtures/init-app/src/index.css
@@ -1,0 +1,9 @@
+@import 'tailwindcss';
+@layer components {
+  .badge {
+    background: var(--color-accent-soft);
+  }
+  .data-table th {
+    text-align: left;
+  }
+}

--- a/packages/nene2-standards/tests/fixtures/init-app/src/legacy-styles.css
+++ b/packages/nene2-standards/tests/fixtures/init-app/src/legacy-styles.css
@@ -1,0 +1,6 @@
+.old-a {
+  color: var(--color-text-primary);
+}
+.old-b {
+  color: var(--color-text-muted);
+}

--- a/packages/nene2-standards/tests/nene2-check.test.ts
+++ b/packages/nene2-standards/tests/nene2-check.test.ts
@@ -1,0 +1,243 @@
+/**
+ * nene2-check（conformance skeleton）— fail-closed（G-6）・5状態ユニオン・gate-integrity・
+ * scan-coverage・init --scan の両方向（green＋故意 fail）検査。
+ */
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+import type { Linter } from 'eslint';
+
+import {
+  CONFORMANCE_KEYS,
+  CONFORMANCE_SCHEMA_ID,
+  validateConformance,
+} from '../src/checks/conformance.js';
+import { checkGateIntegrity } from '../src/checks/gate-integrity.js';
+import { checkScanCoverage } from '../src/checks/scan-coverage.js';
+import { initCheck, initScan, ledgersAlreadyInitialized } from '../src/checks/init-scan.js';
+import { runConformance } from '../src/checks/run.js';
+import { parseRegistries, REGISTRIES_SCHEMA_ID } from '../src/registries/schema.js';
+import { composedConfig } from '../src/index.js';
+
+const dir = (rel: string): string => fileURLToPath(new URL(rel, import.meta.url));
+const probeApp = dir('./fixtures/probe-app/');
+const checkApp = dir('./fixtures/check-app/');
+const checkAppBad = dir('./fixtures/check-app-bad/');
+const checkAppEmpty = dir('./fixtures/check-app-empty/');
+const initApp = dir('./fixtures/init-app/');
+
+function registriesWith(entries: unknown[]): ReturnType<typeof parseRegistries> {
+  return parseRegistries(JSON.stringify({ schema: REGISTRIES_SCHEMA_ID, entries }));
+}
+
+const EMPTY_REGISTRIES = registriesWith([]);
+
+describe('conformance スキーマ（CF-2 — 5状態・n/a 拒否・boolean 拒否）', () => {
+  const base = {
+    schema: CONFORMANCE_SCHEMA_ID,
+    repo: 'nene-payout',
+    meta: {},
+    keys: {} as Record<string, unknown>,
+  };
+
+  it('リポ出力の "n/a" は schema 違反（中央レジストリでのみ宣言可 — G-7）', () => {
+    const doc = { ...base, keys: { 'e2e.axe-smoke': { state: 'n/a', reasonRef: 'x' } } };
+    expect(validateConformance(doc).some((e) => e.includes('n/a'))).toBe(true);
+  });
+
+  it('boolean 状態は MUST NOT（AM-11(vi)）・unknown は reason 判別必須（R5(5)）', () => {
+    expect(
+      validateConformance({ ...base, keys: { 'gate-integrity': true } }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      validateConformance({
+        ...base,
+        keys: { 'gate-integrity': { state: 'unknown' } },
+      }).some((e) => e.includes('reason')),
+    ).toBe(true);
+    expect(
+      validateConformance({
+        ...base,
+        keys: { 'gate-integrity': { state: 'unknown', reason: 'not-installed' } },
+      }),
+    ).toEqual([]);
+  });
+
+  it('red は details（証拠列挙）必須・列挙外キーは違反', () => {
+    expect(
+      validateConformance({ ...base, keys: { 'gate-integrity': { state: 'red' } } }).some((e) =>
+        e.includes('details'),
+      ),
+    ).toBe(true);
+    expect(
+      validateConformance({ ...base, keys: { 'my.new-key': { state: 'green' } } }).some((e) =>
+        e.includes('列挙外'),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('gate-integrity（05 §5.2 #15 — 実効 severity / オプション欠落の照合）', () => {
+  it('配布 config そのまま = green（canonical 自己一致）', async () => {
+    const result = await checkGateIntegrity({
+      cwd: probeApp,
+      productConfigOverride: composedConfig(),
+    });
+    expect(result).toEqual({ state: 'green' });
+  }, 60_000);
+
+  it('故意 fail: 後置き off（差異登録なき緩和）は red', async () => {
+    const relaxed: Linter.Config[] = [
+      ...composedConfig(),
+      { files: ['src/**/*.tsx'], rules: { 'no-restricted-syntax': 'off' } },
+    ];
+    const result = await checkGateIntegrity({ cwd: probeApp, productConfigOverride: relaxed });
+    expect(result.state).toBe('red');
+    if (result.state === 'red') {
+      expect(result.details.some((d) => d.includes('緩和'))).toBe(true);
+    }
+  }, 60_000);
+
+  it('故意 fail: 後勝ち全置換（severity 同じままセレクタ欠落）も red — severity 照合だけでは見えない形', async () => {
+    const clobbered: Linter.Config[] = [
+      ...composedConfig(),
+      {
+        files: ['src/features/**/*.{ts,tsx}'],
+        rules: {
+          'no-restricted-syntax': ['error', { selector: 'DebuggerStatement', message: 'x' }],
+        },
+      },
+    ];
+    const result = await checkGateIntegrity({ cwd: probeApp, productConfigOverride: clobbered });
+    expect(result.state).toBe('red');
+    if (result.state === 'red') {
+      expect(result.details.some((d) => d.includes('後勝ち全置換'))).toBe(true);
+    }
+  }, 60_000);
+
+  it('fail-closed: eslint.config.js 不在 = unknown(not-installed)', async () => {
+    const result = await checkGateIntegrity({ cwd: checkApp });
+    expect(result.state).toBe('unknown');
+    if (result.state === 'unknown') expect(result.reason).toBe('not-installed');
+  });
+
+  it('G-6: 適用ファイル数 0 = unknown（空虚合格 MUST NOT）', async () => {
+    const result = await checkGateIntegrity({
+      cwd: checkAppEmpty,
+      productConfigOverride: composedConfig(),
+    });
+    expect(result.state).toBe('unknown');
+    if (result.state === 'unknown') {
+      expect(result.details?.some((d) => d.includes('適用ファイル数 0'))).toBe(true);
+    }
+  });
+});
+
+describe('scan-coverage（05 §5.2 #14 — 補集合検査）', () => {
+  it('正例: themes＋index.css＋index.html のみ = green', () => {
+    expect(
+      checkScanCoverage({ cwd: checkApp, repo: 'nene-x', registries: EMPTY_REGISTRIES }),
+    ).toEqual({ state: 'green' });
+  });
+
+  it('故意 fail: 台帳外 css は red・scss は即 red', () => {
+    const result = checkScanCoverage({
+      cwd: checkAppBad,
+      repo: 'nene-x',
+      registries: EMPTY_REGISTRIES,
+    });
+    expect(result.state).toBe('red');
+    if (result.state === 'red') {
+      expect(result.details.some((d) => d.includes('extra.css'))).toBe(true);
+      expect(result.details.some((d) => d.includes('legacy.scss') && d.includes('即 red'))).toBe(
+        true,
+      );
+    }
+  });
+
+  it('legacy manifest 登録済みの css は許容・記載ファイル不在は red（台帳腐敗防止）', () => {
+    const withManifest = registriesWith([
+      {
+        kind: 'legacy-manifest',
+        id: 'x-legacy',
+        repo: 'nene-x',
+        path: 'src/styles/extra.css',
+        maxLines: 3,
+        maxBytes: 50,
+      },
+      {
+        kind: 'legacy-manifest',
+        id: 'x-gone',
+        repo: 'nene-x',
+        path: 'src/styles/deleted.css',
+        maxLines: 3,
+        maxBytes: 50,
+      },
+    ]);
+    const result = checkScanCoverage({
+      cwd: checkAppBad,
+      repo: 'nene-x',
+      registries: withManifest,
+    });
+    expect(result.state).toBe('red');
+    if (result.state === 'red') {
+      expect(result.details.some((d) => d.includes('extra.css'))).toBe(false); // 登録済み
+      expect(result.details.some((d) => d.includes('deleted.css') && d.includes('台帳腐敗'))).toBe(
+        true,
+      );
+    }
+  });
+
+  it('fail-closed: 台帳なし = unknown（補集合検査は台帳なしに定義できない）', () => {
+    const result = checkScanCoverage({ cwd: checkApp, repo: 'nene-x', registries: null });
+    expect(result.state).toBe('unknown');
+  });
+});
+
+describe('init --scan（T-3/AM-10 — 走査生成・一度きり・--check 読み取り専用）', () => {
+  it('@layer components の class トークンと legacy manifest 初期値（prettier 整形後行数）を生成する', async () => {
+    const result = await initScan(initApp);
+    expect(result.allowedClasses).toEqual(['.badge', '.data-table']);
+    expect(result.legacyManifest).toHaveLength(1);
+    const entry = result.legacyManifest[0];
+    expect(entry?.path).toBe('src/legacy-styles.css');
+    expect(entry?.maxLines).toBeGreaterThan(0);
+    expect(entry?.maxBytes).toBeGreaterThan(0);
+  });
+
+  it('対象台帳が既存なら実行拒否の判定を返す（生成はゲート導入 PR の一度きり）', () => {
+    const withExisting = registriesWith([
+      {
+        kind: 'legacy-manifest',
+        id: 'x',
+        repo: 'nene-x',
+        path: 'src/legacy-styles.css',
+        maxLines: 8,
+        maxBytes: 120,
+      },
+    ]);
+    expect(ledgersAlreadyInitialized(withExisting, 'nene-x').legacyManifest).toBe(true);
+    expect(ledgersAlreadyInitialized(EMPTY_REGISTRIES, 'nene-x').legacyManifest).toBe(false);
+  });
+
+  it('--check は未登録ファイルを報告する（styling green 条件 = 未分類 0）', async () => {
+    const report = await initCheck(initApp, 'nene-x', EMPTY_REGISTRIES);
+    expect(report.unregisteredLegacyFiles).toEqual(['src/legacy-styles.css']);
+  });
+});
+
+describe('runConformance（skeleton 全体 — CF-1〜4）', () => {
+  it('出力は schema green・n/a なし・未配線キーは unknown(not-installed)', async () => {
+    const vector = await runConformance({ cwd: checkApp, repo: 'nene-x' });
+    expect(validateConformance(vector)).toEqual([]);
+    expect(Object.keys(vector.keys).sort()).toEqual([...CONFORMANCE_KEYS].sort());
+    // skeleton: 空虚合格を出荷しない — 未配線キーが green になっていないこと
+    expect(vector.keys['i18n.parity'].state).toBe('unknown');
+    expect(vector.keys['e2e.axe-smoke'].state).toBe('unknown');
+    // 実装済みキー: scan-coverage はパッケージ同梱 registries（現物）で走る
+    expect(['green', 'red']).toContain(vector.keys['styling.scan-coverage'].state);
+    // meta（CF-4）: contractVersion = テーマプラグマ最小値
+    expect(vector.meta.contractVersion).toBe('1.0');
+    expect(vector.meta.manifestSha).toMatch(/^[0-9a-f]{64}$/);
+  });
+});


### PR DESCRIPTION
## 概要（W0a stage2 — 論点2: conformance skeleton）

**base = #3（registries）**。マージ順: #2 → #3 → 本 PR。

- **適合ベクトル JSON**（CF-1〜4・キー14種の列挙は skeleton 実装で確定 = 起草判断 D-f）
  - 5状態判別ユニオン＋unknown の reason 判別（R5(5)）・**リポ出力の `n/a` は schema 違反**（中央 rollup のみ宣言可 — CF-2 の状態機械分界・G-7）
  - meta（CF-4）: 基盤4パッケージ版・contractVersion（テーマプラグマ最小値）・manifestSha（pinned registries の sha256）・commitSha
- **fail-closed（G-6）**: 検査不能 = unknown・**適用ファイル数 0 = unknown**（§1.2 の glob 不一致対策）・W0a で未配線のゲートは正直に unknown(not-installed) を出力（空虚合格を出荷しない）
- **gate-integrity（05 §5.2 #15）**: `calculateConfigForFile` の実効値を canonical 表（配布 config から機械導出）と照合。**severity 緩和**と**後勝ち全置換（severity 不変・オプション本数欠落）**の両故障様式を検出 — 05 §10.2 の「calculateConfigForFile 方式は実測未実施」を実測で解消
- **init --scan（T-3/AM-10）**: 許可リスト（@layer components class トークン）＋legacy manifest 初期値 `{path, maxLines(pinned prettier 整形後), maxBytes}` の走査生成。**対象台帳が既存なら実行拒否**（一度きり）・`--check` は読み取り専用再走査（未分類 0 が styling green 条件）
- **legacy manifest 形式**: registries スキーマ（#3）の kind=legacy-manifest と同形

## テスト（16本・故意 fail 確認込み）＋ビルド後 CLI スモーク

- 故意 fail: 後置き off（緩和）red／後勝ち全置換 red／n/a 拒否／boolean 拒否／台帳外 css red／scss 即 red／manifest 記載ファイル不在（台帳腐敗）red
- 正例: 配布 config 自己一致 green／compliant fixture の scan-coverage green
- root `npm run check` に `check:nene2-check`（ビルド後 bin を fixture で実行）を追加 — 実出力: `red 0 / unknown 13 / green 1`

## 起草判断（批准レビュー対象）

- conformance キー名の最終列挙 = 05 §7.1 ドラフトの14キーをそのまま確定（D-f）
- gate-integrity の照合マトリクス = §2.2 の互いに素な5集合の代表点
- 適用ファイル数 0 の unknown reason は `not-installed` を使用（3値列挙に「対象不在」の腕がない — 批准で腕追加の要否）
- scan-coverage の正準許容 = `src/shared/ui/theme/**`・`src/index.css`・`index.html`（W0.starter 現物で最終確定）
- exit code: conformance は red>0 で 1（出力自体は非 blocker の条文と両立 — CI 側で扱いを選べる）

## 未実施（誠実性ガード）

- 正準シーケンス（§5.1 の 11 工程駆動）・check:tw-oracle・validate:themes 連携・required-files・fleet-baseline 照合・ratchet・週次 rollup（中央 = _work/tools 管轄）— conformance では unknown を出力
- CLI のファイル読込経路（製品 eslint.config.js のロード）はテストでは overrideConfig で代替（hermetic のため）— 実リポでの素振りは W0b/W1

CI: ローカル `npm run check` 全 green（test 129）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)