### PR TITLE
feat: JP lint 3ノード化 — I18N-16 確定文字クラス＋プローブ6本（AI-19・W0a stage2）

### DIFF
--- a/packages/nene2-standards/src/configs/restrictions.ts
+++ b/packages/nene2-standards/src/configs/restrictions.ts
@@ -37,10 +37,28 @@ import {
 } from '../restricted-imports.js';
 
 /**
- * JP 3ノードセレクタの座席（AI-19 — 別 PR で第4部 I18N-16 の確定文字クラスを実装）。
- * 空配列は「未実装」を意味する。実装 PR がこの export を置換する。
+ * JP lint 3ノード化（AI-19・会議R4 AM-16・R5 文字域修正）。
+ * 文字クラスは第4部 I18N-16 の確定正規表現をそのまま使用（1字も発明しない）:
+ * ひらがな・カタカナ・CJK（records 現行域）＋々（U+3005）・〆（U+3006）・半角カナ（U+FF66-FF9D）。
+ * records 現行の Literal 1本は JSXText / TemplateLiteral を素通しする実穴（AM-16 検証済み）—
+ * 3ノード必須。除外の有限列挙は I18N-16（restrictions のファイル集合設計が実装）。
  */
-export const I18N_JP_SYNTAX: readonly SyntaxSelector[] = [];
+const JP = String.raw`[々〆぀-ヿ㐀-鿿ｦ-ﾝ]`;
+
+export const I18N_JP_SYNTAX: readonly SyntaxSelector[] = [
+  {
+    selector: `Literal[value=/${JP}/]`,
+    message: 'ユーザ知覚文字列は t() 経由（会議R1⑦決定）。',
+  },
+  {
+    selector: `JSXText[value=/${JP}/]`,
+    message: '同上。',
+  },
+  {
+    selector: `TemplateElement[value.cooked=/${JP}/]`,
+    message: '同上。',
+  },
+];
 
 export const APP_GLOB = 'src/**/*.{ts,tsx}';
 export const CLIENT_TS = 'src/shared/api/client.ts';

--- a/packages/nene2-standards/tests/fixtures/probe-app/src/features/probe-slice/jp-probe.tsx
+++ b/packages/nene2-standards/tests/fixtures/probe-app/src/features/probe-slice/jp-probe.tsx
@@ -1,0 +1,13 @@
+// JP lint 3ノード プローブ6本（第4部 I18N-16・AI-19 の表そのまま）
+export function JpProbe({ n }: { n: number }) {
+  const s = '保存しました'; // 1: Literal
+  const t = `合計 ${n} 件`; // 3: TemplateElement
+  const memo = 'ﾒﾓ'; // 5: 半角カナ
+  const shime = '締〆'; // 6: 〆
+  return (
+    <div>
+      <p>保存しました</p> {/* 2: JSXText */}
+      <button aria-label="閉じる">{[s, t, memo, shime].join('')}</button> {/* 4: 属性 Literal */}
+    </div>
+  );
+}

