### PR TITLE
chore: fleet-baseline 発効（tokens/standards ^1.0.0）

### DIFF
--- a/docs/fleet-baseline.test.ts
+++ b/docs/fleet-baseline.test.ts
@@ -41,11 +41,10 @@ describe('fleet-baseline.json', () => {
     }
   });
 
-  it('発効済みは nene2-client ^1.1.0 のみ・本リポ3パッケージは publish 前につき null（誠実性ガード: 未公開版を書かない — 記入は publish 成功後の別 PR）', () => {
+  it('発効済み: client ^1.1.0・tokens/standards ^1.0.0（2026-07-14 npm 公開実測: 39/79 files）・i18n は骨格につき null', () => {
     expect(baseline.packages['@hideyukimori/nene2-client']).toBe('^1.1.0');
-    // ↓ tokens / standards の publish が成功したら、この期待値を実版数に更新する
-    expect(baseline.packages['@hideyukimori/nene2-tokens']).toBeNull();
-    expect(baseline.packages['@hideyukimori/nene2-standards']).toBeNull();
+    expect(baseline.packages['@hideyukimori/nene2-tokens']).toBe('^1.0.0');
+    expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^1.0.0');
     expect(baseline.packages['@hideyukimori/nene2-i18n']).toBeNull();
   });
 });

--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -3,8 +3,8 @@
   "schemaVersion": 1,
   "packages": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-tokens": null,
-    "@hideyukimori/nene2-standards": null,
+    "@hideyukimori/nene2-tokens": "^1.0.0",
+    "@hideyukimori/nene2-standards": "^1.0.0",
     "@hideyukimori/nene2-i18n": null
   }
 }


### PR DESCRIPTION
npm 公開実測（nene2-tokens@1.0.0 = 39 files / nene2-standards@1.0.0 = 79 files・2026-07-14）を受けて null → 実版数へ。i18n は W0a 骨格につき null 維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)