### PR TITLE
fix(publish): prepack ビルドフック——dist 欠落 tarball の防止

### DIFF
--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -25,7 +25,8 @@
     "registries"
   ],
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "prepack": "tsc --build"
   },
   "dependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
@@ -49,7 +50,7 @@
     }
   },
   "bin": {
-    "nene2-check": "./dist/checks/cli.js"
+    "nene2-check": "dist/checks/cli.js"
   },
   "repository": {
     "type": "git",

--- a/packages/nene2-tokens/package.json
+++ b/packages/nene2-tokens/package.json
@@ -13,7 +13,7 @@
     }
   },
   "bin": {
-    "nene2-tokens": "./dist/cli.js"
+    "nene2-tokens": "dist/cli.js"
   },
   "files": [
     "dist",
@@ -22,7 +22,8 @@
     "contract-freeze.json"
   ],
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "prepack": "tsc --build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
施主の初回 publish 実測で tarball が 6 files/8.7kB（dist なし）になる事故を確認。prepack: tsc --build を両パッケージに追加し、クリーン状態からの npm pack で tokens 39 files / standards 79 files を実測確認。bin の ./ 接頭辞除去も同梱。

🤖 Generated with [Claude Code](https://claude.com/claude-code)