### PR TITLE
feat: packages/nene2-i18n 骨格 — 型付きカタログ＋parity AM-17 最終形（W0a stage2）

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NeNe フリート・フロント統一規約の**配布物（versioned 実行可
 |---|---|---|
 | `packages/nene2-tokens` | Core Token Contract v1（color 28＋shadow 4）・CONTRACT_TOKENS export・validate:themes・themegen・codemod 写像表 v1 | **v1.0.0-rc.1 実装済**（W0a stage1・凍結レビュー資料 = `docs/contract-freeze-review-2026-07-18.md`・マージ/publish は施主承認後） |
 | `packages/nene2-standards` | ESLint flat config 配布（合成規律=ルール単位1定義・plugin 同梱）・Stylelint 2枚組・known-utility lint・`nene2-check`（conformance skeleton・fail-closed）・`init --scan` | 未実装 |
-| `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | 未実装（W0a では骨格まで可） |
+| `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | **W0a 骨格 実装済**（型付きカタログ＋parity AM-17 最終形。plural/format/react/vault JSON 形は W0b — パッケージ README 参照） |
 | `registries/` | 構造レジストリ（恒久公認差異）＋負債台帳（lint-baseline / legacy-manifest）＋waiver — kind 判別ユニオン jsonc | 未実装 |
 | `fleet-baseline.json` | 基盤4パッケージ semver の単一マニフェスト | 未作成（版が確定済みなのは nene2-client ^1.1.0 のみ） |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -606,6 +606,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hideyukimori/nene2-i18n": {
+      "resolved": "packages/nene2-i18n",
+      "link": true
+    },
     "node_modules/@hideyukimori/nene2-tokens": {
       "resolved": "packages/nene2-tokens",
       "link": true
@@ -3023,6 +3027,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/nene2-i18n": {
+      "name": "@hideyukimori/nene2-i18n",
+      "version": "0.1.0-rc.1",
+      "license": "UNLICENSED"
     },
     "packages/nene2-tokens": {
       "name": "@hideyukimori/nene2-tokens",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "packages/*"
   ],
   "scripts": {
-    "type-check": "tsc --build packages/nene2-tokens",
+    "type-check": "tsc --build packages/*",
     "lint": "eslint .",
     "format:check": "prettier --check \"packages/**/*.{ts,json,css}\"",
     "test": "vitest run",
-    "build": "tsc --build packages/nene2-tokens",
+    "build": "tsc --build packages/*",
     "check:cli": "node packages/nene2-tokens/dist/cli.js validate packages/nene2-tokens/themes/reference.css",
     "check": "npm run type-check && npm run lint && npm run format:check && npm run test && npm run check:cli"
   },

--- a/packages/nene2-i18n/README.md
+++ b/packages/nene2-i18n/README.md
@@ -1,0 +1,20 @@
+# @hideyukimori/nene2-i18n
+
+NeNe フリートの型付き i18n。**W0a 時点は骨格**（指示書どおり — フル実装は W0a 必須でない）。
+
+## W0a 骨格に含まれるもの
+
+- **型付きカタログ**: `MessageCatalog` / `MessageKeyOf<T>` / `createTranslator`（{name} 補間のみ・ICU パーサ禁止 — 会議R1⑦「ランタイム最小」）。未知キーの実行時到達は throw（fail-closed）。
+- **parity 検査（AM-17 最終形 = R5 AM-17'）**: `expectCatalogParity` / `checkCatalogParity`
+  - shape 100%（欠落・余剰とも FAIL）
+  - 同値率検査は**全ロケール対**（権威対限定は「en→de/es/fr コピー」に盲目）
+  - `maxIdenticalRatio` 既定 20%・`minKeys: 50` の床（床未満は identicalAllowlist の列挙のみで運用）・`identicalAllowlist`
+  - **これは lazy copy の検出器であり翻訳品質の証明ではない**（条文明記 — 数値は検出に使い完了判定に使わない）
+
+## 未実装（W0b — 誠実性ガード）
+
+- `plural`（複数形）・`format`（通貨・日付・数値の Intl ラッパ — I18N-13 の「Intl 直呼びはここだけ」の座席）
+- `react` subpath（I18nProvider・useTranslation・lang/dir scope 同期 — AM-18）
+- `translate` root subpath（非コンポーネント層の解決）
+- vault JSON カタログ形＋DotPaths 型生成（公認差異 #3 — parity の JSON 受理）
+- identicalAllowlist の registries（identical-allowlist kind）からの機械生成配線

