### PR TITLE
docs: 契約凍結の承認記録スタンプ（2026-07-14 hide 承認・Core Token Contract v1 凍結確定）

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ NeNe フリート・フロント統一規約の**配布物（versioned 実行可
 
 | パス | 内容 | 状態 |
 |---|---|---|
-| `packages/nene2-tokens` | Core Token Contract v1（color 28＋shadow 4）・CONTRACT_TOKENS export・validate:themes・themegen・codemod 写像表 v1 | **v1.0.0-rc.1 実装済**（W0a stage1・凍結レビュー資料 = `docs/contract-freeze-review-2026-07-18.md`・マージ/publish は施主承認後） |
+| `packages/nene2-tokens` | Core Token Contract v1（color 28＋shadow 4）・CONTRACT_TOKENS export・validate:themes・themegen・codemod 写像表 v1 | **契約凍結済み・v1.0.0 準備中**（2026-07-14 hide 承認 — §6 全6項目受け入れ・07-18 予定を前倒し。承認記録 = `docs/contract-freeze-review-2026-07-18.md` §7。以後の契約キー集合変更は stop-the-line ADR のみ=AM-2。publish は施主実行） |
 | `packages/nene2-standards` | ESLint flat config 配布（合成規律=ルール単位1定義・plugin 同梱）・Stylelint 2枚組・known-utility lint・`nene2-check`（conformance skeleton・fail-closed）・`init --scan` | **実装済**（W0a stage2 #2/#8/#9） |
 | `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | **W0a 骨格 実装済**（型付きカタログ＋parity AM-17 最終形。plural/format/react/vault JSON 形は W0b — パッケージ README 参照） |
 | `packages/nene2-standards/registries/` | 構造レジストリ（恒久公認差異）＋負債台帳（lint-baseline / legacy-manifest）＋waiver — kind 判別ユニオン jsonc（スキーマ = `src/registries/schema.ts`・配置は 05 §1.1 準拠でパッケージ同梱＝製品は pinned 版で消費） | **v1 発効時点の現物 登録済**（経過措置2件は kind=transition・批准レビュー送り） |

--- a/docs/contract-freeze-review-2026-07-18.md
+++ b/docs/contract-freeze-review-2026-07-18.md
@@ -115,3 +115,28 @@
 | ④ | records focus-ring AA FAIL を W1 是正リストへ追加 | 承認 |
 | ⑤ | color-scheme を閉文法 allowlist に追加提案（standards patch レーン） | 承認 |
 | ⑥ | 28＋4 キーの凍結（text-faint 収載を含む） | **凍結** |
+
+---
+
+## 7. 承認記録（凍結確定 — 2026-07-14・当初予定 07-18 の前倒し）
+
+- **2026-07-14、施主 hide が本レビューを完了**（チャット裁定。07-18 予定を 4 日前倒し）。
+- 判定:
+  - §1 全キー（color 28＋shadow 4・text-faint 収載を含む）— **承認**
+  - §2 W0a 確定値（閉文法 EBNF・contrast ペア表 v1・fill 最終形・決定性・写像規律ほか）— **承認**
+  - §6 提案①〜⑥ — **すべて受け入れ（○）**
+- これをもって **Core Token Contract v1 は凍結確定**。`packages/nene2-tokens` の
+  `COLOR_KEYS`（28）／`SHADOW_KEYS`（4）／`CONTRACT_VERSION = '1.0'` が凍結された正本。
+- **以後の契約キー集合の変更は stop-the-line ADR のみ**（AM-2 契約進化規約:
+  minor=派生式同梱・major=codemod 3点セット。移行窓 W1〜W6 中はいかなる変更も stop-the-line ADR）。
+- §6 受け入れの帰結（各提案の効力）:
+  1. ① -weak 群→-soft・sidebar-*→x- の起草判断写像 = 確定（写像表 v1 収載のまま発効）
+  2. ② vault 個別表 40 行 = 確定（x- 送り名の最終調整は W1 vault PR で可）
+  3. ③ records `text-text-secondary` の是正先 = `text-text-muted` で確定
+  4. ④ records focus-ring AA FAIL（2.51／2.74 < 3:1）を W1 records 是正リストへ追加
+  5. ⑤ `color-scheme` の閉文法 allowlist 追加は standards patch レーンで提案を進める
+     （本凍結の一部ではない — 提案が通るまで現行文法どおり error）
+  6. ⑥ 28＋4 キーの凍結 = 確定
+- §5 の未確定 6 項目は台帳のまま持ち越し（凍結の対象外 — v1.1 以降の較正課題）。
+- 次工程: 承認スタンプ（本節）→ tokens／standards v1.0.0 publish → `fleet-baseline.json`
+  実版数記入 → W0.starter。


### PR DESCRIPTION
## 概要

2026-07-14、施主 hide が契約凍結レビューを完了（当初予定 07-18 の 4 日前倒し・チャット裁定）。
その承認記録を凍結レビュー資料に正式スタンプする。

## 変更

- **`docs/contract-freeze-review-2026-07-18.md` — §7 承認記録を追記**
  - §1 全キー（color 28＋shadow 4・text-faint 収載含む）承認
  - §2 W0a 確定値 承認
  - §6 提案①〜⑥ **すべて受け入れ** → Core Token Contract v1 **凍結確定**
  - 以後の契約キー集合変更は **stop-the-line ADR のみ**（AM-2）を明記
  - §6 各提案の効力（写像確定・W1 是正リスト追加・color-scheme は standards patch レーン提案続行）を記録
- **README** の tokens 行を「契約凍結済み・v1.0.0 準備中」へ更新

## 依存

- base は main。単独でマージ可（リリース準備 PR とは独立。README の同一表を触るが行が異なる）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)