--- a/packages/nene2-standards/tests/jp-lint.probes.test.ts
+++ b/packages/nene2-standards/tests/jp-lint.probes.test.ts
@@ -1,0 +1,78 @@
+/**
+ * JP lint 3ノード化の検出プローブ 6本＋除外の有限列挙（AI-19・会議R4 AM-16・R5 文字域修正 —
+ * 「lint の昇格には検出プローブ添付・自己テスト同梱 MUST」の適用）。
+ */
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+import { ESLint, type Linter } from 'eslint';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const fixtureDir = fileURLToPath(new URL('./fixtures/probe-app/', import.meta.url));
+
+let eslint: ESLint;
+
+beforeAll(async () => {
+  process.chdir(fixtureDir);
+  const { composedConfig } = await import('../src/index.js');
+  eslint = new ESLint({
+    cwd: fixtureDir,
+    overrideConfigFile: true,
+    overrideConfig: composedConfig(),
+  });
+}, 120_000);
+
+async function jpMessages(relPath: string): Promise<Linter.LintMessage[]> {
+  const results = await eslint.lintFiles([relPath]);
+  return (results[0]?.messages ?? []).filter(
+    (m) =>
+      m.ruleId === 'no-restricted-syntax' &&
+      (m.message.includes('t() 経由') || m.message === '同上。'),
+  );
+}
+
+describe('JP lint 3ノード（I18N-16 プローブ表 6本）', () => {
+  it('プローブ 1〜6 を全て検知する（Literal / JSXText / TemplateElement / 属性 / 半角カナ / 〆）', async () => {
+    const msgs = await jpMessages('src/features/probe-slice/jp-probe.tsx');
+    const lines = new Set(msgs.map((m) => m.line));
+    // fixture の行: 3=Literal '保存しました' / 4=Template `合計 ${n} 件` / 5=半角カナ /
+    // 6=〆 / 9=JSXText / 10=aria-label 属性 Literal
+    for (const line of [3, 4, 5, 6, 9, 10]) {
+      expect(lines, `line ${line} のプローブが検知されること`).toContain(line);
+    }
+    expect(msgs.length).toBeGreaterThanOrEqual(6);
+  }, 60_000);
+
+  it('除外の有限列挙: カタログの家（shared/i18n/messages）は JP literal 免除・Intl 禁止は維持', async () => {
+    const msgs = await jpMessages('src/shared/i18n/messages/ja.ts');
+    expect(msgs).toEqual([]); // ja.ts は '閉じる' を含むが免除
+    const cfg = (await eslint.calculateConfigForFile(
+      path.join(fixtureDir, 'src/shared/i18n/messages/ja.ts'),
+    )) as { rules: Record<string, unknown[]> };
+    const selectors = (cfg.rules['no-restricted-syntax'] ?? []).slice(1) as {
+      selector: string;
+    }[];
+    expect(selectors.some((s) => s.selector.includes('Intl'))).toBe(true); // 免除は JP のみ
+  }, 60_000);
+
+  it('除外の有限列挙: テストファイルは JP lint 対象外（R2⑦補記）・testing セレクタは適用', async () => {
+    const cfg = (await eslint.calculateConfigForFile(
+      path.join(fixtureDir, 'tests/msw-probe.fixture.ts'),
+    )) as { rules: Record<string, unknown[]> };
+    const selectors = ((cfg.rules['no-restricted-syntax'] ?? []).slice(1) as { selector: string }[])
+      .map((s) => s.selector)
+      .join('\n');
+    expect(selectors).not.toContain('JSXText'); // JP 3ノードなし
+    expect(selectors).toContain('ByTestId'); // testing 統合は生きている
+  });
+
+  it('client.ts（fetch 例外の座席）でも JP lint は適用されたまま', async () => {
+    const cfg = (await eslint.calculateConfigForFile(
+      path.join(fixtureDir, 'src/shared/api/client.ts'),
+    )) as { rules: Record<string, unknown[]> };
+    const selectors = ((cfg.rules['no-restricted-syntax'] ?? []).slice(1) as { selector: string }[])
+      .map((s) => s.selector)
+      .join('\n');
+    expect(selectors).toContain('JSXText');
+  });
+});


### PR DESCRIPTION
## 概要（W0a stage2 — 論点5: JP lint 3ノード化・AI-19）

**base = #2**（nene2-standards の合成規律の座席 `I18N_JP_SYNTAX` を実装で置換）

- 文字クラスは **04 I18N-16 の確定正規表現をそのまま使用**（1字も発明しない）: `/[々〆぀-ヿ㐀-鿿ｦ-ﾝ]/`
- 3ノード必須（AM-16 — records 現行 `Literal` 1本は JSXText / TemplateLiteral を素通しする実穴）: `Literal` / `JSXText` / `TemplateElement[value.cooked]`
- 適用集合（#2 の互いに素設計に載せる）: app＋client.ts に適用・**免除は I18N-16 の有限列挙のみ**（`src/shared/i18n/messages/**`＝カタログの家・`**/*.test.*`・`**/*.stories.*`・`tests/**`）。client.ts（fetch 例外の座席）にも JP lint は適用されたまま
- リポ側 eslint-disable の禁止は #2 の `eslint-comments/no-restricted-disable`（no-restricted-syntax 収載済み）が担う

## テスト（4本 — プローブは I18N-16 の表の6本そのまま）

| # | プローブ | 期待 | 結果 |
|---|---|---|---|
| 1 | `const s = '保存しました'`（Literal） | 検知 | PASS |
| 2 | `<p>保存しました</p>`（JSXText） | 検知 | PASS |
| 3 | `` `合計 ${n} 件` ``（TemplateElement） | 検知 | PASS |
| 4 | `aria-label="閉じる"`（属性 Literal） | 検知 | PASS |
| 5 | `"ﾒﾓ"`（半角カナ） | 検知 | PASS |
| 6 | `"締〆"`（〆） | 検知 | PASS |

＋負例3本: messages/** 免除（Intl 禁止は維持）・テストファイル免除（testing セレクタは維持）・client.ts 適用維持。typescript-eslint parser 環境（strictTypeChecked 合成済み最終 config）での実測。

## 注記

- I18N-16 のタグ表記 `[E:nene2-i18n/no-hardcoded-jp]` に対し、実装座席は 05 §2.2.5 どおり `no-restricted-syntax` セレクタ（rule-id の綴りは W0a 実装が正本 — RAT-2 生成表で最終確定）。
- baseline 方式（I18N-17・concierge/corpus）は #4 の lint-baseline 台帳＋W0b ゲート導入 PR の管轄。

CI: ローカル `npm run check` 全 green（test 105）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)