### PR TITLE
fix(standards): known-utility entryPoint を FSD 正準へ是正＋per-repo seam＋entry不在fail-loud (#21)

### DIFF
--- a/packages/nene2-standards/README.md
+++ b/packages/nene2-standards/README.md
@@ -12,7 +12,7 @@ export default [
   ...nene2.base,
   ...nene2.fsd,
   ...nene2.api,
-  ...nene2.styling,
+  ...nene2.stylingWith(),  // per-repo Tailwind entry の seam（既定 FSD 正準・下記）
   ...nene2.i18n,
   ...nene2.testing,
   // 公認差異は registries 登録済みの override のみ合成可（05 §8）
@@ -43,6 +43,21 @@ ESLint flat config は同一ルールの再指定が**後勝ちで全置換**に
 - **O-6 (MUST)**: 実効 severity は**ファイル単位**で legacy manifest から機械生成する（掲載= off・それ以外= error）。リポ単位の有効化は当該リポの語彙 codemod スタック直後の連続 PR。
 - つまり「配布値 warn」→「manifest 生成 override が error/off を上書き」が正規の姿。生成器（O-6 の severity 生成）と `check:tw-oracle` は W0a 後続（conformance / W1 配線)。**error/warn 運用の最終形は批准レビュー送り**（規約 README §8 未解消リスト）。
 - O-7: 偽陽性時のリポ側 `eslint-disable` MUST NOT（`eslint-comments/no-restricted-disable` で強制）。是正は 24h の standards patch レーン。
+
+## known-utility の entryPoint seam（fleet-tooling#21・payout#161 実弾テストで確定）
+
+`better-tailwindcss/no-unknown-classes` の `entryPoint` は「アプリ実 entry」（O-3 MUST）＝**アプリ固有**であり、単一ハードコード既定では表現できない。
+
+- **既定は FSD 正準のテーマ入口 `src/shared/ui/theme/index.css`**（init-scan の `CANONICAL_NON_LEGACY`・AM-8(a) canonical cascade header の置き場と一致）。payout など FSD 正準レイアウトの repo は `...nene2.stylingWith()` を無引数で撃てば正しく配線される。
+- **per-repo 上書き**は `stylingWith({ entryPoint })`。W0.starter レイアウト（`src/index.css`）等は `...nene2.stylingWith({ entryPoint: 'src/index.css' })`。
+- **entry 不在は fail-loud**（`stylingWith` が throw）。better-tailwindcss は entry 未発見時に既定 tailwind theme へ silent fallback し、テーマ固有ユーティリティ（`bg-surface`・`px-inline-md` 等）を全て unknown へ化けさせる（＝偽陽性洪水）。G-6（検査不能=unknown・空虚合格禁止）に従い、黙って通さず設定エラーとして即 FAIL させる。
+- **実測（payout#161・`eb5f7aa`）**: 配布既定 `'src/index.css'` では **218 件の偽陽性**（全件 entry-not-found・全テーマユーティリティが unknown）→ 実 entry `'src/shared/ui/theme/index.css'` 指定で **49 件の真陽性のみ**（entry-not-found 0）。回帰テスト `tests/styling-entrypoint.test.ts` が payout 形 fixture でこれを固定する。
+- 後方互換: `...nene2.styling`（静的配列）も残す（既定 entryPoint は同じく FSD 正準へ是正）。ただし fail-loud の存在検査は付かない（import 副作用ゼロのため）— 検査が要る配線は `stylingWith()` を使う。
+
+## 変更履歴
+
+- **1.0.1** — known-utility の `entryPoint` 既定を W0.starter 前提 `'src/index.css'` から FSD 正準 `'src/shared/ui/theme/index.css'` へ是正し、per-repo 上書き `stylingWith({ entryPoint })` seam＋entry 不在 fail-loud を追加（fleet-tooling#21・payout#161: shipped 218 偽陽性 → 実 entry で 49 真陽性）。
+- **1.0.0** — 初回公開。
 
 ## W0a 実装確定値（「実装が正本」化 — 05 §10.2 の確定送り分）
 

--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-standards",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-standards/src/configs/styling.ts
+++ b/packages/nene2-standards/src/configs/styling.ts
@@ -8,37 +8,126 @@
  *   ファイル単位で legacy manifest から機械生成（掲載=off・それ以外=error）— W1 配線。
  * - detectComponentClasses: true 明記（false 既定のままだとフリート数千件偽陽性 — AM-13）。
  * - severity の正本は check:tw-oracle（O-5: 食い違いは仕様・常に oracle が正）。
+ *
+ * entryPoint seam（fleet-tooling#21・payout#161 実弾テストで発覚）:
+ * - better-tailwindcss の entryPoint は「アプリ実 entry」（O-3 MUST）＝アプリ固有であり、単一
+ *   ハードコード既定では表現できない。既定は FSD 正準のテーマ入口 `src/shared/ui/theme/index.css`
+ *   （init-scan の CANONICAL_NON_LEGACY と一致・AM-8(a) canonical cascade header の置き場と共有）へ
+ *   寄せ、per-repo の上書きは `stylingWith({ entryPoint })` seam で受ける（配布断片の無改変合成という
+ *   規律＝製品側 raw rule 直書き MUST NOT と両立させるため）。
+ * - entry 不在は G-6（検査不能=unknown・空虚合格禁止）に従い fail-loud。黙って全テーマユーティリティを
+ *   unknown へ化けさせる（better-tailwindcss は entry 未発見時に既定 tailwind theme へ silent fallback
+ *   する — payout で 218 件偽陽性の実測）のではなく、設定エラーとして即 throw する。
  */
+import { existsSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+
 import betterTailwindcss from 'eslint-plugin-better-tailwindcss';
 import type { Linter } from 'eslint';
 
 import { nene2Plugin } from '../eslint-plugin/index.js';
 import { APP_GLOB } from './restrictions.js';
 
+/**
+ * FSD 正準のテーマ入口。`@import 'tailwindcss'`＋`@theme` はここ（`src/main.tsx` が import する
+ * canonical cascade header の置き場）。init-scan の CANONICAL_NON_LEGACY と同一パス。
+ */
+export const CANONICAL_THEME_ENTRY = 'src/shared/ui/theme/index.css';
+
+/** styling seam のオプション。`entryPoint` は per-repo の Tailwind 実 entry（O-3 MUST）。 */
+export interface StylingOptions {
+  /** アプリの Tailwind entry css（cwd 相対 or 絶対）。既定は FSD 正準 `src/shared/ui/theme/index.css`。 */
+  entryPoint?: string;
+  /** entry 存在検査の基準ディレクトリ。既定は `process.cwd()`（lint 実行 cwd＝frontend/）。 */
+  cwd?: string;
+}
+
+/**
+ * nene2.styling の per-repo entryPoint seam（fleet-tooling#21）。
+ *
+ * `stylingWith({ entryPoint })` で製品の実 entry を受け取り、known-utility fast path の
+ * `better-tailwindcss/no-unknown-classes` に配線する。entry が存在しなければ **fail-loud**（throw）。
+ *
+ * これは未決の妥協ではなく G-6 の適用: better-tailwindcss は entry 未発見時に既定 tailwind theme へ
+ * silent fallback し、テーマ固有ユーティリティ（`bg-surface`・`px-inline-md` 等）を全て unknown へ
+ * 化けさせる（＝偽陽性洪水・payout#161 で 218 件実測）。検査不能を黙って通さず、設定エラーとして
+ * 1 回明示 FAIL させる。
+ */
+export function stylingWith(options: StylingOptions = {}): Linter.Config[] {
+  const entryPoint = options.entryPoint ?? CANONICAL_THEME_ENTRY;
+  const cwd = options.cwd ?? process.cwd();
+  const resolved = isAbsolute(entryPoint) ? entryPoint : resolve(cwd, entryPoint);
+
+  if (!existsSync(resolved)) {
+    throw new Error(
+      `[nene2/styling] Tailwind entry point not found: ${resolved}\n` +
+        `  configured entryPoint: ${JSON.stringify(entryPoint)} (cwd: ${cwd})\n` +
+        `  known-utility fast path (better-tailwindcss/no-unknown-classes) requires the app's real\n` +
+        `  Tailwind entry (O-3 MUST). Without it every theme utility (bg-surface, px-inline-md, …)\n` +
+        `  is silently treated as unknown — 218 false positives in payout#161.\n` +
+        `  Fix: pass this repo's entry via nene2.stylingWith({ entryPoint: '<path>' }).\n` +
+        `  FSD canonical default is '${CANONICAL_THEME_ENTRY}'; the W0.starter layout is 'src/index.css'.\n` +
+        `  This is a fail-loud config error (G-6: 検査不能=unknown・空虚合格禁止), not a lint warning.`,
+    );
+  }
+
+  return [
+    {
+      name: 'nene2/styling/known-utility',
+      files: [APP_GLOB],
+      plugins: { 'better-tailwindcss': betterTailwindcss as never },
+      rules: {
+        // W0a 確定値: rule-id = better-tailwindcss/no-unknown-classes（v4.6.1 実在確認済み）。
+        // entryPoint 既定は FSD 正準 src/shared/ui/theme/index.css（fleet-tooling#21・05 §10.2 の
+        // W0.starter 前提を fleet 正準へ是正）。per-repo 上書きは本 seam の引数で。
+        'better-tailwindcss/no-unknown-classes': [
+          'warn',
+          { detectComponentClasses: true, entryPoint },
+        ],
+      },
+    },
+    {
+      // inline style 禁止・唯一の例外は CSS 変数注入（会議R1⑤・R5 AM-8(f)決定）。
+      // W0a 確定値: react/forbid-dom-props では例外判定（キー全 '--' 始まり・値リテラル色禁止・
+      // 非リテラル値は注入器台帳照合）を表現できないため custom rule に一本化（05 §2.2.4 補足の
+      // 実装確定事項 — forbid-dom-props との併用は唯一の許可形を自分で誤検知するため置かない）。
+      name: 'nene2/styling/style-prop',
+      files: [APP_GLOB],
+      plugins: { nene2: nene2Plugin as never },
+      rules: {
+        // injectorFiles は registries の injector エントリから機械生成（W1 配線・正本は台帳 — G-7）
+        'nene2/style-prop-css-vars-only': ['error', { injectorFiles: [] }],
+      },
+    },
+  ];
+}
+
+/**
+ * 後方互換の静的合成形（`...nene2.styling`）。既定 entryPoint は FSD 正準
+ * `src/shared/ui/theme/index.css`。
+ *
+ * NOTE: fail-loud の存在検査は **import 時に throw させない**ため本静的配列には掛けていない
+ * （config モジュール import は副作用ゼロが安全 — 別 export だけ欲しいツール・非正準レイアウト repo を
+ * 巻き込まない）。per-repo entry の指定と entry 不在 fail-loud を得るには `stylingWith({ entryPoint })`
+ * を使う（コピペ正本は `...nene2.stylingWith()` — README 参照）。
+ */
 export const styling: Linter.Config[] = [
   {
     name: 'nene2/styling/known-utility',
     files: [APP_GLOB],
     plugins: { 'better-tailwindcss': betterTailwindcss as never },
     rules: {
-      // W0a 確定値: rule-id = better-tailwindcss/no-unknown-classes（v4.6.1 実在確認済み）。
-      // entryPoint 既定 src/index.css は W0.starter のスターター同梱現物で最終確定（05 §10.2）。
       'better-tailwindcss/no-unknown-classes': [
         'warn',
-        { detectComponentClasses: true, entryPoint: 'src/index.css' },
+        { detectComponentClasses: true, entryPoint: CANONICAL_THEME_ENTRY },
       ],
     },
   },
   {
-    // inline style 禁止・唯一の例外は CSS 変数注入（会議R1⑤・R5 AM-8(f)決定）。
-    // W0a 確定値: react/forbid-dom-props では例外判定（キー全 '--' 始まり・値リテラル色禁止・
-    // 非リテラル値は注入器台帳照合）を表現できないため custom rule に一本化（05 §2.2.4 補足の
-    // 実装確定事項 — forbid-dom-props との併用は唯一の許可形を自分で誤検知するため置かない）。
     name: 'nene2/styling/style-prop',
     files: [APP_GLOB],
     plugins: { nene2: nene2Plugin as never },
     rules: {
-      // injectorFiles は registries の injector エントリから機械生成（W1 配線・正本は台帳 — G-7）
       'nene2/style-prop-css-vars-only': ['error', { injectorFiles: [] }],
     },
   },

--- a/packages/nene2-standards/src/index.ts
+++ b/packages/nene2-standards/src/index.ts
@@ -7,7 +7,7 @@
  * import nene2 from '@hideyukimori/nene2-standards';
  * export default [
  *   ...nene2.base, ...nene2.fsd, ...nene2.api,
- *   ...nene2.styling, ...nene2.i18n, ...nene2.testing,
+ *   ...nene2.stylingWith(), ...nene2.i18n, ...nene2.testing,
  * ];
  * ```
  */
@@ -18,10 +18,12 @@ import { base } from './configs/base.js';
 import { fsd } from './configs/fsd.js';
 import { i18n } from './configs/i18n.js';
 import { overrides } from './configs/overrides.js';
-import { styling } from './configs/styling.js';
+import { styling, stylingWith, CANONICAL_THEME_ENTRY } from './configs/styling.js';
+import type { StylingOptions } from './configs/styling.js';
 import { testing } from './configs/testing.js';
 
-export { api, base, fsd, i18n, overrides, styling, testing };
+export { api, base, fsd, i18n, overrides, styling, stylingWith, CANONICAL_THEME_ENTRY, testing };
+export type { StylingOptions };
 export { nene2Plugin } from './eslint-plugin/index.js';
 export {
   API_FETCH_SYNTAX,
@@ -52,7 +54,7 @@ export function composedConfig(): Linter.Config[] {
   return [...base, ...fsd, ...api, ...styling, ...i18n, ...testing];
 }
 
-const nene2 = { base, fsd, api, styling, i18n, testing, overrides };
+const nene2 = { base, fsd, api, styling, stylingWith, i18n, testing, overrides };
 export default nene2;
 
 export {

--- a/packages/nene2-standards/tests/fixtures/probe-app/src/shared/ui/theme/index.css
+++ b/packages/nene2-standards/tests/fixtures/probe-app/src/shared/ui/theme/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/packages/nene2-standards/tests/fixtures/styling-entry/jsx-shim.d.ts
+++ b/packages/nene2-standards/tests/fixtures/styling-entry/jsx-shim.d.ts
@@ -1,0 +1,6 @@
+// probe fixture: React 型なしで JSX を書くための最小 shim
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: Record<string, unknown>;
+  }
+}

--- a/packages/nene2-standards/tests/fixtures/styling-entry/src/features/panel/dead.tsx
+++ b/packages/nene2-standards/tests/fixtures/styling-entry/src/features/panel/dead.tsx
@@ -1,0 +1,5 @@
+// A genuinely dead class: not emitted by any theme. The known-utility detector must flag it
+// even when the canonical entry is loaded (proves detection is live, not silenced).
+export function Dead() {
+  return <div className="zzz-not-a-real-class-xyz">dead</div>;
+}

--- a/packages/nene2-standards/tests/fixtures/styling-entry/src/features/panel/panel.tsx
+++ b/packages/nene2-standards/tests/fixtures/styling-entry/src/features/panel/panel.tsx
@@ -1,0 +1,11 @@
+// payout-shape: every class here is a legit theme utility emitted by the FSD canonical
+// entry (src/shared/ui/theme/index.css). With the shipped default entryPoint 'src/index.css'
+// these all became "unknown" false positives (payout#161: 218 件). With the canonical entry
+// they are recognised — 0 false positives.
+export function Panel() {
+  return (
+    <div className="bg-surface border-border px-inline-md py-stack-sm gap-inline-sm">
+      panel
+    </div>
+  );
+}

--- a/packages/nene2-standards/tests/fixtures/styling-entry/src/index.css
+++ b/packages/nene2-standards/tests/fixtures/styling-entry/src/index.css
@@ -1,0 +1,1 @@
+@import 'tailwindcss';

--- a/packages/nene2-standards/tests/fixtures/styling-entry/src/shared/ui/theme/index.css
+++ b/packages/nene2-standards/tests/fixtures/styling-entry/src/shared/ui/theme/index.css
@@ -1,0 +1,9 @@
+@import 'tailwindcss';
+
+@theme {
+  --color-surface: #ffffff;
+  --color-border: #e5e7eb;
+  --spacing-inline-md: 1rem;
+  --spacing-stack-sm: 0.5rem;
+  --spacing-inline-sm: 0.5rem;
+}

--- a/packages/nene2-standards/tests/fixtures/styling-entry/tsconfig.json
+++ b/packages/nene2-standards/tests/fixtures/styling-entry/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": { "@/*": ["./src/*"] },
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src"]
+}

--- a/packages/nene2-standards/tests/styling-entrypoint.test.ts
+++ b/packages/nene2-standards/tests/styling-entrypoint.test.ts
@@ -1,0 +1,115 @@
+/**
+ * nene2.styling entryPoint seam の回帰テスト（fleet-tooling#21・payout#161 実弾テスト由来）。
+ *
+ * 検証:
+ * 1. 既定パス解決 — stylingWith() は FSD 正準 `src/shared/ui/theme/index.css` を配線する。
+ * 2. 上書き seam — stylingWith({ entryPoint }) は per-repo entry を配線する。
+ * 3. fail-loud — entry 不在時は throw する（G-6: 検査不能=unknown・空虚合格禁止。better-tailwindcss の
+ *    entry 未発見 silent fallback＝偽陽性洪水を黙って通さない）。
+ * 4. payout 形 fixture 回帰 — 正準 entry では合法テーマユーティリティが偽陽性化しない（218 が起きない）・
+ *    誤 entry では偽陽性化する（配布既定 'src/index.css' が FSD レイアウトで壊れる実証）。
+ * 5. 故意 fail — 正準 entry でも真に存在しないクラスは検出される（検出は live）。
+ */
+import { fileURLToPath } from 'node:url';
+
+import { ESLint, type Linter } from 'eslint';
+import tseslint from 'typescript-eslint';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { stylingWith, styling, CANONICAL_THEME_ENTRY } from '../src/index.js';
+
+const fixtureDir = fileURLToPath(new URL('./fixtures/styling-entry/', import.meta.url));
+
+const UNKNOWN_RULE = 'better-tailwindcss/no-unknown-classes';
+
+/** parser（typescript-eslint）＋ styling 断片のみで lint し、known-utility の message を返す。 */
+async function lintWith(entryPoint: string): Promise<Linter.LintMessage[]> {
+  const config: Linter.Config[] = [
+    {
+      files: ['**/*.tsx'],
+      languageOptions: {
+        parser: tseslint.parser as never,
+        parserOptions: { ecmaFeatures: { jsx: true } },
+      },
+    },
+    ...stylingWith({ entryPoint, cwd: fixtureDir }),
+  ];
+  const eslint = new ESLint({ cwd: fixtureDir, overrideConfigFile: true, overrideConfig: config });
+  const results = await eslint.lintFiles(['src/**/*.tsx']);
+  return results.flatMap((r) => r.messages).filter((m) => m.ruleId === UNKNOWN_RULE);
+}
+
+function unknownClasses(msgs: Linter.LintMessage[]): string[] {
+  return msgs
+    .map((m) => /Unknown class detected: (.+)$/m.exec(m.message)?.[1])
+    .filter((c): c is string => Boolean(c));
+}
+
+describe('nene2.styling — entryPoint 既定と seam（fleet-tooling#21）', () => {
+  it('stylingWith() の既定 entryPoint は FSD 正準 src/shared/ui/theme/index.css', () => {
+    const config = stylingWith({ cwd: fixtureDir });
+    const known = config.find((c) => c.name === 'nene2/styling/known-utility');
+    const rule = known?.rules?.[UNKNOWN_RULE] as [string, { entryPoint: string }];
+    expect(rule[1].entryPoint).toBe('src/shared/ui/theme/index.css');
+    expect(CANONICAL_THEME_ENTRY).toBe('src/shared/ui/theme/index.css');
+  });
+
+  it('後方互換の静的 styling も既定 entryPoint は FSD 正準（src/index.css から是正）', () => {
+    const known = styling.find((c) => c.name === 'nene2/styling/known-utility');
+    const rule = known?.rules?.[UNKNOWN_RULE] as [string, { entryPoint: string }];
+    expect(rule[1].entryPoint).toBe(CANONICAL_THEME_ENTRY);
+  });
+
+  it('stylingWith({ entryPoint }) は per-repo entry を配線する（上書き seam）', () => {
+    const config = stylingWith({ entryPoint: 'src/index.css', cwd: fixtureDir });
+    const known = config.find((c) => c.name === 'nene2/styling/known-utility');
+    const rule = known?.rules?.[UNKNOWN_RULE] as [string, { entryPoint: string }];
+    expect(rule[1].entryPoint).toBe('src/index.css');
+  });
+
+  it('entry 不在時は fail-loud（throw）— silent fail-open しない（G-6）', () => {
+    expect(() => stylingWith({ entryPoint: 'src/does-not-exist.css', cwd: fixtureDir })).toThrow(
+      /Tailwind entry point not found/,
+    );
+  });
+
+  it('entry 存在時は throw しない', () => {
+    expect(() => stylingWith({ entryPoint: CANONICAL_THEME_ENTRY, cwd: fixtureDir })).not.toThrow();
+  });
+});
+
+describe('payout 形 fixture 回帰 — 218 偽陽性が起きないこと（fleet-tooling#21）', () => {
+  let canonical: Linter.LintMessage[];
+  let shippedDefault: Linter.LintMessage[];
+
+  beforeAll(async () => {
+    canonical = await lintWith(CANONICAL_THEME_ENTRY);
+    // 配布既定 'src/index.css'（W0.starter レイアウト）— FSD 形 repo では bare entry で theme 未ロード
+    shippedDefault = await lintWith('src/index.css');
+  }, 120_000);
+
+  it('FSD 正準 entry では合法テーマユーティリティが偽陽性化しない（bg-surface / px-inline-md 等）', () => {
+    const classes = unknownClasses(canonical);
+    for (const legit of [
+      'bg-surface',
+      'border-border',
+      'px-inline-md',
+      'py-stack-sm',
+      'gap-inline-sm',
+    ]) {
+      expect(classes, `${legit} は合法ユーティリティ — unknown にならない`).not.toContain(legit);
+    }
+  });
+
+  it('故意 fail — 真に存在しないクラス zzz-not-a-real-class-xyz は正準 entry でも検出される（検出は live）', () => {
+    expect(unknownClasses(canonical)).toContain('zzz-not-a-real-class-xyz');
+  });
+
+  it('配布既定 src/index.css（誤 entry）では同じ合法ユーティリティが偽陽性化する（payout#161 の 218 と同型）', () => {
+    const classes = unknownClasses(shippedDefault);
+    expect(classes).toContain('bg-surface');
+    expect(classes).toContain('px-inline-md');
+    // 誤 entry の偽陽性件数は正準 entry の真陽性件数より多い（洪水）。
+    expect(shippedDefault.length).toBeGreaterThan(canonical.length);
+  });
+});


### PR DESCRIPTION
Closes #21

## 論点（1PR=1論点・#19 には触れない）

known-utility 検出器（`better-tailwindcss/no-unknown-classes`）の配布既定 `entryPoint: 'src/index.css'`（W0.starter レイアウト前提）が **FSD 正準のテーマ入口 `src/shared/ui/theme/index.css`** と不一致で、FSD 形 repo でテーマが 1 つもロードされず**合法ユーティリティが全滅**する道具バグの是正。

## 根拠（payout#161 実弾テストの実測・`eb5f7aa`）

配布断片 `nene2.styling` を payout へ無改変合成した実測（プロジェクトパーサ固定・entryPoint のみ差替）:

| entryPoint | no-unknown-classes | 内訳 |
|---|---|---|
| `src/index.css`（配布既定） | **218**（全件 entry-not-found 偽陽性） | 全テーマユーティリティ（bg-surface / px-inline-md / …） |
| `src/shared/ui/theme/index.css`（payout 実 entry） | **49**（真の dead class のみ・entry-not-found 0） | text-body×34・text-primary×10・text-muted×3・text-heading×2 |

**検出器自体は正しく機能している** — 壊れていたのは entryPoint 既定だけ。加えて better-tailwindcss は entry 未発見時に既定 tailwind theme へ **silent fallback**（fail-open）する。

## 変更

1. **既定 entryPoint を FSD 正準 `src/shared/ui/theme/index.css` へ寄せた**（init-scan の `CANONICAL_NON_LEGACY`・AM-8(a) canonical cascade header の置き場と一致）。
2. **per-repo 上書き seam `stylingWith({ entryPoint, cwd })` を追加**。O-3(MUST)「入力はアプリ実 entry」＝ entryPoint はアプリ固有であり単一ハードコード既定では表現できない、を seam で受ける（配布断片の無改変合成という規律＝製品側 raw rule 直書き MUST NOT のまま両立）。コピペ正本は `...nene2.stylingWith()`（無引数＝FSD 正準）。W0.starter 等は `...nene2.stylingWith({ entryPoint: 'src/index.css' })`。
3. **entry 不在時は fail-loud（throw）**。黙って全ユーティリティを unknown 扱いにする silent fail-open ではなく、設定エラーとして即 FAIL させる（G-6「検査不能=unknown・空虚合格禁止」と同型の思想。lint 文脈での表現＝config 構築時に throw → eslint が config error として非ゼロ終了）。
4. 後方互換の静的 `...nene2.styling` も残す（既定は同じく FSD 正準へ是正・fail-loud 検査は import 副作用ゼロのため付けない — 検査が要る配線は `stylingWith()`）。
5. version **1.0.1** bump・README に「entryPoint seam」節＋変更履歴 1 行。

## テスト（実測）

新規 `packages/nene2-standards/tests/styling-entrypoint.test.ts`（8 本・全 pass）:

- 既定パス解決 — `stylingWith()` の entryPoint === `src/shared/ui/theme/index.css`。
- 上書き seam — `stylingWith({ entryPoint })` が per-repo entry を配線。
- **entry 不在 fail-loud** — `stylingWith({ entryPoint: 存在しない })` が throw（entry 存在時は throw しない）。
- **payout 形 fixture 回帰** — `tests/fixtures/styling-entry/`（payout と同じ FSD レイアウト・`@theme` で bg-surface / border-border / px-inline-md / py-stack-sm / gap-inline-sm を emit）で:
  - FSD 正準 entry では合法テーマユーティリティが**偽陽性化しない**（218 が起きない）。
  - 配布既定 `src/index.css`（誤 entry）では同じ合法ユーティリティが**偽陽性化する**（payout#161 の 218 と同型の再現）・件数が正準 entry より多い（洪水）。
- **故意 fail** — 正準 entry でも真に存在しない `zzz-not-a-real-class-xyz` は検出される（検出は live・discriminating）。

受け入れゲート（`npm run check`・全 pass）:
- `type-check`（tsc --build）: 緑
- `lint`（eslint .）: 緑
- `format:check`（prettier）: 緑
- `test`（vitest run）: **198 passed / 18 files**（新規 8 本含む）
- `check:cli` / `check:nene2-check`（conformance 出力・非 blocker）: 緑
- `check:am2-gate`（AM-2 release gate）: **PASS**（contract 1.0 凍結記録一致）

未実施の明記: 実プロダクト（payout frontend）での再配線・実 lint は本 PR では未実施（payout#161 側の update-branch で行う）。本 PR の 218→偽陽性ゼロは fleet-tooling 内の payout 形 fixture 実測。

## 消費フロー

**マージ + publish 1.0.1 後に payout#161 が update-branch で本修正を消費**する（payout は `...nene2.stylingWith()` 無引数＝FSD 正準 entry で 218 偽陽性 → 真の dead class のみへ収束）。#19 と同じ 1.0.1 publish に相乗り。

## スコープ外（触れていない）

#19（W0.starter 素振りの lint false positive 3 件）には触れていない（別論点）。base 基点・非スタック。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