--- a/packages/nene2-i18n/package.json
+++ b/packages/nene2-i18n/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@hideyukimori/nene2-i18n",
+  "version": "0.1.0-rc.1",
+  "description": "NeNe fleet typed i18n — typed catalog + parity (AM-17 final form). W0a skeleton: translate/plural/format/react are W0b.",
+  "type": "module",
+  "license": "UNLICENSED",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc --build"
+  }
+}

--- a/packages/nene2-i18n/src/catalog.ts
+++ b/packages/nene2-i18n/src/catalog.ts
@@ -1,0 +1,40 @@
+/**
+ * 型付きカタログ（規約 04 §1 の骨格 — W0a）。
+ *
+ * - ja が権威カタログ（キー集合の正本）。MessageKey はカタログから型導出する。
+ * - ランタイムは最小（ICU パーサ禁止 — 会議R1⑦。補間は {name} 置換のみ）。
+ * - plural / format（Intl ラッパ）/ react（I18nProvider・useTranslation）/ vault JSON 形
+ *   （DotPaths）は W0b — 本骨格には**存在しない**（未実装を明記）。
+ */
+
+/** メッセージカタログ（flat key → 文字列値）。キーの綴り規約は 04 が正本。 */
+export type MessageCatalog = Record<string, string>;
+
+/** 権威カタログからの MessageKey 型導出（`satisfies` と併用する）。 */
+export type MessageKeyOf<T extends MessageCatalog> = keyof T & string;
+
+export interface Translator<T extends MessageCatalog> {
+  /** 型付き解決。未知キーはコンパイル時に落ちる（実行時到達は Error — fail-closed）。 */
+  t(key: MessageKeyOf<T>, params?: Record<string, string | number>): string;
+}
+
+/**
+ * カタログ束からの translator 生成（骨格）。
+ * ロケール解決・fallback 連鎖・scope 同期（AM-18）は W0b の I18nProvider 管轄。
+ */
+export function createTranslator<T extends MessageCatalog>(catalog: T): Translator<T> {
+  return {
+    t(key, params) {
+      const value = catalog[key];
+      if (value === undefined) {
+        // fail-closed: 型を欺いて到達した未知キーは黙って key を返さない
+        throw new Error(`unknown MessageKey: ${String(key)}`);
+      }
+      if (!params) return value;
+      return value.replaceAll(/\{(\w+)\}/g, (whole, name: string) => {
+        const p = params[name];
+        return p === undefined ? whole : String(p);
+      });
+    },
+  };
+}

--- a/packages/nene2-i18n/src/index.ts
+++ b/packages/nene2-i18n/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @hideyukimori/nene2-i18n — W0a 骨格（型付きカタログ＋parity）。
+ * plural / format / react / vault JSON 形（DotPaths）は W0b — 未実装（README 参照）。
+ */
+export { createTranslator } from './catalog.js';
+export type { MessageCatalog, MessageKeyOf, Translator } from './catalog.js';
+export { checkCatalogParity, expectCatalogParity } from './parity.js';
+export type { ParityOptions, ParityViolation } from './parity.js';

