### PR TITLE
fix(tokens): codemod 写像表の被覆修正 — suite/origin 表・prefix-less・ink バグ・衝突検出・除外 namespace（#23 #24 #25）

### DIFF
--- a/packages/nene2-tokens/package.json
+++ b/packages/nene2-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-tokens",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NeNe Core Token Contract v1 — contract types, CONTRACT_TOKENS, validate:themes CLI, themegen, codemod mapping table v1, reference theme",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-tokens/src/__fixtures__/origin-dark.css
+++ b/packages/nene2-tokens/src/__fixtures__/origin-dark.css
@@ -1,0 +1,52 @@
+/*
+ * Dark theme — overrides the semantic color tokens when `data-theme="dark"` is set on a root
+ * element (the app sets it on <html>). Plain CSS custom-property overrides; every utility reads
+ * `var(--color-…)`, so the whole app re-skins with no component change. Non-color tokens (spacing,
+ * radius, fonts, …) are inherited from the light theme.
+ */
+[data-theme='dark'] {
+  color-scheme: dark;
+
+  --color-surface: #1d1a16;
+  --color-surface-raised: #262119;
+  --color-surface-sunken: #141210;
+  --color-primary: #f0eadf;
+  --color-muted: #a89d8c;
+  --color-border: #332d24;
+  --color-border-strong: #463f33;
+
+  --color-accent: #d57a4d;
+  --color-accent-hover: #e08a5e;
+  --color-accent-soft: #3a271c;
+  --color-accent-ink: #eaa583;
+  --color-accent-contrast: #1a1510;
+
+  --color-danger: #e3697a;
+  --color-danger-soft: #36201f;
+  --color-danger-ink: #f0a6ad;
+  --color-success: #4faf7c;
+  --color-success-soft: #16271d;
+  --color-success-ink: #92d4ae;
+  --color-warning: #d8a23e;
+  --color-warning-soft: #2c2413;
+  --color-warning-ink: #edca84;
+  --color-info: #6f9fe0;
+  --color-info-soft: #19233a;
+  --color-info-ink: #a8c5ef;
+  --color-neutral-soft: #2a251d;
+  --color-neutral-ink: #b4a895;
+
+  --color-focus-ring: rgba(
+    213,
+    122,
+    77,
+    0.85
+  ); /* ≥3:1 non-text contrast on the dark surfaces (#178) */
+  --color-accent-glow: rgba(
+    213,
+    122,
+    77,
+    0.4
+  ); /* decorative accent shadow (toast) — NOT the focus ring */
+  --color-overlay: rgba(0, 0, 0, 0.6); /* modal scrim */
+}

--- a/packages/nene2-tokens/src/__fixtures__/origin-default.css
+++ b/packages/nene2-tokens/src/__fixtures__/origin-default.css
@@ -1,0 +1,128 @@
+/*
+ * Default theme (light) — the complete token set. Clay/terracotta accent + warm neutrals, serif
+ * headings. Swapping the active theme (see ../active.css) or toggling data-theme="dark"
+ * (see ./dark.css) restyles the whole app without touching a component. Semantic names only.
+ */
+@theme {
+  /* Color — surfaces / text / borders */
+  --color-surface: #ffffff;
+  --color-surface-raised: #f6f3ef;
+  --color-surface-sunken: #efeae2;
+  --color-primary: #1b1916;
+  --color-muted: #6c6358;
+  --color-border: #e6e0d6;
+  --color-border-strong: #d7d0c3;
+
+  /* Accent (clay / terracotta) — primary actions, links, focus, active nav */
+  --color-accent: #b3542d;
+  --color-accent-hover: #9c4824;
+  --color-accent-soft: #f5e7df;
+  --color-accent-ink: #8f4322;
+  --color-accent-contrast: #ffffff;
+
+  /* Status — each tone is base / soft (面) / ink (文字) */
+  --color-danger: #c12a3e;
+  --color-danger-soft: #f8e1e4;
+  --color-danger-ink: #a31f30;
+  --color-success: #2f7d57;
+  --color-success-soft: #e3f1e8;
+  --color-success-ink: #246046;
+  --color-warning: #b07d12;
+  --color-warning-soft: #f6ecd6;
+  --color-warning-ink: #8a610c;
+  --color-info: #3563b0;
+  --color-info-soft: #e6edf7;
+  --color-info-ink: #2b4f8c;
+  --color-neutral-soft: #ece7de;
+  --color-neutral-ink: #5d564b;
+
+  --color-focus-ring: rgba(
+    179,
+    84,
+    45,
+    0.8
+  ); /* ≥3:1 non-text contrast on the cream surfaces (#178) */
+  --color-accent-glow: rgba(
+    179,
+    84,
+    45,
+    0.34
+  ); /* decorative accent shadow (toast) — NOT the focus ring */
+  --color-overlay: rgba(15, 10, 8, 0.5); /* modal scrim */
+
+  /* Spacing (inline = horizontal rhythm, stack = vertical rhythm) */
+  --spacing-inline-xs: 0.25rem;
+  --spacing-inline-sm: 0.5rem;
+  --spacing-inline-md: 0.75rem;
+  --spacing-inline-lg: 1rem;
+  --spacing-inline-xl: 1.5rem;
+  --spacing-stack-xs: 0.25rem;
+  --spacing-stack-sm: 0.5rem;
+  --spacing-stack-md: 1rem;
+  --spacing-stack-lg: 1.5rem;
+  --spacing-stack-xl: 2.5rem;
+
+  /* Typography — head=serif (見出し/指標数値), sans=本文/UI, mono=ID/hash/JST */
+  --font-head: 'Newsreader', 'Noto Serif JP', Georgia, serif;
+  --font-sans: 'Inter', 'Noto Sans JP', system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', monospace;
+  --text-body: 0.9375rem;
+  --text-body--line-height: 1.5;
+  --text-caption: 0.8125rem;
+  --text-2xs: 0.6875rem; /* 11px — micro labels (xs/sm/base/lg/4xl come from Tailwind defaults) */
+  --text-heading-sm: 1.25rem;
+  --text-heading-md: 1.5rem;
+  --text-heading-lg: 1.85rem;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Letter-spacing — uppercase labels (wide…widest) + heading micro-tightening (tight) */
+  --tracking-tight: -0.015em;
+  --tracking-wide: 0.07em;
+  --tracking-wider: 0.14em;
+  --tracking-widest: 0.22em;
+
+  /* Radius */
+  --radius-sm: 0.4375rem; /* 7px — chips */
+  --radius-md: 0.5625rem; /* 9px — button / input */
+  --radius-lg: 0.9375rem; /* 15px — card */
+  --radius-xl: 1rem; /* 16px — modal */
+  --radius-full: 9999px;
+
+  /* Shadow */
+  --shadow-sm: 0 1px 2px rgba(20, 16, 12, 0.04);
+  --shadow-md: 0 9px 26px rgba(20, 16, 12, 0.09);
+  --shadow-focus: 0 0 0 3px var(--color-focus-ring);
+  --shadow-lg: 0 14px 38px rgba(15, 10, 8, 0.22); /* popover / dropdown */
+  --shadow-xl: 0 24px 60px rgba(15, 10, 8, 0.3); /* modal */
+  --shadow-accent: 0 6px 18px var(--color-accent-glow); /* toast / accent pop */
+
+  /* Motion */
+  --ease-default: cubic-bezier(0.2, 0, 0.2, 1);
+
+  /* Z-index */
+  --z-dropdown: 1000;
+  --z-modal: 1100;
+  --z-toast: 1200;
+
+  /* Border width (tied to color-border) */
+  --border-width-default: 1px;
+  --border-width-emphasis: 2px;
+
+  /* Sizing — icon/control dimensions */
+  --spacing-icon-sm: 1rem;
+  --spacing-icon-md: 1.5rem;
+
+  /* Container widths */
+  --container-form: 27rem; /* 432px — login */
+  --container-form-wide: 40rem; /* 640px — content forms */
+  --container-main: 66.25rem; /* 1060px — main region */
+
+  /* Responsive breakpoints — design spec. lg (64rem/1024px) is a Tailwind default.
+     Mobile-first naming: base = phone; narrow ≥430, tablet ≥680, rail ≥720, wide ≥820, lg ≥1024. */
+  --breakpoint-narrow: 26.875rem; /* 430px — metric grid drops to one column below */
+  --breakpoint-tablet: 42.5rem; /* 680px — content reflow (page header, tables, grids) below */
+  --breakpoint-rail: 45rem; /* 720px — sidebar is an off-canvas drawer below, icon rail at/above */
+  --breakpoint-wide: 51.25rem; /* 820px — two-column detail grids collapse below */
+}

