### PR TITLE
fix(standards): lint false positive 3件の是正＋正例プローブ較正（1.0.1）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nene2-fleet-tooling",
       "version": "0.0.0",
+      "license": "MIT",
       "workspaces": [
         "packages/*"
       ],
@@ -6702,12 +6703,12 @@
     "packages/nene2-i18n": {
       "name": "@hideyukimori/nene2-i18n",
       "version": "0.1.0-rc.1",
-      "license": "UNLICENSED"
+      "license": "MIT"
     },
     "packages/nene2-standards": {
       "name": "@hideyukimori/nene2-standards",
-      "version": "0.1.0-rc.1",
-      "license": "UNLICENSED",
+      "version": "1.0.1",
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
         "eslint-config-prettier": "^10.1.8",
@@ -6767,8 +6768,8 @@
     },
     "packages/nene2-tokens": {
       "name": "@hideyukimori/nene2-tokens",
-      "version": "1.0.0-rc.1",
-      "license": "UNLICENSED",
+      "version": "1.0.0",
+      "license": "MIT",
       "bin": {
         "nene2-tokens": "dist/cli.js"
       }

--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-standards",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-standards/src/restricted-imports.ts
+++ b/packages/nene2-standards/src/restricted-imports.ts
@@ -31,6 +31,13 @@ export const RESTRICTED_IMPORT_PATHS: readonly RestrictedPath[] = [
   { name: 'react-intl', message: '同上。' },
   { name: '@lingui/core', message: '同上。' },
   { name: 'styled-components', message: '会議R1⑤決定: ランタイム CSS-in-JS 恒久 MUST NOT。' },
+  {
+    // paths は module 名の完全一致 — patterns（gitignore 意味論）に置くと
+    // '@/shared/ui/<component>'（R1① の正例）まで全滅する（#19 素振り実測）
+    name: '@/shared/ui',
+    message:
+      'shared/ui の集約バレルは存在しない。@/shared/ui/<component> を import する（会議R1①決定）。',
+  },
 ];
 
 /** fsd（05 §2.2.2）＋CSS-in-JS patterns（05 §2.2.3）— src/** 全域の基本 patterns。 */
@@ -40,7 +47,8 @@ export const RESTRICTED_IMPORT_PATTERNS_BASE: readonly RestrictedPattern[] = [
     message: 'スライス跨ぎの相対 import MUST NOT。スライス外は @/ 絶対形で書く（第1部 1-4）。',
   },
   {
-    group: ['@/shared/ui', '@/shared/ui/index*'],
+    // '@/shared/ui' 自体（拡張子なし集約バレル）は paths 側の完全一致で禁止（#19）
+    group: ['@/shared/ui/index*'],
     message:
       'shared/ui の集約バレルは存在しない。@/shared/ui/<component> を import する（会議R1①決定）。',
   },

--- a/packages/nene2-standards/src/stylelint/plugin.ts
+++ b/packages/nene2-standards/src/stylelint/plugin.ts
@@ -189,6 +189,9 @@ const layerLegacyManifestOnly: Rule<true, { files?: string[] }> =
     const manifestFiles = secondary?.files ?? [];
     const sourceFile = root.source?.input.file?.replaceAll('\\', '/');
     root.walkAtRules('layer', (atRule) => {
+      // ブロックを持たない @layer 文は順序宣言（canonical cascade header の必須行 — AM-8(a)）
+      // であり legacy レイヤへのルール投入ではない（#19）。@layer legacy { … } のみ manifest 制。
+      if (atRule.nodes === undefined) return;
       if (!layerParamsInclude(atRule.params, 'legacy')) return;
       // fail-closed: ファイル名が特定できない（コード断片 lint）場合も未登録扱い
       const listed = sourceFile !== undefined && manifestFiles.some((f) => sourceFile.endsWith(f));
@@ -240,6 +243,34 @@ const themesTokenOnly: Rule<true, { additionalScopeSelectors?: string[] }> =
     for (const node of topLevelNodes(root)) {
       if (node.type === 'comment') continue;
       if (node.type === 'atrule') {
+        // TH-02: 対になる .components.css の @import 行は正
+        if (node.name === 'import') continue;
+        // TH-03: ブランドテーマの @theme 直値ブロックは 0〜1 個の正（active.css から
+        // import されるテーマでは 1 個必須）。nene2-tokens 配布の参照テーマが現物（#19）。
+        // @theme inline は nene2/no-theme-inline の管轄（ここでは inline のみ badAtRule）。
+        if (node.name === 'theme' && !/^inline\b/.test(node.params.trim())) {
+          for (const child of node.nodes ?? []) {
+            if (child.type === 'comment') continue;
+            if (child.type === 'decl') {
+              if (!child.prop.startsWith('--')) {
+                report({
+                  result,
+                  ruleName: themesTokenOnlyName,
+                  node: child,
+                  message: themesTokenOnlyMessages.nonCustomProperty(child.prop),
+                });
+              }
+              continue;
+            }
+            report({
+              result,
+              ruleName: themesTokenOnlyName,
+              node: child,
+              message: themesTokenOnlyMessages.nested(),
+            });
+          }
+          continue;
+        }
         report({
           result,
           ruleName: themesTokenOnlyName,

--- a/packages/nene2-standards/tests/composed-config.probes.test.ts
+++ b/packages/nene2-standards/tests/composed-config.probes.test.ts
@@ -68,6 +68,13 @@ describe('検出プローブ — api（A-1/A-2/R1③）', () => {
     expect(restricted.some((m) => m.message.includes('集約バレル'))).toBe(true);
   });
 
+  it('per-component import（@/shared/ui/<component>）は禁止されない（#19 正例プローブ）', () => {
+    const restricted = messagesFor('src/features/probe-slice/allowed-imports-probe.ts').filter(
+      (m) => m.ruleId === 'no-restricted-imports',
+    );
+    expect(restricted).toEqual([]);
+  });
+
   it('features からの .css import を検知する（AM-8(c)）', () => {
     const msgs = messagesFor('src/features/probe-slice/css-probe.ts');
     expect(

--- a/packages/nene2-standards/tests/fixtures/probe-app/src/features/probe-slice/allowed-imports-probe.ts
+++ b/packages/nene2-standards/tests/fixtures/probe-app/src/features/probe-slice/allowed-imports-probe.ts
@@ -1,0 +1,5 @@
+// 正例プローブ（#19）: per-component import（@/shared/ui/<component>）は R1① の正 —
+// no-restricted-imports が 1 件も出ないこと（patterns の gitignore 意味論で全滅した実事故の再発防止）
+import { probeToken } from '@/shared/ui/probe';
+
+export const allowedImportsProbe = probeToken;

--- a/packages/nene2-standards/tests/fixtures/probe-app/src/shared/ui/probe/index.ts
+++ b/packages/nene2-standards/tests/fixtures/probe-app/src/shared/ui/probe/index.ts
@@ -1,0 +1,2 @@
+// per-component index（R1① 1-4: 1コンポーネント=1ディレクトリ=1 index）— #19 正例プローブの供給元
+export const probeToken = 'nene2-probe';

--- a/packages/nene2-standards/tests/fixtures/styles/src/index.css
+++ b/packages/nene2-standards/tests/fixtures/styles/src/index.css
@@ -1,0 +1,4 @@
+/* canonical cascade header（AM-8(a) 参照形 — @layer 順序宣言文は legacy manifest 制の対象外・#19） */
+@layer theme, base, vendor, legacy, components, utilities;
+@import 'tailwindcss' theme(static);
+@import './shared/ui/theme/active.css';

--- a/packages/nene2-standards/tests/fixtures/styles/src/shared/ui/theme/themes/brand.css
+++ b/packages/nene2-standards/tests/fixtures/styles/src/shared/ui/theme/themes/brand.css
@@ -1,0 +1,12 @@
+/* @nene2-contract 1.0 @themegen 1.0.0 */
+@import './brand.components.css' layer(components);
+
+@theme {
+  --color-accent: oklch(0.55 0.15 250);
+  --color-on-accent: oklch(0.99 0 0);
+  --color-accent-soft: color-mix(in oklch, var(--color-accent), transparent 85%);
+}
+
+[data-theme='dark'] {
+  --color-accent: oklch(0.75 0.13 250);
+}

--- a/packages/nene2-standards/tests/stylelint-config.test.ts
+++ b/packages/nene2-standards/tests/stylelint-config.test.ts
@@ -77,6 +77,28 @@ describe('.components 対（AM-9 全ルール @layer components 内）', () => {
   });
 });
 
+describe('canonical cascade header と @theme ブロック（#19 正例較正）', () => {
+  it('index.css の @layer 順序宣言文（legacy を含む）は manifest 制の対象外・違反 0', async () => {
+    expect(await lintFile('src/index.css')).toEqual([]);
+  });
+
+  it('ブランドテーマ（@theme 直値＋.components @import＋dark 上書き — TH-02/03・参照テーマ形）は違反 0', async () => {
+    expect(await lintFile('src/shared/ui/theme/themes/brand.css')).toEqual([]);
+  });
+
+  it('@theme ブロック内の通常プロパティは従来どおり検知する', async () => {
+    const { results } = await stylelint.lint({
+      code: '@theme {\n  --color-accent: oklch(0.5 0.1 250);\n  font-family: serif;\n}\n',
+      config,
+      codeFilename: path.join(fixtureDir, 'src/shared/ui/theme/themes/code-probe.css'),
+    });
+    const warnings = results[0]?.warnings ?? [];
+    expect(
+      warnings.some((w) => w.rule === 'nene2/themes-token-only' && w.text.includes('font-family')),
+    ).toBe(true);
+  });
+});
+
 describe('一般 CSS（テーマ外）', () => {
   it('故意 fail unlayered.css — 無レイヤ・!important・ID・hex・rgb()・[data-theme] 場所違反', async () => {
     const warnings = await lintFile('src/app/unlayered.css');


### PR DESCRIPTION
## 目的

W0.starter（NENE2 スターター準拠化）の素振りが `@hideyukimori/nene2-standards@1.0.0` で **規約が正とする形そのものを 5 エラーで落とす** false positive を 3 件検出した（#19）。配布 lint を規約決定（R1① 1-4・AM-8(a)・TH-02/03）と配布現物（nene2-tokens 参照テーマ）に較正する。

## 変更点

1. **`@/shared/ui/<component>` import の全滅を修正**（eslint）
   `no-restricted-imports` の patterns は gitignore 意味論で `'@/shared/ui'` が配下全部にマッチしていた。相対 `../../*` も禁止のため features/pages から shared/ui へ到達する合法経路が存在しなくなっていた（fsd.ts の docstring 自身の正例が error になる状態）。集約バレル禁止は paths（完全一致）＋ `@/shared/ui/index*` パターンで維持。
2. **canonical cascade header の `@layer` 順序宣言文を manifest 制の対象外に**（stylelint `nene2/layer-legacy-manifest-only`）
   AM-8(a) のヘッダ必須行（`@layer theme, base, vendor, legacy, components, utilities;`）はブロックなしの順序宣言であり legacy へのルール投入ではない。`@layer legacy { … }` ブロックは従来どおり。
3. **テーマファイルの `@theme` 直値ブロック（非 inline）と `.components` 対 `@import` 行を許可**（stylelint `nene2/themes-token-only`）
   TH-03「ブランドテーマでは `@theme` ブロック 1 個必須」・TH-02。**nene2-tokens 配布の `themes/reference.css` 自身が `@theme` を持ち validate:themes は PASS する**——配布物間矛盾の解消（AM-6 運営則の適用漏れを較正）。`@theme` 内の通常プロパティ・入れ子・`@theme inline` は従来どおり error。

## 検証結果（実測）

- `npm run check` 全緑（type-check / eslint / prettier / **vitest 194 tests** / check:cli / nene2-check / AM-2 gate）
- 追加プローブ: per-component import 正例（restricted 0 件）／canonical header fixture（違反 0）／参照テーマ形 brand.css（違反 0）／`@theme` 内通常プロパティの故意 fail（検知維持）
- NENE2 側の再現: 規約準拠スターターに 1.0.0 で eslint 3 error＋stylelint 2 error → 本修正の dist を当てると 0（素振りログは NENE2 W0.starter PR 群の本文参照）

## 残リスク・依存

- **publish（1.0.1）が W0.starter の CI 緑の前提**（マージ後に施主承認のうえ publish をお願いします）
- known-utility の entryPoint 既定 `src/index.css` は W0.starter が **`src/index.css` をエントリとして確定**（scan-coverage / depcruise 仕様と一致・変更不要）

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)