--- a/packages/nene2-i18n/src/parity.test.ts
+++ b/packages/nene2-i18n/src/parity.test.ts
@@ -1,0 +1,90 @@
+/**
+ * parity（AM-17 最終形）— green＋故意 fail の両方向。
+ */
+import { describe, expect, it } from 'vitest';
+
+import { createTranslator } from './catalog.js';
+import { checkCatalogParity, expectCatalogParity } from './parity.js';
+
+/** n キーの健全カタログ対を生成（値はロケールごとに異なる） */
+function catalogs(n: number): { ja: Record<string, string>; en: Record<string, string> } {
+  const ja: Record<string, string> = {};
+  const en: Record<string, string> = {};
+  for (let i = 0; i < n; i++) {
+    ja[`common.key${i}`] = `日本語${i}`;
+    en[`common.key${i}`] = `English ${i}`;
+  }
+  return { ja, en };
+}
+
+describe('shape 100%', () => {
+  it('キー集合完全一致は green', () => {
+    expect(() => expectCatalogParity(catalogs(60))).not.toThrow();
+  });
+
+  it('故意 fail: 欠落キーも余剰キーも FAIL', () => {
+    const { ja, en } = catalogs(60);
+    delete en['common.key0']; // 欠落
+    expect(checkCatalogParity({ ja, en }).some((v) => v.kind === 'shape')).toBe(true);
+    const { ja: ja2, en: en2 } = catalogs(60);
+    en2['common.extra'] = 'x'; // 余剰
+    expect(checkCatalogParity({ ja: ja2, en: en2 }).some((v) => v.kind === 'shape')).toBe(true);
+  });
+
+  it('fail-closed: 権威カタログ不在は FAIL', () => {
+    expect(checkCatalogParity({ en: { a: 'x' } })).toHaveLength(1);
+  });
+});
+
+describe('同値率検査（全ロケール対・maxIdenticalRatio 20%・minKeys 50 床）', () => {
+  it('故意 fail: ja の値を en に丸コピー（次世代スタブ）は FAIL', () => {
+    const { ja } = catalogs(60);
+    const violations = checkCatalogParity({ ja, en: { ...ja } });
+    expect(violations.some((v) => v.kind === 'identical-ratio')).toBe(true);
+    expect(violations[0]?.message).toContain('検出器であり翻訳品質の証明ではない');
+  });
+
+  it('故意 fail: 権威対は健全でも en→de コピーは全ロケール対で FAIL（AM-17 全対化の根拠）', () => {
+    const { ja, en } = catalogs(60);
+    const violations = checkCatalogParity({ ja, en, de: { ...en } });
+    const pairs = violations.map((v) => v.locales.join('×'));
+    expect(pairs).toContain('en×de');
+    expect(pairs).not.toContain('ja×en');
+  });
+
+  it('同値率 ≤20% は green・identicalAllowlist 収載分は同値に数えない', () => {
+    const { ja, en } = catalogs(60);
+    // 同値 6/60 = 10% ≤ 20%
+    for (let i = 0; i < 6; i++) en[`common.key${i}`] = ja[`common.key${i}`] as string;
+    expect(() => expectCatalogParity({ ja, en })).not.toThrow();
+    // 同値 18/60 = 30% > 20% → FAIL、ただし列挙で免除すれば green
+    const en2 = { ...en };
+    const allow: string[] = [];
+    for (let i = 0; i < 18; i++) {
+      en2[`common.key${i}`] = ja[`common.key${i}`] as string;
+      allow.push(`common.key${i}`);
+    }
+    expect(() => expectCatalogParity({ ja, en: en2 })).toThrow(/同値率/);
+    expect(() => expectCatalogParity({ ja, en: en2 }, { identicalAllowlist: allow })).not.toThrow();
+  });
+
+  it('minKeys 床未満: 統計不能 — 列挙外の同値は全件 FAIL・列挙済みなら green', () => {
+    const ja = { 'common.locale.ja': '日本語', 'common.brand': 'NeNe', 'common.save': '保存' };
+    const en = { 'common.locale.ja': '日本語', 'common.brand': 'NeNe', 'common.save': 'Save' };
+    const violations = checkCatalogParity({ ja, en });
+    expect(violations.some((v) => v.kind === 'identical-below-floor')).toBe(true);
+    expect(() =>
+      expectCatalogParity({ ja, en }, { identicalAllowlist: ['common.locale.ja', 'common.brand'] }),
+    ).not.toThrow();
+  });
+});
+
+describe('型付きカタログ（骨格）', () => {
+  it('t() は補間つきで解決・未知キーの実行時到達は throw（fail-closed）', () => {
+    const catalog = { 'common.total': '合計 {count} 件' } as const;
+    const { t } = createTranslator(catalog);
+    expect(t('common.total', { count: 3 })).toBe('合計 3 件');
+    // @ts-expect-error 未知キーはコンパイル時に落ちる（型検査そのものがテスト）
+    expect(() => t('common.unknown')).toThrow(/unknown MessageKey/);
+  });
+});