--- a/packages/nene2-tokens/src/codemod-map.test.ts
+++ b/packages/nene2-tokens/src/codemod-map.test.ts
@@ -1,9 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { CODEMOD_MAP_V1, REMEDIATION_V1, mapTokenName } from './codemod-map.js';
+import {
+  CODEMOD_MAP_V1,
+  ORIGIN_TABLE,
+  REMEDIATION_V1,
+  SUITE_TABLE,
+  VAULT_TABLE,
+  classifyTokenName,
+  mapTokenName,
+  mapTokenSet,
+} from './codemod-map.js';
 
 describe('codemod mapping table v1 (versioned)', () => {
   it('is versioned (M-1: 使い捨てスクリプト化 MUST NOT)', () => {
-    expect(CODEMOD_MAP_V1.version).toBe('1.0.0');
+    expect(CODEMOD_MAP_V1.version).toBe('1.0.1');
     expect(CODEMOD_MAP_V1.contract).toBe('1.0');
   });
 
@@ -51,13 +62,262 @@ describe('codemod mapping table v1 (versioned)', () => {
 
   it('unknown color keys map to null (caller must reject — silent drop prohibited)', () => {
     expect(mapTokenName('--color-mystery-role')).toBeNull();
-    expect(mapTokenName('--breakpoint-lg')).toBeNull();
   });
 
   it('non-contract categories go to mechanical x- namespacing (AM-3 scope)', () => {
     expect(mapTokenName('--radius-md')).toBe('--radius-x-md');
     expect(mapTokenName('--font-sans')).toBe('--font-x-sans');
     expect(mapTokenName('--shadow-glow')).toBe('--shadow-x-glow');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* #24 point5 — classifyTokenName の型で contract/rename/passthrough/reject を区別 */
+/* ------------------------------------------------------------------ */
+
+describe('classifyTokenName (fatal null と pass-through を型で区別 — #24)', () => {
+  it('already-contract/extension token → kind:contract', () => {
+    expect(classifyTokenName('--color-surface')).toEqual({
+      kind: 'contract',
+      name: '--color-surface',
+    });
+    expect(classifyTokenName('--color-x-approved')).toEqual({
+      kind: 'contract',
+      name: '--color-x-approved',
+    });
+  });
+  it('renamed token → kind:rename', () => {
+    expect(classifyTokenName('--color-fg')).toEqual({
+      kind: 'rename',
+      name: '--color-text-primary',
+    });
+  });
+  it('excluded namespace → kind:passthrough (NOT reject — legit Tailwind @theme token)', () => {
+    expect(classifyTokenName('--breakpoint-lg')).toEqual({
+      kind: 'passthrough',
+      name: '--breakpoint-lg',
+    });
+    expect(classifyTokenName('--container-form')).toEqual({
+      kind: 'passthrough',
+      name: '--container-form',
+    });
+  });
+  it('unknown color token → kind:reject (fail-closed)', () => {
+    const r = classifyTokenName('--color-mystery-role');
+    expect(r.kind).toBe('reject');
+  });
+  it('mapTokenName: passthrough returns the name (non-null); only reject is null', () => {
+    // #24 point5 の挙動変更: 除外 namespace は fatal null ではなく pass-through
+    expect(mapTokenName('--breakpoint-lg')).toBe('--breakpoint-lg');
+    expect(mapTokenName('--container-main')).toBe('--container-main');
+    expect(mapTokenName('--color-mystery-role')).toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* #23 — SUITE_TABLE（prefix-less 全名写像・PR #381 実証済み）              */
+/* ------------------------------------------------------------------ */
+
+describe('#23 SUITE_TABLE (prefix-less vocabulary)', () => {
+  it('every SUITE_TABLE key maps to its recorded target and never NULL', () => {
+    for (const [bare, target] of Object.entries(SUITE_TABLE)) {
+      expect(mapTokenName(`--${bare}`, 'suite')).toBe(target);
+    }
+  });
+
+  it('single-segment prefix-less names no longer fall to NULL (#23 原因3)', () => {
+    // 旧: --bg / --r / --shadow は汎用 x- 送り正規表現でハイフン不一致 → NULL
+    expect(mapTokenName('--bg', 'suite')).toBe('--color-surface');
+    expect(mapTokenName('--r', 'suite')).toBe('--r-x-base');
+    expect(mapTokenName('--shadow', 'suite')).toBe('--shadow-md');
+    expect(mapTokenName('--fg-2', 'suite')).toBe('--color-text-muted');
+    expect(mapTokenName('--brand-strong', 'suite')).toBe('--color-x-brand-strong');
+  });
+
+  it('already-contract --shadow-lg is left untouched (not in SUITE_TABLE)', () => {
+    expect(mapTokenName('--shadow-lg', 'suite')).toBe('--shadow-lg');
+  });
+
+  it('mapping counts: 16 contract-rename + 27 x- extension = 43 mapped (44th name --shadow-lg is already contract, untouched)', () => {
+    const targets = Object.values(SUITE_TABLE);
+    const xSend = targets.filter((t) => /^--[a-z0-9]+-x-/.test(t));
+    const contract = targets.filter((t) => !/^--[a-z0-9]+-x-/.test(t));
+    expect(targets.length).toBe(43);
+    expect(xSend.length).toBe(27);
+    expect(contract.length).toBe(16);
+    // PR #381 の「契約名 rename 17」= 16 rename + 不変 --shadow-lg（既に契約名・非収載）
+    expect(mapTokenName('--shadow-lg', 'suite')).toBe('--shadow-lg');
+  });
+
+  it('the whole suite vocabulary maps with 0 NULL and 0 conflicts', () => {
+    const names = Object.keys(SUITE_TABLE).map((k) => `--${k}`);
+    const r = mapTokenSet(names, 'suite');
+    expect(r.rejected).toEqual([]);
+    expect(r.conflicts).toEqual([]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* #24 — ORIGIN_TABLE をフル現物列挙に拡張 + 衝突裁定 + breakpoint pass-through */
+/* ------------------------------------------------------------------ */
+
+describe('#24 ORIGIN_TABLE (full 現物 enumeration)', () => {
+  it('accent 衝突の裁定: contrast→on-accent / ink→x-accent-ink (別値・別座席)', () => {
+    expect(mapTokenName('--color-accent-contrast', 'origin')).toBe('--color-on-accent');
+    expect(mapTokenName('--color-accent-ink', 'origin')).toBe('--color-x-accent-ink');
+  });
+  it('warning 系: soft→warn-soft / ink→on-warn (契約語彙)', () => {
+    expect(mapTokenName('--color-warning', 'origin')).toBe('--color-warn');
+    expect(mapTokenName('--color-warning-soft', 'origin')).toBe('--color-warn-soft');
+    expect(mapTokenName('--color-warning-ink', 'origin')).toBe('--color-on-warn');
+  });
+  it('status ink (現物): danger/success/info → on-<role>', () => {
+    expect(mapTokenName('--color-danger-ink', 'origin')).toBe('--color-on-danger');
+    expect(mapTokenName('--color-success-ink', 'origin')).toBe('--color-on-success');
+    expect(mapTokenName('--color-info-ink', 'origin')).toBe('--color-on-info');
+  });
+  it('neutral (契約ロール外) → x- 送り (on-neutral は契約に無い)', () => {
+    expect(mapTokenName('--color-neutral-soft', 'origin')).toBe('--color-x-neutral-soft');
+    expect(mapTokenName('--color-neutral-ink', 'origin')).toBe('--color-x-neutral-ink');
+  });
+  it('overlay → scrim (契約) / accent-glow → x- (装飾)', () => {
+    expect(mapTokenName('--color-overlay', 'origin')).toBe('--color-scrim');
+    expect(mapTokenName('--color-accent-glow', 'origin')).toBe('--color-x-accent-glow');
+  });
+  it('breakpoint/container namespace → pass-through (NOT fatal null — #24 point4)', () => {
+    for (const n of [
+      '--breakpoint-narrow',
+      '--breakpoint-tablet',
+      '--breakpoint-rail',
+      '--breakpoint-wide',
+      '--container-form',
+      '--container-form-wide',
+      '--container-main',
+    ]) {
+      expect(classifyTokenName(n, 'origin').kind).toBe('passthrough');
+      expect(mapTokenName(n, 'origin')).toBe(n);
+    }
+  });
+
+  it('the real origin themes (default.css + dark.css) map with 0 NULL — faithful 実測', () => {
+    const names = new Set<string>();
+    for (const f of ['./__fixtures__/origin-default.css', './__fixtures__/origin-dark.css']) {
+      const src = readFileSync(fileURLToPath(new URL(f, import.meta.url)), 'utf8');
+      for (const m of src.matchAll(/^\s*(--[a-z][a-z0-9-]*)\s*:/gim)) names.add(m[1]!);
+    }
+    expect(names.size).toBeGreaterThan(40);
+    const nulls = [...names].filter((n) => mapTokenName(n, 'origin') === null);
+    expect(nulls).toEqual([]);
+  });
+
+  it('the real origin themes map with 0 conflicts (accent-ink disambiguation resolves it)', () => {
+    const names = new Set<string>();
+    for (const f of ['./__fixtures__/origin-default.css', './__fixtures__/origin-dark.css']) {
+      const src = readFileSync(fileURLToPath(new URL(f, import.meta.url)), 'utf8');
+      for (const m of src.matchAll(/^\s*(--[a-z][a-z0-9-]*)\s*:/gim)) names.add(m[1]!);
+    }
+    const r = mapTokenSet([...names], 'origin');
+    expect(r.rejected).toEqual([]);
+    expect(r.conflicts).toEqual([]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* #24 point2 — ink 規則バグ (warning-ink → on-warning) の回帰                */
+/* ------------------------------------------------------------------ */
+
+describe('#24 ink-rule bug (*-ink fires before warning→warn synonym)', () => {
+  it('warning-ink → on-warn (契約語彙) — NOT the contract-external on-warning', () => {
+    // COMMON 表経路（origin 表に無くても）でも正規化が ink 規則より先に効く
+    expect(mapTokenName('--color-warning-ink', 'common')).toBe('--color-on-warn');
+    expect(mapTokenName('--color-warning-ink')).not.toBe('--color-on-warning');
+  });
+  it('ok-ink → on-success (同義正規化 ok→success を ink より先に)', () => {
+    expect(mapTokenName('--color-ok-ink', 'common')).toBe('--color-on-success');
+  });
+  it('normal roles still use the plain ink rule', () => {
+    expect(mapTokenName('--color-danger-ink', 'common')).toBe('--color-on-danger');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* #25 — 個別表引きを契約短絡より先に評価する（vault surface→surface-raised）    */
+/* ------------------------------------------------------------------ */
+
+describe('#25 table lookup precedes the contract short-circuit', () => {
+  it('vault --color-surface → --color-surface-raised (NOT swallowed by contract short-circuit)', () => {
+    // vault の surface は pre-contract 名（カード面）で、契約名 --color-surface と綴り衝突する。
+    // 契約短絡が先だと --color-surface のまま素通り → bg→surface と潰し合う（#25）。
+    expect(mapTokenName('--color-surface', 'vault')).toBe('--color-surface-raised');
+    expect(VAULT_TABLE['surface']).toBe('surface-raised');
+  });
+  it('vault bg and surface no longer collide on --color-surface', () => {
+    // bg → --color-surface, surface → --color-surface-raised: 別座席
+    expect(mapTokenName('--color-bg', 'vault')).toBe('--color-surface');
+    expect(mapTokenName('--color-surface', 'vault')).toBe('--color-surface-raised');
+    const r = mapTokenSet(
+      Object.keys(VAULT_TABLE).map((k) => `--color-${k}`),
+      'vault',
+    );
+    expect(r.rejected).toEqual([]);
+    expect(r.conflicts).toEqual([]);
+  });
+  it('common table names that are also contract-spelled still short-circuit when not in table', () => {
+    // 表に無い契約名はそのまま（改名しない）
+    expect(mapTokenName('--color-surface', 'common')).toBe('--color-surface');
+    expect(mapTokenName('--color-warn', 'common')).toBe('--color-warn');
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* #24 point3 — 衝突検出の一般化（複数ソース→単一ターゲットは error 停止）        */
+/* ------------------------------------------------------------------ */
+
+describe('#24 mapTokenSet conflict detection (silent overwrite prohibited — G-6)', () => {
+  it('flags 2+ distinct sources landing on the same target', () => {
+    // accent-contrast と accent-ink を naive に両方 on-accent へ写像すると衝突する（origin 表以前の姿）。
+    // COMMON 経路: accent-contrast→on-accent、accent-ink→(ink 規則)→on-accent の2ソース。
+    const r = mapTokenSet(['--color-accent-contrast', '--color-accent-ink'], 'common');
+    expect(r.conflicts).toHaveLength(1);
+    expect(r.conflicts[0]!.target).toBe('--color-on-accent');
+    expect(r.conflicts[0]!.sources).toEqual(['--color-accent-contrast', '--color-accent-ink']);
+  });
+  it('origin table disambiguates the same pair → 0 conflicts', () => {
+    const r = mapTokenSet(['--color-accent-contrast', '--color-accent-ink'], 'origin');
+    expect(r.conflicts).toEqual([]);
+  });
+  it('rejects are reported, not thrown', () => {
+    const r = mapTokenSet(['--color-mystery-role', '--color-fg'], 'common');
+    expect(r.rejected.map((x) => x.from)).toEqual(['--color-mystery-role']);
+    expect(r.renames).toContainEqual({ from: '--color-fg', to: '--color-text-primary' });
+  });
+  it('passthrough (excluded namespace) is bucketed separately from renames/rejects', () => {
+    const r = mapTokenSet(['--breakpoint-lg', '--color-fg'], 'common');
+    expect(r.passthrough).toEqual(['--breakpoint-lg']);
+    expect(r.rejected).toEqual([]);
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* origin table full enumeration is present (regression on 現物列挙)          */
+/* ------------------------------------------------------------------ */
+
+describe('ORIGIN_TABLE completeness', () => {
+  it('carries the pre-contract origin color vocabulary (#24 追加分)', () => {
+    for (const k of [
+      'primary',
+      'muted',
+      'accent-contrast',
+      'accent-ink',
+      'accent-glow',
+      'warning-soft',
+      'warning-ink',
+      'neutral-soft',
+      'neutral-ink',
+      'overlay',
+    ]) {
+      expect(ORIGIN_TABLE[k]).toBeDefined();
+    }
   });
 });
 

--- a/packages/nene2-tokens/src/codemod-map.ts
+++ b/packages/nene2-tokens/src/codemod-map.ts
@@ -5,6 +5,9 @@
  * - 確定写像: 議事録 R2 ⑥(B)「codemod 写像表 v1」＋ AM-3 追記
  *   （accent-weak→accent-soft / brand-violet→x-brand-violet / danger-hover→x-danger-hover）。
  * - vault 個別表: AI-13（tokens 管轄で確定）— nene-vault themes/default.css の現物列挙から作成。
+ * - suite 個別表: #23（suite W1 stage1 実測）— nene-suite PR #381 の実証済み SUITE_MAP を正とする
+ *   （契約 17・x- 27・prefix-less 全名写像）。
+ * - origin 個別表: #24（origin W1 実測）— nene-origin themes/default.css+dark.css の現物全 --color- 列挙。
  * - 是正リスト: R2⑥(B) 第1波（payout dead 17・records text-text-secondary 16）＋
  *   R5 議題(3) 実弾成果（records silent no-op 群）＋ AI-18 必須収載（payout typography）。
  *
@@ -13,13 +16,40 @@
 
 import { EXCLUDED_NAMESPACES, isContractTokenName, isExtensionTokenName } from './contract.js';
 
-export const CODEMOD_MAP_VERSION = '1.0.0';
+export const CODEMOD_MAP_VERSION = '1.0.1';
 
-export type MappingTableId = 'common' | 'origin' | 'vault';
+export type MappingTableId = 'common' | 'origin' | 'vault' | 'suite';
+
+/**
+ * 写像の結果類型（#24 point5 — 「fatal null」と「pass-through」を型で区別する）。
+ * - `contract`    : 既に契約/拡張トークン — 不変（rewrite 不要）。
+ * - `rename`      : 旧語彙 → 契約/拡張ターゲットへ改名。
+ * - `passthrough` : 除外 namespace（--breakpoint-* ・ --container-*）。Tailwind の正規 @theme
+ *                   トークンとして宣言は正当 — 変換対象外・宣言はそのまま維持（fatal ではない）。
+ * - `reject`      : 未知の色トークン等 — fail-closed（silent drop 禁止・呼び出し側で error）。
+ *
+ * fail-closed の対象は「未知の色トークン」であって「既知の非対象 namespace」ではない（#24）。
+ */
+export type TokenMapping =
+  | { readonly kind: 'contract'; readonly name: string }
+  | { readonly kind: 'rename'; readonly name: string }
+  | { readonly kind: 'passthrough'; readonly name: string }
+  | { readonly kind: 'reject'; readonly reason: string };
+
+/**
+ * 同義ロール名の正規化（R2⑥(A) の synonym ban と同型）。
+ * ink 規則（`*-ink → on-*`）より **先に** 適用する — さもないと `warning-ink` が契約外の
+ * `on-warning` を吐く（#24 バグ #2: ink 規則が `warning→warn` より先に発火していた）。
+ */
+const ROLE_SYNONYMS: Readonly<Record<string, string>> = {
+  warning: 'warn',
+  ok: 'success',
+};
 
 /**
  * 共通表（records/payout 系 → 契約 v1）。キーは `--color-` を除いた部分。
- * 値が `x-` で始まるものは拡張トークン送り。
+ * 値が `x-` で始まるものは拡張トークン送り。individual 表（origin/vault）の
+ * フォールバック共通ベースでもある（TABLES[table][key] ?? COMMON_TABLE[key]）。
  */
 export const COMMON_TABLE: Readonly<Record<string, string>> = {
   // ⑥(B) 確定写像
@@ -49,15 +79,48 @@ export const COMMON_TABLE: Readonly<Record<string, string>> = {
   'sidebar-border': 'x-sidebar-border',
 };
 
-/** origin 個別表（議事録: primary・muted(origin) → text-primary・text-muted） */
+/**
+ * origin 個別表（#24 — nene-origin/frontend/src/shared/ui/theme/themes/default.css + dark.css の
+ * 現物 --color-* 全列挙）。契約名そのものの roles（surface / accent / danger / focus-ring 等）は
+ * ここに載せない — 表に無い名は契約短絡でそのまま通る。ここに載せるのは pre-contract 語彙のみ。
+ *
+ * 衝突裁定（AM-3「x- 送りは tokens の技術判断」の範囲 — AI-5 非掲載）:
+ *  - accent-contrast(#fff = accent 面上のテキスト) → on-accent（契約の「on-」ロール）
+ *  - accent-ink(#8f4322 = 別トーン・components で text-accent-ink×10 が別色として使用) → x-accent-ink
+ *    naive では両者とも on-accent に潰れ 19 usage が1色化する（#24 見た目退行）。ink を x- へ退避して衝突解消。
+ *  - neutral は契約ロール外 → on-neutral は契約に存在しない。ink 規則を使わず x- 送り。
+ */
 export const ORIGIN_TABLE: Readonly<Record<string, string>> = {
+  // 文字（origin は primary/muted を裸で使う）
   primary: 'text-primary',
   muted: 'text-muted',
+  // accent 系の余剰（現物）— 衝突裁定は上コメント参照
+  'accent-contrast': 'on-accent',
+  'accent-ink': 'x-accent-ink',
+  'accent-glow': 'x-accent-glow', // 装飾影(toast) — focus-ring ではない
+  // status ink（現物）: warning は warn へ正規化してから on- を付ける（#24 バグ #2 の明示回避）
+  'danger-ink': 'on-danger',
+  'success-ink': 'on-success',
+  'info-ink': 'on-info',
+  'warning-ink': 'on-warn',
+  // status soft（現物）: warn-soft は COMMON 未収載の契約語彙
+  warning: 'warn', // COMMON にもあるが現物列挙のため明示
+  'warning-soft': 'warn-soft',
+  // neutral（契約ロール外）→ x- 送り（on-neutral は契約に無い）
+  'neutral-soft': 'x-neutral-soft',
+  'neutral-ink': 'x-neutral-ink',
+  // 遮蔽（現物 overlay = modal scrim）→ 契約 scrim
+  overlay: 'scrim',
 };
 
 /**
  * vault 個別表（AI-13 — nene-vault/frontend/src/shared/ui/theme/themes/default.css の
  * 全 --color-* 現物 40 個の写像。凍結レビュー資料に「要確認」印付きで全行掲載）。
+ *
+ * 注意（#25）: `surface → surface-raised` のように **pre-contract 名が契約名と綴り衝突** する
+ * キーがある。mapTokenName は個別表引きを契約短絡より先に評価するため、vault の `--color-surface`
+ * は契約名として素通りせず正しく `--color-surface-raised` へ改名される（`--color-bg → --color-surface`
+ * との衝突を回避）。
  */
 export const VAULT_TABLE: Readonly<Record<string, string>> = {
   // 面（vault は bg=ページ地・surface=カード面）
@@ -110,39 +173,220 @@ export const VAULT_TABLE: Readonly<Record<string, string>> = {
   'rail-text': 'x-rail-text',
 };
 
-const TABLES: Record<MappingTableId, Readonly<Record<string, string>>> = {
+/**
+ * suite 個別表（#23 — nene-suite PR #381 `frontend/scripts/w1-stage1-token-rename.mjs` の
+ * SUITE_MAP を正とする実証済み写像）。**prefix-less 全名表**: 他表と違いキーは `--color-`/`--shadow-`
+ * を含まない裸名（`bg`/`fg-2`/`r`/`shadow`/`font-sans` …）で、**値は完全なターゲット名**（`--color-*`
+ * / `--shadow-*` / `--font-*` / `--r-*` とカテゴリを跨ぐ）。これにより suite の単一セグメント名
+ * （`--bg`/`--r` 等）が汎用 x- 送り正規表現で NULL に落ちる #23 原因3 を根本回避する。
+ *
+ * 内訳（PR #381 実測）: 契約名 rename 17（surface×4・border×2・text×3・accent 3・status 3・shadow 1
+ * ＋不変 --shadow-lg）／x- 送り 27（brand primitives 7・origin 1・dark sidebar 6・hero 5・
+ * logo-ring/dot 2・typography 3・radius 3）。値は不変（名前のみ・vault 前例と同型）。
+ */
+export const SUITE_TABLE: Readonly<Record<string, string>> = {
+  // ── surfaces (contract) ──
+  bg: '--color-surface',
+  surface: '--color-surface-raised',
+  'surface-2': '--color-surface-overlay',
+  'surface-3': '--color-surface-sunken',
+  // ── borders (contract) ──
+  border: '--color-border',
+  'border-2': '--color-border-strong',
+  // ── text (contract) ──
+  fg: '--color-text-primary',
+  'fg-2': '--color-text-muted',
+  'fg-3': '--color-text-faint',
+  // ── accent (contract — suite の意味的別名が契約座席になる) ──
+  accent: '--color-accent',
+  'accent-soft': '--color-accent-soft',
+  'on-brand': '--color-on-accent',
+  // ── brand primitives (x- 拡張; accent/*-soft はこれ由来) ──
+  brand: '--color-x-brand',
+  'brand-strong': '--color-x-brand-strong',
+  'brand-deep': '--color-x-brand-deep',
+  'brand-soft': '--color-x-brand-soft',
+  'brand-softer': '--color-x-brand-softer',
+  'side-brand': '--color-x-side-brand',
+  ink: '--color-x-ink',
+  // ── status (contract) ──
+  ok: '--color-success',
+  warn: '--color-warn',
+  danger: '--color-danger',
+  // ── product/domain color (x-) ──
+  origin: '--color-x-origin',
+  // ── dark sidebar chrome (x-) ──
+  'side-bg': '--color-x-side-bg',
+  'side-bg-2': '--color-x-side-bg-2',
+  'side-fg': '--color-x-side-fg',
+  'side-fg-mut': '--color-x-side-fg-mut',
+  'side-active': '--color-x-side-active',
+  'side-line': '--color-x-side-line',
+  // ── marketing hero gradient (x-) ──
+  'hero-1': '--color-x-hero-1',
+  'hero-2': '--color-x-hero-2',
+  'hero-3': '--color-x-hero-3',
+  'hero-accent': '--color-x-hero-accent',
+  'hero-bd': '--color-x-hero-bd',
+  // ── misc color (x-) ──
+  'logo-ring': '--color-x-logo-ring',
+  dot: '--color-x-dot',
+  // ── shadow (contract) ──
+  // NOTE: `--shadow-lg` は既に契約名（SHADOW_KEYS に lg）— 意図的に非収載・不変。
+  shadow: '--shadow-md',
+  // ── typography (v1 スコープ外 → x-) ──
+  'font-sans': '--font-x-sans',
+  'font-num': '--font-x-num',
+  'font-serif': '--font-x-serif',
+  // ── radius (v1 スコープ外 → x-) ──
+  r: '--r-x-base',
+  'r-sm': '--r-x-sm',
+  'r-pill': '--r-x-pill',
+};
+
+/** `--color-` 接尾辞で引く個別表（common 共通ベース付き）。 */
+const COLOR_SUFFIX_TABLES: Record<
+  'common' | 'origin' | 'vault',
+  Readonly<Record<string, string>>
+> = {
   common: COMMON_TABLE,
   origin: ORIGIN_TABLE,
   vault: VAULT_TABLE,
 };
 
-/**
- * CSS カスタムプロパティ名の写像。
- * 順序: 契約/拡張トークンはそのまま → 除外名前空間は null → 個別表 → common →
- * 汎用 `*-ink → on-*`（⑥(B)） → 非 color/shadow カテゴリの機械的 x- 送り → null（未知 = reject）。
- */
-export function mapTokenName(name: string, table: MappingTableId = 'common'): string | null {
-  if (isContractTokenName(name) || isExtensionTokenName(name)) return name;
-  if (EXCLUDED_NAMESPACES.some((ns) => name.startsWith(ns))) return null;
+/** prefix-less 全名で引く個別表（suite — キーは裸名・値は完全なターゲット名）。 */
+const FULLNAME_TABLES: Partial<Record<MappingTableId, Readonly<Record<string, string>>>> = {
+  suite: SUITE_TABLE,
+};
 
+/**
+ * CSS カスタムプロパティ名の写像分類（#24 point5 — 型で contract/rename/passthrough/reject を区別）。
+ *
+ * 評価順（#25 是正 — 個別表引きを契約短絡より **先** に）:
+ *  1. 個別表（全名表 suite → `--color-` 接尾辞表）。pre-contract 名が契約名と綴り衝突しても改名を優先。
+ *  2. 表に無い契約/拡張トークン → そのまま（contract）。
+ *  3. 除外 namespace（--breakpoint-* ・ --container-*）→ passthrough（宣言は素通し・fatal ではない）。
+ *  4. 表に無い `--color-*` → 汎用 `*-ink → on-*`（同義正規化を先に）→ 未知は reject。
+ *  5. `--shadow-*`（契約4键以外）→ x- 送り。
+ *  6. 非契約カテゴリ（typography/radius/spacing 等）→ 機械的 x- 送り。
+ *  7. 単一セグメント等の未知名 → reject（fail-closed・写像を発明しない）。
+ */
+export function classifyTokenName(name: string, table: MappingTableId = 'common'): TokenMapping {
+  // 1a. prefix-less 全名表（suite）— #23 原因3 の根本回避（単一セグメント名の NULL 落ち防止）
+  const wholeTable = FULLNAME_TABLES[table];
+  if (wholeTable) {
+    const whole = wholeTable[name.slice(2)]; // 先頭 `--` を除いた裸名で引く
+    if (whole !== undefined) return { kind: 'rename', name: whole };
+  }
+  // 1b. `--color-` 接尾辞表（#25: 契約短絡より先 — vault surface→surface-raised 等の衝突回避）
   if (name.startsWith('--color-')) {
     const key = name.slice('--color-'.length);
-    const specific = TABLES[table][key] ?? COMMON_TABLE[key];
-    if (specific !== undefined) return `--color-${specific}`;
+    const t = (COLOR_SUFFIX_TABLES as Record<string, Readonly<Record<string, string>>>)[table];
+    const specific = (t ? t[key] : undefined) ?? COMMON_TABLE[key];
+    if (specific !== undefined) return { kind: 'rename', name: `--color-${specific}` };
+  }
+
+  // 2. 表に無い名で契約/拡張トークンなら不変（既に移行済み）
+  if (isContractTokenName(name) || isExtensionTokenName(name)) return { kind: 'contract', name };
+
+  // 3. 除外 namespace は pass-through（fatal null ではない — #24 point5）
+  if (EXCLUDED_NAMESPACES.some((ns) => name.startsWith(ns))) return { kind: 'passthrough', name };
+
+  // 4. 表に無い `--color-*` — 汎用 ink 規則 → reject
+  if (name.startsWith('--color-')) {
+    const key = name.slice('--color-'.length);
     const ink = /^(.+)-ink$/.exec(key);
-    if (ink) return `--color-on-${ink[1]}`;
-    return null; // 未知の color キー — silent drop 禁止・呼び出し側で error
+    if (ink) {
+      const base = ROLE_SYNONYMS[ink[1]!] ?? ink[1]!; // #24: warning→warn を ink より先に
+      return { kind: 'rename', name: `--color-on-${base}` };
+    }
+    return {
+      kind: 'reject',
+      reason: `unknown color token ${name} (table='${table}') — silent drop 禁止`,
+    };
   }
+  // 5. 契約 4 键以外の shadow は x- 送り（--shadow-glow → --shadow-x-glow）
   if (name.startsWith('--shadow-')) {
-    // 契約 4 キー以外の shadow は x- 送り（--shadow-glow → --shadow-x-glow）
-    const key = name.slice('--shadow-'.length);
-    return `--shadow-x-${key}`;
+    return { kind: 'rename', name: `--shadow-x-${name.slice('--shadow-'.length)}` };
   }
-  // 非契約カテゴリ（typography/radius/spacing 等）は v1 スコープ外 — 機械的 x- 送り
-  // （AM-3 scope 宣言「x- 拡張で書き v2 で契約化を再審」の写像実装 — tokens 技術判断）
+  // 6. 非契約カテゴリ（typography/radius/spacing 等）は v1 スコープ外 — 機械的 x- 送り
+  //    （AM-3 scope 宣言「x- 拡張で書き v2 で契約化を再審」の写像実装 — tokens 技術判断）
   const m = /^--([a-z][a-z0-9]*)-(.+)$/.exec(name);
-  if (m) return `--${m[1]}-x-${m[2]}`;
-  return null;
+  if (m) return { kind: 'rename', name: `--${m[1]}-x-${m[2]}` };
+
+  // 7. 単一セグメント等の未知名 — 発明せず reject
+  return {
+    kind: 'reject',
+    reason: `unknown token ${name} — single-segment name not in table '${table}'`,
+  };
+}
+
+/**
+ * CSS カスタムプロパティ名の写像（後方互換 API）。
+ * rename/contract/passthrough はターゲット名（passthrough は不変）、reject は null（呼び出し側で error）。
+ * 注意: null は「未知＝reject」のみ。除外 namespace の pass-through は非 null で名前を返す
+ * （fatal と pass-through の区別は classifyTokenName の kind で行う — #24 point5）。
+ */
+export function mapTokenName(name: string, table: MappingTableId = 'common'): string | null {
+  const r = classifyTokenName(name, table);
+  return r.kind === 'reject' ? null : r.name;
+}
+
+/* ------------------------------------------------------------------ */
+/* 衝突検出の一般化（#24 point3 — 複数ソース→単一ターゲットは driver で明示 error）  */
+/* ------------------------------------------------------------------ */
+
+export interface TokenSetConflict {
+  /** 2 ソース以上が集中したターゲット名 */
+  readonly target: string;
+  /** そのターゲットへ写る旧名（辞書順） */
+  readonly sources: readonly string[];
+}
+
+export interface TokenSetResult {
+  readonly renames: readonly { readonly from: string; readonly to: string }[];
+  readonly passthrough: readonly string[];
+  readonly rejected: readonly { readonly from: string; readonly reason: string }[];
+  /** 同一ターゲットに 2 ソース以上（silent 上書き＝G-6 違反）。空でなければ driver は停止すべき。 */
+  readonly conflicts: readonly TokenSetConflict[];
+}
+
+/**
+ * 名前集合を一括写像し、衝突（複数ソース→単一ターゲット）を検出する（#24 point3）。
+ * silent 上書き禁止（G-6 同型）。衝突を「通す」唯一の方法は個別表で明示 disambiguation する
+ * こと（例: origin の accent-contrast→on-accent と accent-ink→x-accent-ink）。本関数に許可
+ * リストは無い — 表で別ターゲットへ振り分けた時点で衝突は消える。
+ */
+export function mapTokenSet(
+  names: readonly string[],
+  table: MappingTableId = 'common',
+): TokenSetResult {
+  const renames: { from: string; to: string }[] = [];
+  const passthrough: string[] = [];
+  const rejected: { from: string; reason: string }[] = [];
+  const byTarget = new Map<string, Set<string>>(); // ターゲット名 → それを生む相異なる旧名
+  for (const name of names) {
+    const r = classifyTokenName(name, table);
+    if (r.kind === 'reject') {
+      rejected.push({ from: name, reason: r.reason });
+      continue;
+    }
+    if (r.kind === 'passthrough') {
+      passthrough.push(name);
+      continue;
+    }
+    if (r.kind === 'rename') renames.push({ from: name, to: r.name });
+    // contract / rename はターゲット座席を占有する — 衝突判定に載せる
+    const set = byTarget.get(r.name) ?? new Set<string>();
+    set.add(name);
+    byTarget.set(r.name, set);
+  }
+  const conflicts: TokenSetConflict[] = [];
+  for (const [target, sources] of byTarget) {
+    if (sources.size > 1) conflicts.push({ target, sources: [...sources].sort() });
+  }
+  conflicts.sort((a, b) => (a.target < b.target ? -1 : a.target > b.target ? 1 : 0));
+  return { renames, passthrough, rejected, conflicts };
 }
 
 /* ------------------------------------------------------------------ */
@@ -252,6 +496,12 @@ export const REMEDIATION_V1: readonly RemediationItem[] = [
 export const CODEMOD_MAP_V1 = {
   version: CODEMOD_MAP_VERSION,
   contract: '1.0',
-  tables: TABLES,
+  tables: {
+    common: COMMON_TABLE,
+    origin: ORIGIN_TABLE,
+    vault: VAULT_TABLE,
+    // suite は prefix-less 全名表（キー＝裸名・値＝完全ターゲット名）— 他表と引き方が異なる
+    suite: SUITE_TABLE,
+  },
   remediation: REMEDIATION_V1,
 } as const;

--- a/packages/nene2-tokens/src/index.ts
+++ b/packages/nene2-tokens/src/index.ts
@@ -47,10 +47,19 @@ export {
   COMMON_TABLE,
   ORIGIN_TABLE,
   VAULT_TABLE,
+  SUITE_TABLE,
   REMEDIATION_V1,
+  classifyTokenName,
   mapTokenName,
+  mapTokenSet,
 } from './codemod-map.js';
-export type { MappingTableId, RemediationItem } from './codemod-map.js';
+export type {
+  MappingTableId,
+  RemediationItem,
+  TokenMapping,
+  TokenSetConflict,
+  TokenSetResult,
+} from './codemod-map.js';
 
 export { FROZEN_CONTRACT_VERSION, checkContractFreeze } from './release-gate.js';
 export type { FreezeRecord, CurrentContract, GateOptions, GateResult } from './release-gate.js';

--- a/packages/nene2-tokens/src/themegen.ts
+++ b/packages/nene2-tokens/src/themegen.ts
@@ -9,6 +9,7 @@
 import {
   COLOR_KEYS,
   CONTRACT_VERSION,
+  EXCLUDED_NAMESPACES,
   SHADOW_KEYS,
   isContractTokenName,
   isExtensionTokenName,
@@ -16,9 +17,22 @@ import {
 import { parseTokenValue } from './grammar.js';
 import { parseThemeFile, isRootScopeSelector, type Block } from './parser.js';
 import { transitiveDependents } from './resolve.js';
-import { mapTokenName, type MappingTableId } from './codemod-map.js';
+import { classifyTokenName, type MappingTableId } from './codemod-map.js';
 
 export class ThemegenError extends Error {}
+
+/**
+ * @theme に出してよいキーか（契約・拡張トークン、または除外 namespace の pass-through 宣言）。
+ * 除外 namespace（--breakpoint-* ・ --container-*）は Tailwind の正規 @theme トークンとして宣言は
+ * 正当 — codemod は変換対象外としてそのまま維持する（#24 point4: fatal ではない）。
+ */
+function isAllowedThemeKey(name: string): boolean {
+  return (
+    isContractTokenName(name) ||
+    isExtensionTokenName(name) ||
+    EXCLUDED_NAMESPACES.some((ns) => name.startsWith(ns))
+  );
+}
 
 /** パッケージ版 — プラグマ `@themegen <ver>` に焼く（dx D4）。 */
 export const THEMEGEN_VERSION = '1.0.0';
@@ -130,9 +144,9 @@ function renderBlock(
 export function generateTheme(doc: ThemeDocument, opts: GenerateOptions = {}): string {
   const rootEntries = sortDecls(new Map(Object.entries(doc.theme)));
   for (const [name] of rootEntries) {
-    if (!isContractTokenName(name) && !isExtensionTokenName(name)) {
+    if (!isAllowedThemeKey(name)) {
       throw new ThemegenError(
-        `unknown key '${name}' — not contract v${CONTRACT_VERSION} and not an extension token; refusing to generate (silent drop is prohibited). Map it first: nene2-tokens extract --map <table>`,
+        `unknown key '${name}' — not contract v${CONTRACT_VERSION}, not an extension token, and not an excluded namespace; refusing to generate (silent drop is prohibited). Map it first: nene2-tokens extract --map <table>`,
       );
     }
   }
@@ -147,7 +161,7 @@ export function generateTheme(doc: ThemeDocument, opts: GenerateOptions = {}): s
   for (const selector of scopeSelectors) {
     const authoredRecord = doc.scopes![selector]!;
     for (const name of Object.keys(authoredRecord)) {
-      if (!isContractTokenName(name) && !isExtensionTokenName(name)) {
+      if (!isAllowedThemeKey(name)) {
         throw new ThemegenError(
           `unknown key '${name}' in scope '${selector}' — refusing to generate (silent drop is prohibited)`,
         );
@@ -184,12 +198,15 @@ export function extractTheme(source: string, opts: ExtractOptions = {}): ThemeDo
   const mapBlock = (block: Block): Record<string, string> => {
     const out: Record<string, string> = {};
     for (const d of block.decls) {
-      const mapped = mapTokenName(d.name, table);
-      if (mapped === null) {
+      const cls = classifyTokenName(d.name, table);
+      if (cls.kind === 'reject') {
         throw new ThemegenError(
           `unknown key '${d.name}' (line ${d.line}) — not contract v${CONTRACT_VERSION}, not an extension token, and not in codemod mapping table '${table}'; refusing to extract (silent drop is prohibited)`,
         );
       }
+      // rename/contract はターゲット名、passthrough（除外 namespace）は宣言をそのまま維持する
+      // （#24 point4: fatal null にしない — breakpoint を宣言するテーマでも codemod を走らせる）。
+      const mapped = cls.name;
       const value = mapValueRefs(d.value, table);
       // 語彙統一による直エイリアスの畳み込み: 写像後に `X: var(X)` の恒等形になった宣言は
       // 同義二重名（ok/success 等）の alias が消滅した痕跡 — 決定的に除去する
@@ -233,13 +250,19 @@ export function extractTheme(source: string, opts: ExtractOptions = {}): ThemeDo
 /** 値の中の var(--旧名) も写像する（写像は名前と参照の両方に適用） */
 function mapValueRefs(value: string, table: MappingTableId): string {
   return value.replace(/var\(\s*(--[a-zA-Z0-9-]+)\s*\)/g, (_whole, name: string) => {
-    const mapped = mapTokenName(name, table);
-    if (mapped === null) {
+    const cls = classifyTokenName(name, table);
+    if (cls.kind === 'reject') {
       throw new ThemegenError(
         `unknown key '${name}' referenced in value — refusing (silent drop is prohibited)`,
       );
     }
-    return `var(${mapped})`;
+    // 除外 namespace は宣言は素通しだが var() 参照は契約 error（#24 point4 の切り分け・Case D）。
+    if (cls.kind === 'passthrough') {
+      throw new ThemegenError(
+        `var(${name}) references the excluded --breakpoint-* ・ --container-* namespace — prohibited (emits invalid CSS with no error, Case D)`,
+      );
+    }
+    return `var(${cls.name})`;
   });
 }
 


### PR DESCRIPTION
## 要旨

W1 実弾テスト（suite / origin / vault）で露見した `@hideyukimori/nene2-tokens` codemod 写像表 v1 の被覆穴を **1 PR** で修正し、パッケージを **1.0.1** へ bump。**契約キー集合は不変**（color 28 + shadow 4）＝ AM-2 release gate 通過を実測確認。誠実性ガード: 写像判断はすべて実測（PR #381 の実証済み SUITE_MAP・origin 現物 CSS）に基づき、裁定の根拠は表コメントに記載。発明なし。

Closes #23, #24, #25

## #23 — suite 表欠落・prefix-less 語彙

- **`SUITE_TABLE` 同梱**: nene-suite PR #381 `w1-stage1-token-rename.mjs` の実証済み `SUITE_MAP` を正とする。**prefix-less 全名表**（キー＝裸名・値＝完全なターゲット名でカテゴリ跨ぎ）として実装。
- **prefix-less 名の正規化**: 個別表引きを最優先で評価することで、単一セグメント名（`--bg`/`--r`/`--shadow`）が汎用 x- 送り正規表現（ハイフン必須）で NULL に落ちる **原因3を根本回避**。
- 写像数: **契約 rename 16 + x- 送り 27 = 43**（44番目 `--shadow-lg` は既に契約名で不変・非収載）。

## #24 — origin 表不完全・衝突・ink バグ・breakpoint fail-closed

- **`ORIGIN_TABLE` を現物フル列挙へ拡張**（default.css + dark.css）: `accent-contrast→on-accent`, `warning-soft→warn-soft`, `warning-ink→on-warn`, `neutral-soft/ink→x-`, `accent-glow→x-`, `overlay→scrim` ほか。**実テーマ 82 トークン NULL 0・衝突 0** を実測。
- **衝突裁定**（AM-3「x- 送りは tokens の技術判断」の範囲・AI-5 非掲載 — 表コメントに根拠）:
  - `accent-contrast`（#fff = accent 面上のテキスト）→ **`on-accent`**
  - `accent-ink`（#8f4322 = 別トーン・components で `text-accent-ink`×10 が別色として使用）→ **`--color-x-accent-ink`**（x- 送り）
  - naive では両者が `on-accent` へ潰れ 19 usage が1色化する見た目退行を、x- 退避で解消。
- **ink 規則バグ #2 修正**: `warning-ink` が契約外 `on-warning` を生成していた（ink 規則が `warning→warn` より先に発火）。`ROLE_SYNONYMS`（warning→warn / ok→success）を ink 規則より**先に**適用。回帰テスト追加。
- **除外 namespace のドライバ挙動**: `--breakpoint-*` / `--container-*` を **fatal null でなく pass-through**（宣言はそのまま維持・変換対象外）へ。`classifyTokenName` が **contract / rename / passthrough / reject を型で区別**。driver（extract/generate）は宣言を素通しし、**var() 参照のみ contract-error**（Case D の切り分け）。

## #25 — 個別表引きを契約短絡より先に評価（コーディネータ追加指示）

- `mapTokenName` の `isContractTokenName` 短絡が VAULT_TABLE の `surface→surface-raised` を握り潰し、`bg→surface` と衝突する評価順バグを是正。**評価順: 表引き → 契約/拡張 → 除外 → 汎用**。pre-contract 名が契約名と綴り衝突しても改名を優先。
- vault 全名 **conflict 0** を実測・`surface→surface-raised` 回帰テスト追加。

## 衝突検出の一般化（#24 point3）

- **`mapTokenSet`**: 複数ソース→単一ターゲットを検出（silent 上書き禁止・G-6 同型）。許可リストは無く、**表で明示 disambiguation** した時のみ衝突が消える。故意衝突の検出テスト＋origin/suite/vault の 0 衝突テストを同梱。

## 実測（dist 通し）

| 対象 | 結果 |
|---|---|
| origin 実テーマ（82 uniq） | NULL 0 / renames 56 / passthrough 7（breakpoint×4 + container×3）/ rejected 0 / conflicts 0 |
| suite（43 mapped） | NULL 0 / x- 27 / contract 16 / conflicts 0 |
| vault | `--color-surface`→`--color-surface-raised`・`--color-bg`→`--color-surface`・conflicts 0 |
| #24 ink バグ | `--color-warning-ink`(common) → `--color-on-warn`（旧 on-warning） |

## テスト・ゲート

- `codemod-map.test.ts` **40 tests**（新規 ~30）。全体 **219 passed**（旧 190 非退行・+29）。
- `npm run check` **全緑（EXIT 0）**: type-check / lint / format:check / test / check:cli / check:nene2-check / **check:am2-gate PASS**（contract 1.0 color 28 + shadow 4 は凍結記録と一致）。

## スコープ外（コーディネータ指示）

- **#26**（単一ファイルテーマの extract/validate 非対応）は本 PR では触らない — **別対応（W0b 候補）**。

## 保留（発明しない・要施主/後続判断）

- validate.ts の Case D（`--breakpoint-*` 宣言＝error）は council 決定のため本 PR では**変更せず**。本 PR は codemod driver の pass-through 化に限定（issue #24 の切り分けに沿う）。validate 側の宣言許容が要るかは別途 council 判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)