--- a/packages/nene2-i18n/src/parity.ts
+++ b/packages/nene2-i18n/src/parity.ts
@@ -1,0 +1,131 @@
+/**
+ * カタログ parity 検査 — AM-17 最終形（会議R4 AM-17・R5 AM-17' 決定）。
+ *
+ * 1. shape 100%: 全ロケールのキー集合が権威（ja）と完全一致（欠落・余剰とも FAIL）。
+ * 2. 同値率検査: **全ロケール対**（権威対限定 MUST NOT — 「en の値を de/es/fr にコピー」経路に
+ *    盲目になる。全対の健全最大 8.5% 実測・n≤6 で ≤15対＝コストゼロ）。
+ *    - maxIdenticalRatio 既定 20%（叩き台 — 健全カタログの実測同値率 2.6% が根拠）
+ *    - minKeys 既定 50 の床: 床未満の小カタログは統計不能 — identicalAllowlist の**列挙のみ**で
+ *      運用（「数でなく列挙」の再適用）
+ *    - identicalAllowlist: 翻訳不能な固有表記（ブランド名・ロケール自称名等）の列挙
+ *
+ * **これは lazy copy の検出器であり翻訳品質の証明ではない**（R5 AM-17' 条文 —
+ * 数値は検出に使い完了判定に使わない）。
+ */
+import type { MessageCatalog } from './catalog.js';
+
+export interface ParityOptions {
+  /** 権威ロケール（既定 'ja' — 04 I18N の権威カタログ） */
+  authority?: string;
+  /** 同値率の上限（既定 0.2 — R5 AM-17' 叩き台） */
+  maxIdenticalRatio?: number;
+  /** 同値率検査が統計的に意味を持つ最小キー数の床（既定 50） */
+  minKeys?: number;
+  /** 全ロケールで同値が正当なキーの列挙（identical-allowlist 台帳 — registries 管轄） */
+  identicalAllowlist?: readonly string[];
+}
+
+export interface ParityViolation {
+  kind: 'shape' | 'identical-ratio' | 'identical-below-floor';
+  locales: [string, string];
+  message: string;
+  keys: string[];
+}
+
+export function checkCatalogParity(
+  catalogs: Record<string, MessageCatalog>,
+  options: ParityOptions = {},
+): ParityViolation[] {
+  const {
+    authority = 'ja',
+    maxIdenticalRatio = 0.2,
+    minKeys = 50,
+    identicalAllowlist = [],
+  } = options;
+  const violations: ParityViolation[] = [];
+  const locales = Object.keys(catalogs);
+  const authorityCatalog = catalogs[authority];
+  if (!authorityCatalog) {
+    return [
+      {
+        kind: 'shape',
+        locales: [authority, authority],
+        message: `権威カタログ '${authority}' が存在しない（fail-closed）`,
+        keys: [],
+      },
+    ];
+  }
+  const authorityKeys = Object.keys(authorityCatalog).sort();
+
+  // 1. shape 100%（欠落・余剰とも FAIL）
+  for (const locale of locales) {
+    if (locale === authority) continue;
+    const catalog = catalogs[locale] ?? {};
+    const keys = new Set(Object.keys(catalog));
+    const missing = authorityKeys.filter((k) => !keys.has(k));
+    const extra = [...keys].filter((k) => !(k in authorityCatalog)).sort();
+    if (missing.length > 0 || extra.length > 0) {
+      violations.push({
+        kind: 'shape',
+        locales: [authority, locale],
+        message: `shape 不一致: 欠落 ${missing.length} / 余剰 ${extra.length}（shape は 100% MUST）`,
+        keys: [...missing, ...extra],
+      });
+    }
+  }
+
+  // 2. 同値率検査（全ロケール対 — R5 AM-17'）
+  const allowset = new Set(identicalAllowlist);
+  for (let i = 0; i < locales.length; i++) {
+    for (let j = i + 1; j < locales.length; j++) {
+      const [a, b] = [locales[i] as string, locales[j] as string];
+      const ca = catalogs[a] ?? {};
+      const cb = catalogs[b] ?? {};
+      const shared = Object.keys(ca).filter((k) => k in cb);
+      const identical = shared.filter(
+        (k) => ca[k] === cb[k] && (ca[k] ?? '') !== '' && !allowset.has(k),
+      );
+      if (shared.length >= minKeys) {
+        const ratio = identical.length / shared.length;
+        if (ratio > maxIdenticalRatio) {
+          violations.push({
+            kind: 'identical-ratio',
+            locales: [a, b],
+            message:
+              `同値率 ${(ratio * 100).toFixed(1)}% > ${(maxIdenticalRatio * 100).toFixed(0)}%` +
+              `（lazy copy の疑い — これは検出器であり翻訳品質の証明ではない）`,
+            keys: identical.slice(0, 20),
+          });
+        }
+      } else if (identical.length > 0) {
+        // 床未満: 統計不能 — allowlist の列挙のみで運用（列挙外の同値は全件 FAIL）
+        violations.push({
+          kind: 'identical-below-floor',
+          locales: [a, b],
+          message:
+            `キー数 ${shared.length} < minKeys ${minKeys}（統計不能）— ` +
+            `identicalAllowlist 列挙外の同値 ${identical.length} 件は全件 FAIL`,
+          keys: identical,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+/** テスト用アサーション形（05 §5.2 #8 の `expectCatalogParity` — 違反があれば throw）。 */
+export function expectCatalogParity(
+  catalogs: Record<string, MessageCatalog>,
+  options: ParityOptions = {},
+): void {
+  const violations = checkCatalogParity(catalogs, options);
+  if (violations.length > 0) {
+    throw new Error(
+      'catalog parity FAIL:\n' +
+        violations
+          .map((v) => `- [${v.locales.join('×')}] ${v.message}\n  keys: ${v.keys.join(', ')}`)
+          .join('\n'),
+    );
+  }
+}

--- a/packages/nene2-i18n/tsconfig.json
+++ b/packages/nene2-i18n/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## 概要（W0a stage2 — 論点6: nene2-i18n 骨格）

指示書どおり **骨格まで**（フル実装は W0a 必須でない — 明記）。

- **型付きカタログ**: `MessageKeyOf<T>` による型導出・`createTranslator`（{name} 補間のみ — ICU パーサ禁止 = R1⑦ ランタイム最小）・未知キーの実行時到達は throw（fail-closed）
- **parity 検査 = AM-17 最終形（R5 AM-17'）**:
  - shape 100%（欠落も余剰も FAIL）
  - 同値率検査は**全ロケール対**（権威対限定は「en の値を de/es/fr にコピー」経路に盲目 — テストで実証）
  - `maxIdenticalRatio` 既定 **20%**・`minKeys: 50` の床（床未満は identicalAllowlist の**列挙のみ**で運用）・`identicalAllowlist`
  - 条文明記: **「これは lazy copy の検出器であり翻訳品質の証明ではない」**（違反メッセージにも埋め込み）

## テスト（8本・故意 fail 確認込み）

丸コピー（次世代スタブ）FAIL／en→de コピー FAIL（ja×en は green のまま — 全対化の根拠の実証）／shape 欠落・余剰 FAIL／床未満の列挙外同値 FAIL／allowlist 免除 green／権威不在 fail-closed。

## 未実施（W0b — README に列挙）

plural / format（I18N-13 の Intl 座席）/ react subpath（I18nProvider・AM-18 scope 同期）/ translate root subpath / vault JSON カタログ形＋DotPaths（公認差異 #3）/ identicalAllowlist の registries 配線。

## 注記

- root scripts を `tsc --build packages/*` に変更（#2 と同一編集 — どちらが先にマージされても衝突しない同文）。

CI: ローカル `npm run check` 全 green（test 82）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)