### PR TITLE
feat(tokens): 語彙 codemod ランナー同梱（jscodeshift）— T-4 の実行物を配布物へ（#15）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -42,15 +41,552 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "devOptional": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.29.7.tgz",
+      "integrity": "sha512-ajMX6QPcyomotqwpzhkYGxcK2i/us0rs1Qo9QvUpa+Fca0FTmqrzKrctoIYLMxcOhGZldGT/BAVkRGTWBiR8gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-class-properties": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz",
+      "integrity": "sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.29.7.tgz",
+      "integrity": "sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-flow": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz",
+      "integrity": "sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz",
+      "integrity": "sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-private-methods": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz",
+      "integrity": "sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.29.7.tgz",
+      "integrity": "sha512-KYIRV0BuaN68CDdsqFkAD7MU7yipUqQNuNElwATdxaIdpTjhvtY82QvkBJs7zV3Evxj2jFAAZ1iO8nyy0nhjqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-transform-flow-strip-types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.29.7.tgz",
+      "integrity": "sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "@babel/plugin-syntax-jsx": "^7.29.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.29.7",
+        "@babel/plugin-transform-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.7.tgz",
+      "integrity": "sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -969,12 +1505,50 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
@@ -1434,6 +2008,17 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
+    },
+    "node_modules/@types/jscodeshift": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/@types/jscodeshift/-/jscodeshift-17.3.0.tgz",
+      "integrity": "sha512-ogvGG8VQQqAQQ096uRh+d6tBHrYuZjsumHirKtvBa5qEyTMN3IQJ7apo+sw9lxaB/iKWIhbbLlF3zmAWk9XQIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "recast": "^0.23.11"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2325,6 +2910,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2389,6 +2986,18 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.43",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
+      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
@@ -2403,7 +3012,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2411,6 +3019,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.6.tgz",
+      "integrity": "sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001803",
+        "electron-to-chromium": "^1.5.389",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -2502,6 +3149,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001805",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
+      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -2545,6 +3212,32 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clone-deep/node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2579,10 +3272,22 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -2813,6 +3518,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
+      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3064,6 +3775,15 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3378,6 +4098,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -3558,13 +4291,26 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/find-up": {
@@ -3601,6 +4347,27 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
+    },
+    "node_modules/flow-estree": {
+      "version": "0.322.0",
+      "resolved": "https://registry.npmjs.org/flow-estree/-/flow-estree-0.322.0.tgz",
+      "integrity": "sha512-v7wiiFWSKbJ1HGVCRKhxl+6pQWTQV6P4c7XEfKjVlH71YkgQyJCq0AG5dhJDD/3/SkJgX/F9lvAj2rbrFzArdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/flow-parser": {
+      "version": "0.322.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.322.0.tgz",
+      "integrity": "sha512-Qfd8N4sSuWmlf1qk5M60fi8JrvhNvj9fbwMsRkcnm3UhLYukkbm2CFkAhiTD3n4RVXb6TuCHFCp78TMXpO0zcA==",
+      "license": "MIT",
+      "dependencies": {
+        "flow-estree": "0.322.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3680,6 +4447,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4286,7 +5062,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4466,6 +5241,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -4502,6 +5286,58 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jscodeshift": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-17.3.0.tgz",
+      "integrity": "sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/plugin-transform-class-properties": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/preset-flow": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/register": "^7.24.6",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.7",
+        "neo-async": "^2.5.0",
+        "picocolors": "^1.0.1",
+        "recast": "^0.23.11",
+        "tmp": "^0.2.3",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/preset-env": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -4569,7 +5405,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4655,6 +5490,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4663,6 +5507,28 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4719,7 +5585,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4733,7 +5598,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4807,6 +5671,21 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4959,6 +5838,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5051,6 +5939,97 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5218,6 +6197,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/recast": {
+      "version": "0.23.12",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.12.tgz",
+      "integrity": "sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5479,6 +6474,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5583,7 +6590,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5620,6 +6626,15 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5627,6 +6642,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stable-hash-x": {
@@ -6042,6 +7067,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6102,11 +7133,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6160,8 +7199,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6345,6 +7383,36 @@
         "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
         "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -6678,7 +7746,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -6687,6 +7754,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -6768,10 +7841,16 @@
     },
     "packages/nene2-tokens": {
       "name": "@hideyukimori/nene2-tokens",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
+      "dependencies": {
+        "jscodeshift": "^17.3.0"
+      },
       "bin": {
         "nene2-tokens": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/jscodeshift": "^17.3.0"
       }
     }
   }

--- a/packages/nene2-tokens/README.md
+++ b/packages/nene2-tokens/README.md
@@ -15,7 +15,8 @@ publish は `release-gate` が拒否する）。
   WCAG AA コントラスト（ペア表 v1・focus 3:1）。fail-closed（検査不能=エラー終了）
 - `themegen` — 決定性 MUST（bit 同一・prettier 固定点）・`plain/unplain`（`@theme`↔`:root`）・
   `extract → map → generate` 順序固定（未知キー error reject）・`fill`（局所スコープのツール維持）
-- codemod 写像表 v1（common＋origin＋vault 個別表＋是正リスト — versioned）
+- codemod 写像表 v1（common＋origin＋vault＋suite 個別表＋是正リスト — versioned）
+- **語彙 codemod ランナー**（jscodeshift transform＋CLI — 規約 05 §6.6 T-4 MUST・#15）
 - 参照テーマ `themes/reference.css`・active.css 機構サンプル `samples/active.css`
 
 ## CLI
@@ -24,12 +25,56 @@ publish は `release-gate` が拒否する）。
 nene2-tokens validate [--container] [--container-selector <sel>] [--parent <brand.css>] <files…>
 nene2-tokens fill [--parent <brand.css>] [--check] <files…>
 nene2-tokens plain <file> / unplain <file>
-nene2-tokens extract [--map common|origin|vault] <file>
+nene2-tokens extract [--map common|origin|vault|suite] <file>
 nene2-tokens generate [--plain] <doc.json>
 nene2-tokens contract / map
+nene2-tokens codemod-plan --theme <theme.css> [--map <table>]
+nene2-tokens codemod --theme <theme.css> [--map <table>] [--check] [--ext ts,tsx] <paths…>
 ```
 
 終了コード: 0 = green ／ 1 = 違反 ／ 2 = 検査不能（fail-closed — unknown は green ではない）。
+
+## 語彙 codemod（T-4）
+
+テーマの**トークン改名**（`--spacing-inline-md → --spacing-x-inline-md`）に対応する
+**utility class 改名**（`px-inline-md → px-x-inline-md`）を TSX/TS へ撃つ実行物。
+写像判断は一切持たず、正本の写像表（`CODEMOD_MAP_V1` / `mapTokenSet`）から機械導出する。
+
+### W1 移行の順序（**厳守** — 逆順・二度撃ちは壊れる）
+
+```sh
+# 0. 何が起きるかを先に見る（M-1 の PR 本文へ貼る: codemod 名・version・写像表 version）
+npx nene2-tokens codemod-plan --theme src/shared/ui/theme/themes/default.css --map common
+
+# 1. TSX/TS の class・var(--) 位置を撃つ（★テーマ移行より先。計画はテーマから導出される）
+npx nene2-tokens codemod --theme src/shared/ui/theme/themes/default.css --map common src tests
+
+# 2. テーマ本体を移行（versioned CLI — extract→map→generate の順序固定）
+npx nene2-tokens extract --map common src/shared/ui/theme/themes/default.css > /tmp/doc.json
+npx nene2-tokens generate /tmp/doc.json > src/shared/ui/theme/themes/default.css
+
+# 3. 冪等確認（テーマ移行後は計画が空になり no-op = exit 0）
+npx nene2-tokens codemod --check --theme src/shared/ui/theme/themes/default.css --map common src
+```
+
+**codemod は 1 回だけ撃つ。** 計画はテーマから導出されるので、テーマを移行する前に 2 回撃つと
+`gap-inline-sm → gap-x-inline-sm → gap-x-x-inline-sm` と二重適用される（`gap-x` が Tailwind の
+実在ルートである字面衝突 — hideyukiMORI/nene2-fleet-tooling#17）。CLI は該当する再入 rename を
+`NOTE` 行で開示する。手順 2 を済ませれば計画は空になり、以後 `--check` は緑で固定される。
+
+### 素の jscodeshift から叩く
+
+```sh
+npx jscodeshift -t node_modules/@hideyukimori/nene2-tokens/dist/codemod-transform.js \
+  --parser=tsx --theme=src/shared/ui/theme/themes/default.css --map=common src
+```
+
+### 出力方式
+
+AST は書き換えず、jscodeshift で class 文字列の**位置**を特定して原文の該当範囲だけ差し替える
+（`toSource()` は使わない）。recast は変更した文字列リテラルを `quote` 設定で刷り直すが、
+フリートの prettier は JS 文字列 `'…'`・JSX 属性 `"…"` で**どの quote 設定でも片方が崩れる**ため。
+この方式なら入力が prettier 固定点なら出力も固定点のまま（repo ごとの prettier 設定に非依存）。
 
 契約凍結レビュー: `../../docs/contract-freeze-review-2026-07-18.md`（07-18）。
 契約進化は AM-2（minor=派生式同梱・major=codemod 3点セット・移行窓中は stop-the-line ADR のみ）。

--- a/packages/nene2-tokens/README.md
+++ b/packages/nene2-tokens/README.md
@@ -69,12 +69,25 @@ npx jscodeshift -t node_modules/@hideyukimori/nene2-tokens/dist/codemod-transfor
   --parser=tsx --theme=src/shared/ui/theme/themes/default.css --map=common src
 ```
 
-### 出力方式
+### 出力方式（splice — 施主追認済み 2026-07-15）
 
 AST は書き換えず、jscodeshift で class 文字列の**位置**を特定して原文の該当範囲だけ差し替える
 （`toSource()` は使わない）。recast は変更した文字列リテラルを `quote` 設定で刷り直すが、
 フリートの prettier は JS 文字列 `'…'`・JSX 属性 `"…"` で**どの quote 設定でも片方が崩れる**ため。
-この方式なら入力が prettier 固定点なら出力も固定点のまま（repo ごとの prettier 設定に非依存）。
+T-4 は engine（jscodeshift）の指定であって recast printer の指定ではない、という整理。
+
+**prettier 固定点について（実測・over-claim しない）**:
+splice は引用符・空白・セミコロンに触れないので、prettier の整形判断を動かし得る要因は
+「rename で行が **+2 桁伸びる**」ことだけに限られる。
+
+- **payout 実ツリーでは固定点**（実測）: 移行前ツリー（prettier 緑）に codemod を流した
+  **41 ファイル・133 置換**の出力に対し、payout の実 `.prettierrc.json`
+  （`semi:false`・`singleQuote`・`printWidth:100`）で `prettier --check` が**緑**。
+  100 桁超の行は 20 本あるが、**折り返せない class 文字列**なので prettier は動かせない。
+- **一般には保証されない**（反例あり・テストで固定）: **折り返せる**行が rename で
+  `printWidth` を跨ぐと prettier は再整形したがる（例: 99 桁 → 101 桁の 1 行 JSX は
+  括弧で包み直される）。この形が出る repo では codemod 後に pinned prettier を流すこと。
+  codemod の diff と prettier の diff は別コミットに分けられるのでレビュー性は保たれる。
 
 契約凍結レビュー: `../../docs/contract-freeze-review-2026-07-18.md`（07-18）。
 契約進化は AM-2（minor=派生式同梱・major=codemod 3点セット・移行窓中は stop-the-line ADR のみ）。

--- a/packages/nene2-tokens/package.json
+++ b/packages/nene2-tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hideyukimori/nene2-tokens",
   "version": "1.0.1",
-  "description": "NeNe Core Token Contract v1 — contract types, CONTRACT_TOKENS, validate:themes CLI, themegen, codemod mapping table v1, reference theme",
+  "description": "NeNe Core Token Contract v1 — contract types, CONTRACT_TOKENS, validate:themes CLI, themegen, codemod mapping table v1 + jscodeshift codemod runner, reference theme",
   "type": "module",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./codemod-transform": {
+      "types": "./dist/codemod-transform.d.ts",
+      "default": "./dist/codemod-transform.js"
     }
   },
   "bin": {
@@ -33,5 +37,11 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "dependencies": {
+    "jscodeshift": "^17.3.0"
+  },
+  "devDependencies": {
+    "@types/jscodeshift": "^17.3.0"
   }
 }

--- a/packages/nene2-tokens/src/__fixtures__/payout-w1-before.css
+++ b/packages/nene2-tokens/src/__fixtures__/payout-w1-before.css
@@ -1,0 +1,30 @@
+/**
+ * Default theme — the ONLY place (with sibling theme files) where raw visual
+ * values live (frontend-standards: no magic styling). Swapping the active theme
+ * restyles the whole app without touching components.
+ */
+@theme {
+  --color-surface: oklch(99% 0.004 260);
+  --color-surface-raised: oklch(100% 0 0);
+  --color-text-primary: oklch(25% 0.02 260);
+  --color-text-muted: oklch(55% 0.02 260);
+  --color-border: oklch(90% 0.01 260);
+  --color-accent: oklch(55% 0.15 250);
+  --color-accent-contrast: oklch(99% 0 0);
+  --color-danger: oklch(55% 0.2 25);
+
+  --spacing-inline-sm: 0.5rem;
+  --spacing-inline-md: 1rem;
+  --spacing-stack-sm: 0.75rem;
+  --spacing-stack-md: 1.25rem;
+  --spacing-stack-lg: 2rem;
+
+  --font-family-sans: 'Inter', system-ui, sans-serif;
+  --font-size-body: 0.875rem;
+  --font-size-heading: 1.25rem;
+  --line-height-body: 1.5;
+  --font-weight-medium: 500;
+
+  --radius-md: 0.5rem;
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
+}

--- a/packages/nene2-tokens/src/cli.ts
+++ b/packages/nene2-tokens/src/cli.ts
@@ -9,11 +9,18 @@
  *   nene2-tokens extract [--map common|origin|vault] <file>   # 写像適用済み JSON（stdout）
  *   nene2-tokens generate [--plain] <doc.json>                # JSON → テーマ CSS（stdout）
  *   nene2-tokens contract                                     # CONTRACT_TOKENS を JSON で出力
+ *   nene2-tokens map                                          # CODEMOD_MAP_V1 を JSON で出力
+ *   nene2-tokens codemod-plan --theme <theme.css> [--map <table>]
+ *                                                             # 写像表から導出した rename 計画（stdout）
+ *   nene2-tokens codemod --theme <theme.css> [--map <table>] [--check] <path...>
+ *                                                             # TSX/TS の class・var(--) 位置を書き換え
  *
  * 終了コード: 0 = green / 1 = 違反あり / 2 = 検査不能（fail-closed — unknown は green ではない）
  */
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import jscodeshift from 'jscodeshift';
 import { CONTRACT_TOKENS } from './contract.js';
 import { validateThemeSource, type ValidateOptions } from './validate.js';
 import {
@@ -25,6 +32,14 @@ import {
   ThemegenError,
 } from './themegen.js';
 import { CODEMOD_MAP_V1, type MappingTableId } from './codemod-map.js';
+import {
+  CodemodError,
+  buildPlan,
+  buildRenameIndex,
+  reentrantRenames,
+  type CodemodPlan,
+} from './codemod.js';
+import { applyToSourceDetailed } from './codemod-transform.js';
 
 interface Parsed {
   command: string;
@@ -36,7 +51,7 @@ function parseArgs(argv: string[]): Parsed {
   const [command = 'help', ...rest] = argv;
   const flags = new Map<string, string | true>();
   const files: string[] = [];
-  const valued = new Set(['--parent', '--map', '--container-selector']);
+  const valued = new Set(['--parent', '--map', '--container-selector', '--theme', '--ext']);
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i]!;
     if (a.startsWith('--')) {
@@ -63,6 +78,40 @@ function read(file: string): string {
   } catch (e) {
     console.error(`cannot read ${file}: ${(e as Error).message} (fail-closed)`);
     process.exit(2);
+  }
+}
+
+/** codemod: `--theme` から rename 計画を導出する（写像判断は写像表が正本）。 */
+function planFrom(flags: Map<string, string | true>): CodemodPlan {
+  const theme = flags.get('--theme');
+  if (typeof theme !== 'string') {
+    console.error(
+      'codemod: --theme <theme css> is required — the rename plan is derived from the theme via the versioned mapping table (no mappings are invented here)',
+    );
+    process.exit(2);
+  }
+  const map = flags.get('--map');
+  return buildPlan(read(theme), typeof map === 'string' ? (map as MappingTableId) : 'common');
+}
+
+/** 対象ソースを列挙する（node_modules / dist は除外）。 */
+function* walkSources(root: string, exts: readonly string[]): Generator<string> {
+  let st;
+  try {
+    st = statSync(root);
+  } catch (e) {
+    console.error(`cannot stat ${root}: ${(e as Error).message} (fail-closed)`);
+    process.exit(2);
+  }
+  if (st.isFile()) {
+    if (exts.some((x) => root.endsWith(x))) yield root;
+    return;
+  }
+  for (const name of readdirSync(root).sort()) {
+    if (name === 'node_modules' || name === 'dist') continue;
+    const p = join(root, name);
+    if (statSync(p).isDirectory()) yield* walkSources(p, exts);
+    else if (exts.some((x) => name.endsWith(x))) yield p;
   }
 }
 
@@ -156,9 +205,76 @@ function main(): void {
       process.stdout.write(generateTheme(doc, { plain: flags.get('--plain') === true }));
       return;
     }
+    case 'codemod-plan': {
+      console.log(JSON.stringify(planFrom(flags), null, 2));
+      return;
+    }
+    case 'codemod': {
+      if (files.length === 0) {
+        console.error('codemod: no paths given — refusing to report success on nothing (G-6)');
+        process.exit(2);
+      }
+      const plan = planFrom(flags);
+      const index = buildRenameIndex(plan);
+      const extFlag = flags.get('--ext');
+      const exts =
+        typeof extFlag === 'string'
+          ? extFlag.split(',').map((x) => (x.startsWith('.') ? x : `.${x}`))
+          : ['.ts', '.tsx'];
+      const checkOnly = flags.get('--check') === true;
+
+      // M-1: 出力の出所を機械可読に開示する（PR 本文へ貼るための版表示）
+      console.log(
+        `${plan.codemod}@${plan.codemodVersion} (mapping table v${plan.mapVersion}, table='${plan.table}')`,
+      );
+      console.log(
+        `plan: ${plan.tokenRenames.length} token rename(s) → ${plan.classRenames.length} class rename(s)`,
+      );
+      // 誤用（テーマ未移行のまま 2 回撃つ）で壊れる対を開示する — 正順なら 2 回目の計画は空になる
+      const reentrant = reentrantRenames(index);
+      if (reentrant.length > 0) {
+        console.log(
+          `NOTE  ${reentrant.length} rename(s) are re-entrant (e.g. ${reentrant[0]!.from} → ${reentrant[0]!.to} → …).`,
+        );
+        console.log(
+          '      Run this codemod EXACTLY ONCE, then migrate the theme with `extract --map … | generate`.',
+        );
+        console.log(
+          '      Re-running against an un-migrated theme double-applies them (see fleet-tooling#17).',
+        );
+      }
+      for (const u of plan.unmapped) {
+        console.log(`WARN  no class rename derived for ${u.from} → ${u.to}: ${u.reason}`);
+      }
+      if (index.size === 0) {
+        console.log('codemod — nothing to rename (theme is already on contract vocabulary)');
+        return;
+      }
+
+      const j = jscodeshift.withParser('tsx');
+      let changed = 0;
+      let total = 0;
+      for (const path of files) {
+        for (const file of walkSources(path, exts)) {
+          const source = read(file);
+          const out = applyToSourceDetailed(source, j, index);
+          if (out === undefined || out.text === source) continue;
+          changed++;
+          total += out.count;
+          if (checkOnly) console.log(`STALE ${file} (${out.count} replacement(s))`);
+          else {
+            writeFileSync(file, out.text);
+            console.log(`${out.count}\t${file}`);
+          }
+        }
+      }
+      console.log(`codemod — ${changed} file(s), ${total} replacement(s)`);
+      process.exit(checkOnly && changed > 0 ? 1 : 0);
+      return;
+    }
     default: {
       console.error(
-        'usage: nene2-tokens <validate|fill|plain|unplain|extract|generate|contract|map> …',
+        'usage: nene2-tokens <validate|fill|plain|unplain|extract|generate|contract|map|codemod|codemod-plan> …',
       );
       process.exit(command === 'help' ? 0 : 2);
     }
@@ -173,7 +289,7 @@ function missing(what: string): never {
 try {
   main();
 } catch (e) {
-  if (e instanceof ThemegenError) {
+  if (e instanceof ThemegenError || e instanceof CodemodError) {
     console.error(`ERROR ${e.message}`);
     process.exit(1);
   }

--- a/packages/nene2-tokens/src/codemod-transform.test.ts
+++ b/packages/nene2-tokens/src/codemod-transform.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import jscodeshift from 'jscodeshift';
+import * as prettier from 'prettier';
 import { describe, expect, it } from 'vitest';
 import { buildPlan, buildRenameIndex } from './codemod.js';
 import transform, { applyToSource, applyToSourceDetailed } from './codemod-transform.js';
@@ -126,6 +127,95 @@ describe('codemod transform — 実測カウント', () => {
     // 109 箇所すべてが x- 送り後の綴りになる ＝ dead 化しない
     expect(out!.text).not.toMatch(/className="(px|py|gap)-(inline|stack)-/);
     expect(out!.text).not.toContain('-x-x-');
+  });
+});
+
+/**
+ * splice 方式の眼目は「codemod 出力がそのまま pinned prettier の固定点である」こと
+ * （T-1 の themegen と同じ流儀・追認済み 2026-07-15）。主張ではなく**実証**する。
+ *
+ * 設定は nene-payout/frontend/.prettierrc.json の現物（W1 先頭走者）。
+ */
+const PAYOUT_PRETTIER: prettier.Options = {
+  semi: false,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+  parser: 'typescript',
+};
+
+/**
+ * nene-payout `src/shared/ui/primitives/Button.tsx` の **移行前現物**（#159 の親 eb5f7aa）。
+ * template literal の className・object 値の class 文字列・**printWidth 100 を超える行**
+ * （114 桁）を含む。移行前ツリー全体が prettier 固定点であることは実測済み。
+ */
+const PAYOUT_BUTTON_TSX = `import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger'
+  children: ReactNode
+}
+
+const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
+  primary: 'bg-accent text-accent-contrast',
+  secondary: 'bg-surface-raised text-primary border border-border',
+  danger: 'bg-danger text-accent-contrast',
+}
+
+export function Button({ variant = 'primary', children, type = 'button', ...rest }: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={\`rounded-md px-inline-md py-stack-sm font-sans text-body font-medium \${VARIANT_CLASS[variant]}\`}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}
+`;
+
+describe('codemod transform — prettier 固定点（splice 方式の眼目・実証）', () => {
+  it('前提: 移行前の payout 現物はそのものが prettier 固定点である', async () => {
+    expect(await prettier.check(PAYOUT_BUTTON_TSX, PAYOUT_PRETTIER)).toBe(true);
+  });
+
+  it('codemod 出力は pinned prettier の固定点のまま（payout 現物・実測）', async () => {
+    const out = applyToSourceDetailed(PAYOUT_BUTTON_TSX, j, index);
+    // G-6: 空虚合格禁止 — 何も置換していないのに緑、を許さない
+    expect(out).toBeDefined();
+    expect(out!.count).toBe(5);
+    expect(out!.text).toContain('px-x-inline-md');
+    expect(out!.text).toContain('text-on-accent');
+
+    expect(await prettier.check(out!.text, PAYOUT_PRETTIER)).toBe(true);
+  });
+
+  it('printWidth 100 を超える長い className 行は、伸びても固定点のまま', async () => {
+    // 折り返せない文字列を含む属性は既に自分の行にあるので、+2 桁しても prettier は動かない
+    const src = `export const B = () => (
+  <button className="rounded-md bg-accent px-inline-md py-stack-sm font-sans text-body font-medium text-accent-contrast">
+    go
+  </button>
+)
+`;
+    expect(await prettier.check(src, PAYOUT_PRETTIER)).toBe(true);
+    const out = applyToSource(src, j, index)!;
+    expect(Math.max(...out.split('\n').map((l) => l.length))).toBeGreaterThan(100);
+    expect(await prettier.check(out, PAYOUT_PRETTIER)).toBe(true);
+  });
+
+  it('既知の限界: 折り返せる行が rename で printWidth を跨ぐと固定点でなくなる', async () => {
+    // 反例（実測）。99 桁 → +2 で 101 桁。prettier は JSX を括弧で包み直したがる。
+    // payout 実ツリーでは発生しない（全 41 ファイル prettier --check 緑）が、
+    // 「splice は常に固定点」と over-claim しないために反例を固定しておく。
+    const src = `export const D = () => <div id="${'y'.repeat(38)}" className="px-inline-md" />\n`;
+    expect(src.split('\n')[0]!.length).toBe(99);
+    expect(await prettier.check(src, PAYOUT_PRETTIER)).toBe(true);
+
+    const out = applyToSource(src, j, index)!;
+    expect(out.split('\n')[0]!.length).toBe(101);
+    expect(await prettier.check(out, PAYOUT_PRETTIER)).toBe(false);
   });
 });
 

--- a/packages/nene2-tokens/src/codemod-transform.test.ts
+++ b/packages/nene2-tokens/src/codemod-transform.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import jscodeshift from 'jscodeshift';
+import { describe, expect, it } from 'vitest';
+import { buildPlan, buildRenameIndex } from './codemod.js';
+import transform, { applyToSource, applyToSourceDetailed } from './codemod-transform.js';
+
+const j = jscodeshift.withParser('tsx');
+
+const payoutBefore = readFileSync(
+  fileURLToPath(new URL('./__fixtures__/payout-w1-before.css', import.meta.url)),
+  'utf8',
+);
+const index = buildRenameIndex(buildPlan(payoutBefore, 'common'));
+
+const run = (source: string): string | undefined => applyToSource(source, j, index);
+
+describe('codemod transform — payout#159 現物の行を再現する', () => {
+  it('rewrites a非-JSX class string (payout: `const base = …`)', () => {
+    // 実際の payout diff の 1 行そのもの。className 属性に限定すると取り漏らす現物。
+    const src = `const base = 'block rounded-md px-inline-md py-stack-sm font-sans text-body'\n`;
+    expect(run(src)).toBe(
+      `const base = 'block rounded-x-md px-x-inline-md py-x-stack-sm font-sans text-body'\n`,
+    );
+  });
+
+  it('rewrites className attributes (payout: AppLayout header)', () => {
+    const src = `<header className="flex items-center justify-between border-b border-border px-inline-md py-stack-sm">x</header>;\n`;
+    expect(run(src)).toBe(
+      `<header className="flex items-center justify-between border-b border-border px-x-inline-md py-x-stack-sm">x</header>;\n`,
+    );
+  });
+
+  it('rewrites the accent-contrast button (payout: text-accent-contrast → text-on-accent)', () => {
+    const src = `<button className="rounded-md bg-accent px-inline-md py-stack-sm font-sans text-body font-medium text-accent-contrast">go</button>;\n`;
+    expect(run(src)).toBe(
+      `<button className="rounded-x-md bg-accent px-x-inline-md py-x-stack-sm font-sans text-body font-medium text-on-accent">go</button>;\n`,
+    );
+  });
+
+  it('does not double-replace gap-inline-sm (payout 35件誤置換の回帰)', () => {
+    const src = `<div className="flex items-center gap-inline-sm">x</div>;\n`;
+    const out = run(src);
+    expect(out).toBe(`<div className="flex items-center gap-x-inline-sm">x</div>;\n`);
+    expect(out).not.toContain('gap-x-x-');
+  });
+});
+
+describe('codemod transform — 出力の非破壊性（splice 方式の根拠）', () => {
+  it('preserves single quotes on JS strings (prettier singleQuote:true)', () => {
+    expect(run(`const a = 'px-inline-md';\n`)).toBe(`const a = 'px-x-inline-md';\n`);
+  });
+
+  it('preserves double quotes on JSX attributes (prettier jsxSingleQuote:false)', () => {
+    expect(run(`const A = () => <b className="px-inline-md" />;\n`)).toBe(
+      `const A = () => <b className="px-x-inline-md" />;\n`,
+    );
+  });
+
+  it('leaves everything it does not rename byte-identical (semicolons/spacing 不変)', () => {
+    // semi:false・独特のインデントでも触らない（repo ごとの prettier 設定に非依存）
+    const src = [
+      'export function Panel() {',
+      '  const cls = `px-inline-md ${flag ? "gap-inline-sm" : ""}`',
+      '  return <div className={cls} data-x="untouched" />',
+      '}',
+      '',
+    ].join('\n');
+    const out = run(src)!;
+    expect(out).toBe(
+      [
+        'export function Panel() {',
+        '  const cls = `px-x-inline-md ${flag ? "gap-x-inline-sm" : ""}`',
+        '  return <div className={cls} data-x="untouched" />',
+        '}',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('returns undefined when nothing matches (jscodeshift の「触っていない」表現)', () => {
+    expect(run(`const a = 'nothing-to-see';\n`)).toBeUndefined();
+  });
+});
+
+describe('codemod transform — AST スコープ（sed との差）', () => {
+  it('does not rewrite module specifiers', () => {
+    const src = `import x from './px-inline-md';\n`;
+    expect(run(src)).toBeUndefined();
+  });
+
+  it('does not rewrite identifiers or comments (文字列位置のみ撃つ)', () => {
+    const src = `// px-inline-md is the old name\nconst px_inline_md = 1;\n`;
+    expect(run(src)).toBeUndefined();
+  });
+
+  it('rewrites template literal chunks around interpolations', () => {
+    const src = 'const c = `px-inline-md ${v} gap-inline-sm`;\n';
+    expect(run(src)).toBe('const c = `px-x-inline-md ${v} gap-x-inline-sm`;\n');
+  });
+
+  it('rewrites var(--) references inside strings', () => {
+    const src = `const s = 'var(--spacing-inline-md)';\n`;
+    expect(run(src)).toBe(`const s = 'var(--spacing-x-inline-md)';\n`);
+  });
+});
+
+describe('codemod transform — 実測カウント', () => {
+  it('counts 109 spacing utility replacements across a payout 模擬コンポーネント', () => {
+    // payout 実測「spacing utility 109 箇所」を模した現実的な構成
+    const spacing = [
+      'px-inline-md',
+      'py-stack-sm',
+      'gap-inline-sm',
+      'gap-stack-md',
+      'px-inline-sm',
+    ];
+    const lines: string[] = ['export const Big = () => (', '  <div>'];
+    for (let i = 0; i < 109; i++)
+      lines.push(`    <span className="${spacing[i % spacing.length]}" />`);
+    lines.push('  </div>', ');', '');
+    const src = lines.join('\n');
+
+    const out = applyToSourceDetailed(src, j, index);
+    expect(out?.count).toBe(109);
+    // 109 箇所すべてが x- 送り後の綴りになる ＝ dead 化しない
+    expect(out!.text).not.toMatch(/className="(px|py|gap)-(inline|stack)-/);
+    expect(out!.text).not.toContain('-x-x-');
+  });
+});
+
+describe('codemod transform — jscodeshift transform 署名', () => {
+  it('is callable as a standard jscodeshift transform with a prebuilt plan', () => {
+    const plan = buildPlan(payoutBefore, 'common');
+    const api = { jscodeshift: j, j, stats: () => {}, report: () => {} };
+    const out = transform(
+      { path: 'X.tsx', source: `const a = 'px-inline-md';\n` },
+      api as unknown as Parameters<typeof transform>[1],
+      { plan },
+    );
+    expect(out).toBe(`const a = 'px-x-inline-md';\n`);
+  });
+
+  it('is fail-closed when no theme is given (写像を発明しない)', () => {
+    const api = { jscodeshift: j, j, stats: () => {}, report: () => {} };
+    expect(() =>
+      transform(
+        { path: 'X.tsx', source: `const a = 'px-inline-md';\n` },
+        api as unknown as Parameters<typeof transform>[1],
+        {},
+      ),
+    ).toThrow(/requires a theme/);
+  });
+});

--- a/packages/nene2-tokens/src/codemod-transform.ts
+++ b/packages/nene2-tokens/src/codemod-transform.ts
@@ -1,0 +1,182 @@
+/**
+ * 語彙 codemod の jscodeshift transform（規約 05 §6.6 T-4 MUST — 実行物の本体）。
+ *
+ * 標準の jscodeshift transform 署名なので、同梱 CLI（`nene2-tokens codemod`）からも
+ * 素の jscodeshift からも叩ける:
+ *
+ *   npx jscodeshift -t node_modules/@hideyukimori/nene2-tokens/dist/codemod-transform.js \
+ *     --parser=tsx --theme=src/shared/ui/theme/themes/default.css --map=common src
+ *
+ * ## 出力方式（設計上の要点 — 施主/評議会の追認対象）
+ *
+ * AST は **書き換えない**。jscodeshift で「class 文字列がソースのどこに居るか」を特定し、
+ * その **文字範囲だけを原文に差し戻す**（splice）。`root.toSource()` は使わない。理由:
+ *
+ *  - recast の printer は変更した StringLiteral を `options.quote` で**必ず引用符ごと刷り直す**
+ *    （printer.js: `case "StringLiteral": return fromString(nodeStr(n.value, options))` —
+ *    `extra.raw` は参照されない）。recast の quote 設定は 1 つしかなく JSX 属性にも同じ物が効く。
+ *  - フリートの prettier は `singleQuote: true` かつ `jsxSingleQuote` 既定 false。つまり
+ *    JS 文字列は `'…'`・JSX 属性は `"…"` が正。**どの quote 設定でも片方が必ず崩れる**（実測）。
+ *  - splice なら引用符・空白・セミコロンに一切触れないので、入力が prettier 固定点なら
+ *    出力も prettier 固定点のまま（T-1 の themegen と同じ流儀）。repo ごとに prettier 設定が
+ *    割れている（payout は semi:false・本リポは semi:true）フリートで設定非依存になる。
+ *  - 既マージの nene-payout#159 の diff は引用符が保存されている。splice はその diff を再現する。
+ *
+ * ## 走査対象
+ *
+ * 文字列リテラルと template literal の生チャンク。**className 属性に限定しない** —
+ * payout 現物に `const base = 'block rounded-md px-inline-md …'` のような JSX 外の
+ * class 文字列があり、限定すると取り漏らす（実測）。module specifier は除外する。
+ */
+
+import { readFileSync } from 'node:fs';
+import type { API, FileInfo, Options, Transform } from 'jscodeshift';
+import type { ASTPath } from 'jscodeshift';
+import {
+  CodemodError,
+  applyRenames,
+  buildPlan,
+  buildRenameIndex,
+  type CodemodPlan,
+} from './codemod.js';
+import type { MappingTableId } from './codemod-map.js';
+
+export interface CodemodTransformOptions extends Options {
+  /** 事前に組んだ計画（CLI からの in-process 実行用 — 毎ファイル再導出しない） */
+  plan?: CodemodPlan;
+  /** テーマ CSS のパス（素の jscodeshift から叩くとき用） */
+  theme?: string;
+  /** 写像表 ID（既定 common） */
+  map?: MappingTableId;
+}
+
+/** 素の jscodeshift 実行時、テーマからの計画導出はプロセス内で 1 度きりにする。 */
+const planCache = new Map<string, CodemodPlan>();
+
+function resolvePlan(options: CodemodTransformOptions): CodemodPlan {
+  if (options.plan) return options.plan;
+  const theme = options.theme;
+  if (typeof theme !== 'string' || theme.length === 0) {
+    throw new CodemodError(
+      'codemod requires a theme: pass --theme=<path to theme css> (the rename plan is derived from it — this transform invents no mappings)',
+    );
+  }
+  const table: MappingTableId = options.map ?? 'common';
+  const key = `${theme}\u0000${table}`;
+  let plan = planCache.get(key);
+  if (!plan) {
+    let source: string;
+    try {
+      source = readFileSync(theme, 'utf8');
+    } catch (e) {
+      throw new CodemodError(`cannot read theme ${theme}: ${(e as Error).message} (fail-closed)`);
+    }
+    plan = buildPlan(source, table);
+    planCache.set(key, plan);
+  }
+  return plan;
+}
+
+/** import/export の module specifier か（`'./px-inline-md'` を class と誤認しない）。 */
+function isModuleSpecifier(path: ASTPath): boolean {
+  const parent = path.parent?.node as { type?: string } | undefined;
+  if (!parent?.type) return false;
+  return (
+    parent.type === 'ImportDeclaration' ||
+    parent.type === 'ExportNamedDeclaration' ||
+    parent.type === 'ExportAllDeclaration' ||
+    parent.type === 'ImportExpression' ||
+    parent.type === 'TSImportType' ||
+    parent.type === 'TSExternalModuleReference'
+  );
+}
+
+interface Edit {
+  start: number;
+  end: number;
+  text: string;
+}
+
+interface Ranged {
+  start?: number | null;
+  end?: number | null;
+}
+
+export interface TransformResult {
+  readonly text: string;
+  /** 置換回数（CLI が M-1 用の実測値として報告する） */
+  readonly count: number;
+}
+
+/**
+ * 置換を適用した結果を返す（変更なしなら undefined = jscodeshift の「触っていない」表現）。
+ * 公開して単体テスト・CLI から直接叩けるようにする。
+ */
+export function applyToSourceDetailed(
+  source: string,
+  j: API['jscodeshift'],
+  index: ReadonlyMap<string, string>,
+): TransformResult | undefined {
+  if (index.size === 0) return undefined;
+  const root = j(source);
+  const edits: Edit[] = [];
+  let count = 0;
+
+  const spliceRange = (start: number | null | undefined, end: number | null | undefined): void => {
+    if (typeof start !== 'number' || typeof end !== 'number' || end <= start) return;
+    const original = source.slice(start, end);
+    const applied = applyRenames(original, index);
+    if (applied.count > 0) {
+      edits.push({ start, end, text: applied.text });
+      count += applied.count;
+    }
+  };
+
+  // 文字列リテラルの中身（引用符の内側だけ — 引用符には触れない）
+  root.find(j.StringLiteral).forEach((path) => {
+    if (isModuleSpecifier(path)) return;
+    const node = path.node as unknown as Ranged;
+    if (typeof node.start !== 'number' || typeof node.end !== 'number') return;
+    spliceRange(node.start + 1, node.end - 1);
+  });
+
+  // template literal の生チャンク（`${}` の外側の literal 部分のみ）
+  root.find(j.TemplateElement).forEach((path) => {
+    const node = path.node as unknown as Ranged;
+    spliceRange(node.start, node.end);
+  });
+
+  if (edits.length === 0) return undefined;
+
+  edits.sort((a, b) => a.start - b.start);
+  let out = '';
+  let cursor = 0;
+  for (const edit of edits) {
+    // AST 由来の範囲は入れ子にならない（StringLiteral と TemplateElement は互いに素）
+    if (edit.start < cursor) continue;
+    out += source.slice(cursor, edit.start) + edit.text;
+    cursor = edit.end;
+  }
+  out += source.slice(cursor);
+  return { text: out, count };
+}
+
+/** `applyToSourceDetailed` の文字列版（jscodeshift transform の戻り値そのもの）。 */
+export function applyToSource(
+  source: string,
+  j: API['jscodeshift'],
+  index: ReadonlyMap<string, string>,
+): string | undefined {
+  return applyToSourceDetailed(source, j, index)?.text;
+}
+
+const transform: Transform = (file: FileInfo, api: API, options: CodemodTransformOptions) => {
+  const plan = resolvePlan(options);
+  const index = buildRenameIndex(plan);
+  return applyToSource(file.source, api.jscodeshift, index);
+};
+
+export default transform;
+
+/** jscodeshift に tsx パーサを使わせる（`.ts`/`.tsx` 両方を 1 本で扱う）。 */
+export const parser = 'tsx';

--- a/packages/nene2-tokens/src/codemod-transform.ts
+++ b/packages/nene2-tokens/src/codemod-transform.ts
@@ -17,10 +17,14 @@
  *    `extra.raw` は参照されない）。recast の quote 設定は 1 つしかなく JSX 属性にも同じ物が効く。
  *  - フリートの prettier は `singleQuote: true` かつ `jsxSingleQuote` 既定 false。つまり
  *    JS 文字列は `'…'`・JSX 属性は `"…"` が正。**どの quote 設定でも片方が必ず崩れる**（実測）。
- *  - splice なら引用符・空白・セミコロンに一切触れないので、入力が prettier 固定点なら
- *    出力も prettier 固定点のまま（T-1 の themegen と同じ流儀）。repo ごとに prettier 設定が
+ *  - splice なら引用符・空白・セミコロンに一切触れないので、repo ごとに prettier 設定が
  *    割れている（payout は semi:false・本リポは semi:true）フリートで設定非依存になる。
  *  - 既マージの nene-payout#159 の diff は引用符が保存されている。splice はその diff を再現する。
+ *
+ * prettier 固定点は **payout 実ツリーでは実測で緑**（41 ファイル・133 置換）。ただし
+ * **一般には保証しない**: 整形判断を動かし得る唯一の要因＝「rename で行が +2 桁伸びる」ため、
+ * **折り返せる**行が printWidth を跨ぐと prettier は再整形したがる（反例をテストで固定）。
+ * 折り返せない class 文字列はどれだけ長くても動かないので、payout の 100 桁超 20 行は緑のまま。
  *
  * ## 走査対象
  *

--- a/packages/nene2-tokens/src/codemod.test.ts
+++ b/packages/nene2-tokens/src/codemod.test.ts
@@ -1,0 +1,262 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  CODEMOD_NAME,
+  CODEMOD_VERSION,
+  CodemodError,
+  NAMESPACE_UTILITY_ROOTS,
+  applyRenames,
+  buildPlan,
+  buildRenameIndex,
+  collectDeclaredTokenNames,
+  deriveClassRenames,
+  namespaceOf,
+  reentrantRenames,
+} from './codemod.js';
+import { CODEMOD_MAP_VERSION } from './codemod-map.js';
+
+/**
+ * nene-payout#159（W1 初弾）の **移行前** テーマ現物。
+ * 期待値は PR #159 の実測（テーマ 12 トークン rename・TSX 133 置換＝
+ * text-accent-contrast×10・spacing 系×109・rounded-md×14）と突き合わせてある。
+ */
+const payoutBefore = readFileSync(
+  fileURLToPath(new URL('./__fixtures__/payout-w1-before.css', import.meta.url)),
+  'utf8',
+);
+
+describe('codemod runner — versioning (T-4 / M-1)', () => {
+  it('exposes a stable codemod name and version for the migration PR body', () => {
+    expect(CODEMOD_NAME).toBe('@hideyukimori/nene2-tokens/codemod');
+    expect(CODEMOD_VERSION).toBe('1.0.0');
+  });
+
+  it('stamps the mapping table version into the plan (写像判断の出所を開示する)', () => {
+    const plan = buildPlan(payoutBefore, 'common');
+    expect(plan.mapVersion).toBe(CODEMOD_MAP_VERSION);
+    expect(plan.codemod).toBe(CODEMOD_NAME);
+    expect(plan.table).toBe('common');
+  });
+});
+
+describe('namespaceOf — Tailwind v4 namespace 照合', () => {
+  it('matches longer namespaces before their prefixes (--font-weight-* が font に食われない)', () => {
+    expect(namespaceOf('--font-weight-medium')).toBe('font-weight');
+    expect(namespaceOf('--font-size-body')).toBe('font');
+    expect(namespaceOf('--inset-shadow-glow')).toBe('inset-shadow');
+    expect(namespaceOf('--text-shadow-sm')).toBe('text-shadow');
+    expect(namespaceOf('--shadow-sm')).toBe('shadow');
+  });
+
+  it('falls back to the leading segment for unknown namespaces', () => {
+    expect(namespaceOf('--line-height-body')).toBe('line');
+  });
+
+  it('yields no utility roots for namespaces v4 does not generate utilities from', () => {
+    expect(NAMESPACE_UTILITY_ROOTS['line']).toBeUndefined();
+    expect(NAMESPACE_UTILITY_ROOTS['font-weight']).toBeUndefined();
+  });
+});
+
+describe('collectDeclaredTokenNames', () => {
+  it('collects declarations from a *pre-migration* theme (移行前テーマで動かないと使えない)', () => {
+    const names = collectDeclaredTokenNames(payoutBefore);
+    expect(names).toHaveLength(20);
+    expect(names).toContain('--color-accent-contrast');
+    expect(names).toContain('--spacing-inline-md');
+  });
+
+  it('is fail-closed on a theme with no declarations (G-6: 空虚合格禁止)', () => {
+    expect(() => collectDeclaredTokenNames('@theme {\n}\n')).toThrow(CodemodError);
+  });
+
+  it('is fail-closed on structural errors', () => {
+    expect(() => collectDeclaredTokenNames('@theme {\n  color: red;\n}\n')).toThrow(CodemodError);
+  });
+});
+
+describe('buildPlan — payout#159 現物での機械導出', () => {
+  const plan = buildPlan(payoutBefore, 'common');
+
+  it('derives exactly the 12 token renames PR #159 measured', () => {
+    expect(plan.tokenRenames).toEqual([
+      { from: '--color-accent-contrast', to: '--color-on-accent' },
+      { from: '--spacing-inline-sm', to: '--spacing-x-inline-sm' },
+      { from: '--spacing-inline-md', to: '--spacing-x-inline-md' },
+      { from: '--spacing-stack-sm', to: '--spacing-x-stack-sm' },
+      { from: '--spacing-stack-md', to: '--spacing-x-stack-md' },
+      { from: '--spacing-stack-lg', to: '--spacing-x-stack-lg' },
+      { from: '--font-family-sans', to: '--font-x-family-sans' },
+      { from: '--font-size-body', to: '--font-x-size-body' },
+      { from: '--font-size-heading', to: '--font-x-size-heading' },
+      { from: '--line-height-body', to: '--line-x-height-body' },
+      { from: '--font-weight-medium', to: '--font-x-weight-medium' },
+      { from: '--radius-md', to: '--radius-x-md' },
+    ]);
+  });
+
+  it('leaves contract tokens alone (surface/text-primary/accent/danger/shadow-sm)', () => {
+    const renamed = plan.tokenRenames.map((r) => r.from);
+    for (const stable of [
+      '--color-surface',
+      '--color-surface-raised',
+      '--color-text-primary',
+      '--color-text-muted',
+      '--color-border',
+      '--color-accent',
+      '--color-danger',
+      '--shadow-sm',
+    ]) {
+      expect(renamed).not.toContain(stable);
+    }
+  });
+
+  it('translates token renames into the utility class renames payout actually needed', () => {
+    const index = buildRenameIndex(plan);
+    // spacing utility — 109 箇所 dead 化を防いだ本体
+    expect(index.get('px-inline-md')).toBe('px-x-inline-md');
+    expect(index.get('py-stack-sm')).toBe('py-x-stack-sm');
+    expect(index.get('gap-inline-sm')).toBe('gap-x-inline-sm');
+    expect(index.get('mx-stack-lg')).toBe('mx-x-stack-lg');
+    // radius utility — rounded-md×14
+    expect(index.get('rounded-md')).toBe('rounded-x-md');
+    // color utility — text-accent-contrast×10
+    expect(index.get('text-accent-contrast')).toBe('text-on-accent');
+    expect(index.get('bg-accent-contrast')).toBe('bg-on-accent');
+    // var(--) 参照の置換にトークン改名も索引へ入る
+    expect(index.get('--spacing-inline-md')).toBe('--spacing-x-inline-md');
+  });
+
+  it('derives no class renames for namespaces without utilities (--line-height-*)', () => {
+    const index = buildRenameIndex(plan);
+    expect(index.has('leading-body')).toBe(false);
+    expect(index.has('line-height-body')).toBe(false);
+  });
+
+  it('reports nothing as unmapped for payout (全 rename が namespace 保存)', () => {
+    expect(plan.unmapped).toEqual([]);
+  });
+});
+
+describe('buildPlan — fail-closed', () => {
+  it('refuses unknown color tokens (silent drop 禁止)', () => {
+    const theme = '@theme {\n  --color-totally-unknown: red;\n}\n';
+    expect(() => buildPlan(theme, 'common')).toThrow(/unknown token/);
+  });
+
+  it('refuses when 2 sources collapse onto one target (silent 上書き禁止)', () => {
+    // ok → success と success → success が同一座席に集中する
+    const theme = '@theme {\n  --color-ok: green;\n  --color-success: lime;\n}\n';
+    expect(() => buildPlan(theme, 'common')).toThrow(/conflict/);
+  });
+});
+
+describe('deriveClassRenames — Tailwind 側の機械翻訳（写像判断は入力済み）', () => {
+  it('distributes a spacing rename over every spacing utility root', () => {
+    const { classRenames } = deriveClassRenames([
+      { from: '--spacing-inline-md', to: '--spacing-x-inline-md' },
+    ]);
+    const index = new Map(classRenames.map((r) => [r.from, r.to]));
+    expect(index.get('p-inline-md')).toBe('p-x-inline-md');
+    expect(index.get('gap-y-inline-md')).toBe('gap-y-x-inline-md');
+    expect(index.get('max-w-inline-md')).toBe('max-w-x-inline-md');
+  });
+
+  it('derives nothing for a namespace with no utility roots', () => {
+    expect(
+      deriveClassRenames([{ from: '--line-height-body', to: '--line-x-height-body' }]),
+    ).toEqual({ classRenames: [], unmapped: [] });
+    // suite の prefix-less 改名（--bg → --color-surface）も namespace 'bg' に roots が無い
+    expect(deriveClassRenames([{ from: '--bg', to: '--color-surface' }])).toEqual({
+      classRenames: [],
+      unmapped: [],
+    });
+  });
+
+  it('discloses (not silently skips) a namespace-changing rename — 防御枝', () => {
+    // 写像表 v1.0.1 では到達しない形。表が育ったときに silent skip しないことを固定する。
+    const { classRenames, unmapped } = deriveClassRenames([
+      { from: '--spacing-inline-md', to: '--color-surface' },
+    ]);
+    expect(classRenames).toEqual([]);
+    expect(unmapped).toEqual([
+      {
+        from: '--spacing-inline-md',
+        to: '--color-surface',
+        reason: expect.stringContaining('namespace changes'),
+      },
+    ]);
+  });
+
+  it('refuses when one class would map to two different targets', () => {
+    expect(() =>
+      deriveClassRenames([
+        { from: '--color-fg', to: '--color-text-primary' },
+        { from: '--color-fg', to: '--color-text-muted' },
+      ]),
+    ).toThrow(/class rename conflict/);
+  });
+});
+
+describe('reentrantRenames — 2 回撃つと壊れる対の開示（#17 の字面衝突）', () => {
+  it('flags gap-inline-sm → gap-x-inline-sm as re-entrant (gap-x ルートが再マッチする)', () => {
+    const index = buildRenameIndex(buildPlan(payoutBefore, 'common'));
+    const reentrant = reentrantRenames(index);
+    expect(reentrant).toContainEqual({ from: 'gap-inline-sm', to: 'gap-x-inline-sm' });
+    // 索引には gap-x ルート由来のキーが実在する＝2 回目の実行で gap-x-x- になる
+    expect(index.get('gap-x-inline-sm')).toBe('gap-x-x-inline-sm');
+  });
+
+  it('reports nothing re-entrant when no target is itself a source', () => {
+    expect(reentrantRenames(new Map([['a', 'b']]))).toEqual([]);
+  });
+});
+
+describe('applyRenames — 単一パス（逐次置換の二重置換事故の回帰テスト）', () => {
+  const plan = buildPlan(payoutBefore, 'common');
+  const index = buildRenameIndex(plan);
+
+  it('does NOT double-replace gap-inline-sm into gap-x-x-inline-sm (payout 35件誤置換の回帰)', () => {
+    const out = applyRenames('flex items-center gap-inline-sm', index);
+    expect(out.text).toBe('flex items-center gap-x-inline-sm');
+    expect(out.text).not.toContain('gap-x-x-');
+    expect(out.count).toBe(1);
+  });
+
+  it('keeps variant colon prefixes', () => {
+    const out = applyRenames('hover:bg-accent-contrast md:px-inline-md', index);
+    expect(out.text).toBe('hover:bg-on-accent md:px-x-inline-md');
+    expect(out.count).toBe(2);
+  });
+
+  it('respects class boundaries (部分一致で撃たない)', () => {
+    const out = applyRenames('px-inline-mdx px-inline-md-2 xpx-inline-md', index);
+    expect(out.text).toBe('px-inline-mdx px-inline-md-2 xpx-inline-md');
+    expect(out.count).toBe(0);
+  });
+
+  it('rewrites var(--) references', () => {
+    const out = applyRenames('var(--spacing-inline-md)', index);
+    expect(out.text).toBe('var(--spacing-x-inline-md)');
+  });
+
+  it('counts every occurrence — 109 spacing utilities stay live (payout 実測の模擬)', () => {
+    const spacing = [
+      'px-inline-md',
+      'py-stack-sm',
+      'gap-inline-sm',
+      'gap-stack-md',
+      'px-inline-sm',
+    ];
+    // payout 実測と同じ 109 箇所を組み立てる
+    const occurrences: string[] = [];
+    for (let i = 0; i < 109; i++) occurrences.push(spacing[i % spacing.length]!);
+    const source = occurrences.join(' ');
+    const out = applyRenames(source, index);
+    expect(out.count).toBe(109);
+    // 全部が x- 送り後の綴りになっている＝ dead 化しない
+    expect(out.text.split(' ').every((c) => c.includes('-x-'))).toBe(true);
+    expect(out.text).not.toContain('-x-x-');
+  });
+});

--- a/packages/nene2-tokens/src/codemod.ts
+++ b/packages/nene2-tokens/src/codemod.ts
@@ -1,0 +1,382 @@
+/**
+ * 語彙 codemod ランナー v1 — 配管のみ（#15 / 規約 05 §6.6 T-4 MUST）。
+ *
+ * **責務分界（最重要）**: このモジュールは *写像判断を一切持たない*。
+ * 「どのトークンがどの契約名へ写るか」の正本は `codemod-map.ts` の
+ * `CODEMOD_MAP_V1` / `mapTokenSet()` ただ一つ（versioned）。ここにあるのは
+ *
+ *   1. テーマ CSS の宣言済みトークン名を集める（parser.ts に委譲）
+ *   2. その名前集合を `mapTokenSet()` に渡して rename 対を **機械導出** する
+ *   3. トークン rename を **Tailwind v4 の namespace→utility 規則** で class rename へ翻訳する
+ *   4. 単一パス・全パターン alternation の置換器を組む
+ *
+ * だけである。3 の表（`NAMESPACE_UTILITY_ROOTS`）は Tailwind の規則であって
+ * NeNe 語彙の写像判断ではない — 新しい写像を発明したくなったら codemod-map.ts へ行くこと。
+ *
+ * 由来: nene-payout#159（W1 初弾）で使った使い捨て配管ドライバの恒久化。
+ * T-4 が「使い捨てスクリプト化 MUST NOT」と言う以上、実行物はここ（配布物）に居るのが正しい。
+ */
+
+import { CODEMOD_MAP_VERSION, mapTokenSet, type MappingTableId } from './codemod-map.js';
+import { parseThemeFile } from './parser.js';
+
+/** ランナー名（M-1: 移行 PR 本文に「codemod 名・version」を書くための正本） */
+export const CODEMOD_NAME = '@hideyukimori/nene2-tokens/codemod';
+
+/** ランナーの版。写像表の版（CODEMOD_MAP_VERSION）とは独立に上げる。 */
+export const CODEMOD_VERSION = '1.0.0';
+
+/** codemod が失敗を報告する唯一の型（fail-closed — silent drop 禁止）。 */
+export class CodemodError extends Error {}
+
+export interface Rename {
+  readonly from: string;
+  readonly to: string;
+}
+
+/** class rename を機械導出できなかった token rename（silent skip 禁止 — 必ず報告する）。 */
+export interface UnmappedRename {
+  readonly from: string;
+  readonly to: string;
+  readonly reason: string;
+}
+
+export interface CodemodPlan {
+  readonly codemod: string;
+  readonly codemodVersion: string;
+  /** 写像表の版（M-1 の PR 本文要件） */
+  readonly mapVersion: string;
+  readonly table: MappingTableId;
+  /** テーマの `--x: …` 宣言から導出したトークン改名（`var(--x)` 参照の置換に使う） */
+  readonly tokenRenames: readonly Rename[];
+  /** トークン改名から Tailwind v4 規則で翻訳した utility class 改名 */
+  readonly classRenames: readonly Rename[];
+  /** class 翻訳不能だった token rename（namespace が変わる等）— 手当対象として開示する */
+  readonly unmapped: readonly UnmappedRename[];
+}
+
+/**
+ * Tailwind v4 の「namespace → その namespace のトークンを値に取る utility ルート」表。
+ *
+ * **これは Tailwind の規則であって NeNe 語彙の写像判断ではない**（責務分界の要）。
+ * 網羅の出典は v4 docs の functional utilities。payout#159 の実弾ドライバの表を踏襲する。
+ */
+export const NAMESPACE_UTILITY_ROOTS: Readonly<Record<string, readonly string[]>> = {
+  color: [
+    'text',
+    'bg',
+    'border',
+    'border-t',
+    'border-r',
+    'border-b',
+    'border-l',
+    'border-x',
+    'border-y',
+    'decoration',
+    'divide',
+    'outline',
+    'ring',
+    'ring-offset',
+    'accent',
+    'caret',
+    'fill',
+    'stroke',
+    'shadow',
+    'inset-shadow',
+    'from',
+    'via',
+    'to',
+    'placeholder',
+  ],
+  spacing: [
+    'p',
+    'px',
+    'py',
+    'pt',
+    'pr',
+    'pb',
+    'pl',
+    'ps',
+    'pe',
+    'm',
+    'mx',
+    'my',
+    'mt',
+    'mr',
+    'mb',
+    'ml',
+    'ms',
+    'me',
+    'gap',
+    'gap-x',
+    'gap-y',
+    'space-x',
+    'space-y',
+    'w',
+    'h',
+    'size',
+    'min-w',
+    'min-h',
+    'max-w',
+    'max-h',
+    'inset',
+    'inset-x',
+    'inset-y',
+    'top',
+    'right',
+    'bottom',
+    'left',
+    'start',
+    'end',
+    'translate-x',
+    'translate-y',
+    'scroll-m',
+    'scroll-p',
+    'indent',
+    'basis',
+  ],
+  radius: [
+    'rounded',
+    'rounded-t',
+    'rounded-r',
+    'rounded-b',
+    'rounded-l',
+    'rounded-tl',
+    'rounded-tr',
+    'rounded-br',
+    'rounded-bl',
+    'rounded-s',
+    'rounded-e',
+    'rounded-ss',
+    'rounded-se',
+    'rounded-es',
+    'rounded-ee',
+  ],
+  shadow: ['shadow', 'inset-shadow', 'text-shadow'],
+  font: ['font'],
+};
+
+/**
+ * namespace 照合順。**長い namespace が短い prefix より先** でなければならない
+ * （`--font-weight-medium` が `font` に食われて `font-weight-medium` を吐く事故の回避）。
+ * 不変条件はテストで固定する。
+ */
+const NAMESPACE_ORDER: readonly string[] = [
+  'inset-shadow',
+  'text-shadow',
+  'font-weight',
+  'shadow',
+  'color',
+  'spacing',
+  'radius',
+  'font',
+  'text',
+  'leading',
+  'tracking',
+  'breakpoint',
+  'container',
+  'ease',
+  'animate',
+  'blur',
+  'perspective',
+  'aspect',
+];
+
+/** トークン名の namespace を返す（既知 namespace を長い順に照合 → 失敗時は先頭セグメント）。 */
+export function namespaceOf(token: string): string | null {
+  for (const ns of NAMESPACE_ORDER) {
+    if (token.startsWith(`--${ns}-`)) return ns;
+  }
+  const m = /^--([a-z][a-z0-9]*(?:-[a-z0-9]+)*?)-/.exec(token);
+  return m ? m[1]! : null;
+}
+
+/**
+ * テーマ CSS が **宣言している** カスタムプロパティ名を出現順・重複排除で集める。
+ * `var(--x)` の参照は拾わない（parser.ts の宣言解析に委譲 — 正規表現で再実装しない）。
+ */
+export function collectDeclaredTokenNames(themeSource: string): readonly string[] {
+  const parsed = parseThemeFile(themeSource);
+  if (parsed.errors.length > 0) {
+    const e = parsed.errors[0]!;
+    throw new CodemodError(
+      `theme file has structural errors — fix before codemod: ${e.message} (line ${e.line})`,
+    );
+  }
+  const names: string[] = [];
+  const seen = new Set<string>();
+  for (const block of parsed.blocks) {
+    for (const decl of block.decls) {
+      if (seen.has(decl.name)) continue;
+      seen.add(decl.name);
+      names.push(decl.name);
+    }
+  }
+  if (names.length === 0) {
+    throw new CodemodError(
+      'no token declarations found in theme — refusing to report an empty plan (G-6: 検査不能は green ではない)',
+    );
+  }
+  return names;
+}
+
+/**
+ * テーマから rename 計画を機械導出する。写像判断は `mapTokenSet()`（= 写像表）に完全委譲。
+ *
+ * fail-closed:
+ *  - 未知トークン（reject）が 1 つでもあれば停止（silent drop 禁止）
+ *  - 複数ソース → 単一ターゲットの衝突があれば停止（G-6 同型・silent 上書き禁止）
+ *  - 2 つの token rename が同一 class を別ターゲットへ写す場合も停止
+ */
+export function buildPlan(themeSource: string, table: MappingTableId = 'common'): CodemodPlan {
+  const names = collectDeclaredTokenNames(themeSource);
+  const mapped = mapTokenSet(names, table);
+
+  if (mapped.rejected.length > 0) {
+    throw new CodemodError(
+      `unknown token(s) in theme — refusing (silent drop is prohibited):\n` +
+        mapped.rejected.map((r) => `  ${r.from} — ${r.reason}`).join('\n'),
+    );
+  }
+  if (mapped.conflicts.length > 0) {
+    throw new CodemodError(
+      `token mapping conflict(s) — 2+ sources map to a single target (silent overwrite prohibited):\n` +
+        mapped.conflicts.map((c) => `  ${c.target} ← ${c.sources.join(', ')}`).join('\n'),
+    );
+  }
+
+  const { classRenames, unmapped } = deriveClassRenames(mapped.renames);
+
+  return {
+    codemod: CODEMOD_NAME,
+    codemodVersion: CODEMOD_VERSION,
+    mapVersion: CODEMOD_MAP_VERSION,
+    table,
+    tokenRenames: mapped.renames,
+    classRenames,
+    unmapped,
+  };
+}
+
+export interface ClassRenameResult {
+  readonly classRenames: readonly Rename[];
+  readonly unmapped: readonly UnmappedRename[];
+}
+
+/**
+ * トークン改名を Tailwind v4 の namespace→utility 規則で class 改名へ翻訳する（純関数）。
+ *
+ * **写像判断はしない** — 入力の rename 対は写像表が既に決めたもの。ここがやるのは
+ * 「`--spacing-inline-md → --spacing-x-inline-md` なら spacing namespace の utility ルート
+ * （p/px/py/gap/…）に `-inline-md → -x-inline-md` を配る」という Tailwind 側の機械翻訳だけ。
+ */
+export function deriveClassRenames(tokenRenames: readonly Rename[]): ClassRenameResult {
+  const classIndex = new Map<string, string>();
+  const classRenames: Rename[] = [];
+  const unmapped: UnmappedRename[] = [];
+
+  for (const { from, to } of tokenRenames) {
+    const ns = namespaceOf(from);
+    const roots = ns === null ? undefined : NAMESPACE_UTILITY_ROOTS[ns];
+    // v4 が utility を生成しない namespace（--line-height-* 等）— class 置換は発生しない
+    if (ns === null || roots === undefined) continue;
+    if (!to.startsWith(`--${ns}-`)) {
+      // 写像表 v1.0.1 では到達しない防御枝（全 125 エントリで namespace は保存される）。
+      // 表が育って namespace を跨ぐ改名が入ったとき、silent skip ではなく開示させるための座席。
+      unmapped.push({
+        from,
+        to,
+        reason: `namespace changes ('${ns}' → other) — utility class rename cannot be derived mechanically; handle manually`,
+      });
+      continue;
+    }
+    const oldKey = from.slice(`--${ns}-`.length);
+    const newKey = to.slice(`--${ns}-`.length);
+    for (const root of roots) {
+      const classFrom = `${root}-${oldKey}`;
+      const classTo = `${root}-${newKey}`;
+      const existing = classIndex.get(classFrom);
+      if (existing !== undefined) {
+        if (existing === classTo) continue;
+        throw new CodemodError(
+          `class rename conflict: '${classFrom}' would map to both '${existing}' and '${classTo}' — resolve in the mapping table first`,
+        );
+      }
+      classIndex.set(classFrom, classTo);
+      classRenames.push({ from: classFrom, to: classTo });
+    }
+  }
+  return { classRenames, unmapped };
+}
+
+/**
+ * 置換索引（class rename ∪ token rename）。トークン改名は `var(--x)` 参照の書き換えに要る。
+ */
+export function buildRenameIndex(plan: CodemodPlan): ReadonlyMap<string, string> {
+  const index = new Map<string, string>();
+  for (const { from, to } of plan.classRenames) index.set(from, to);
+  for (const { from, to } of plan.tokenRenames) index.set(from, to);
+  return index;
+}
+
+/**
+ * **再入 rename**（rename 先が、それ自身また別の rename 元でもある対）を洗い出す。
+ *
+ * 単一パス実行の中では安全（1 回しか撃たない）が、**同じ計画で 2 回走らせると壊れる**:
+ * `gap-inline-sm → gap-x-inline-sm` を撃った後にもう一度走らせると、`gap-x` ルート由来の
+ * `gap-x-inline-sm → gap-x-x-inline-sm` が発火する（実測）。計画はテーマから導出されるので、
+ * **正順（テーマを extract→generate で先に移行する）なら 2 回目の計画は空になり no-op** に
+ * なる。ここで洗い出すのは「テーマ未移行のまま 2 回撃つ」誤用の被害範囲。
+ *
+ * 字面衝突そのものの是非は hideyukiMORI/nene2-fleet-tooling#17（x- 送りの namespace 意味論）。
+ */
+export function reentrantRenames(index: ReadonlyMap<string, string>): readonly Rename[] {
+  const out: Rename[] = [];
+  for (const [from, to] of index) {
+    if (index.has(to)) out.push({ from, to });
+  }
+  return out;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * 単一パス・全パターン alternation の置換正規表現を組む。
+ *
+ * **逐次 replace は禁止**（payout 実測の事故）: `gap-inline-sm → gap-x-inline-sm` を当てた後に
+ * `gap-x` ルート由来の `gap-x-inline-sm → gap-x-x-inline-sm` が再マッチし二重置換になる
+ * （payout で 35 件誤置換 — 単一パス化で解消）。索引の全キーを 1 本の alternation にして
+ * 1 回の走査で撃つことがこの関数の存在理由。
+ *
+ * class 境界: `(^|[^a-zA-Z0-9_-])<class>(?![a-zA-Z0-9_-])`。前方の 1 文字を消費するので
+ * variant のコロン prefix（`hover:bg-…`）は保持される。
+ */
+export function buildRenameRegex(index: ReadonlyMap<string, string>): RegExp | null {
+  const keys = [...index.keys()].sort(
+    (a, b) => b.length - a.length || (a < b ? -1 : a > b ? 1 : 0),
+  );
+  if (keys.length === 0) return null;
+  return new RegExp(
+    `(^|[^a-zA-Z0-9_-])(${keys.map(escapeRegExp).join('|')})(?![a-zA-Z0-9_-])`,
+    'g',
+  );
+}
+
+export interface ApplyResult {
+  readonly text: string;
+  readonly count: number;
+}
+
+/** 索引を単一パスで当てる。戻り値の count は置換回数。 */
+export function applyRenames(text: string, index: ReadonlyMap<string, string>): ApplyResult {
+  const re = buildRenameRegex(index);
+  if (re === null) return { text, count: 0 };
+  let count = 0;
+  const out = text.replace(re, (_m: string, pre: string, hit: string) => {
+    count++;
+    return `${pre}${index.get(hit)!}`;
+  });
+  return { text: out, count };
+}

--- a/packages/nene2-tokens/src/index.ts
+++ b/packages/nene2-tokens/src/index.ts
@@ -61,6 +61,35 @@ export type {
   TokenSetResult,
 } from './codemod-map.js';
 
+export {
+  CODEMOD_NAME,
+  CODEMOD_VERSION,
+  NAMESPACE_UTILITY_ROOTS,
+  CodemodError,
+  applyRenames,
+  buildPlan,
+  buildRenameIndex,
+  buildRenameRegex,
+  collectDeclaredTokenNames,
+  deriveClassRenames,
+  namespaceOf,
+  reentrantRenames,
+} from './codemod.js';
+export type {
+  ApplyResult,
+  ClassRenameResult,
+  CodemodPlan,
+  Rename,
+  UnmappedRename,
+} from './codemod.js';
+
+export {
+  applyToSource,
+  applyToSourceDetailed,
+  default as codemodTransform,
+} from './codemod-transform.js';
+export type { CodemodTransformOptions, TransformResult } from './codemod-transform.js';
+
 export { FROZEN_CONTRACT_VERSION, checkContractFreeze } from './release-gate.js';
 export type { FreezeRecord, CurrentContract, GateOptions, GateResult } from './release-gate.js';
 


### PR DESCRIPTION
Closes #15

## 目的

規約 05 §6.6 **T-4 (MUST)**「語彙 codemod は jscodeshift・nene2-tokens に versioned 同梱。使い捨てスクリプト化 MUST NOT」に対し、配布物には**写像表しか無く、TSX/class を書き換える実行物が存在しなかった**。テーマだけ変換すると utility class が dead 化する（payout 実測: spacing 109 箇所）ため、W1 移行 PR は M-1「versioned codemod の出力のみ」を**構造的に**満たせない状態だった。

nene-payout#159 の使い捨て配管ドライバを**恒久化して配布物に同梱**する。#15 は不具合ではなく **W0a 成果物「versioned codemod」の未完了そのもの**（05 §9.2 W0a 定義）なので、これを塞ぐと W0a 完了判定に前進する。

## payout#159 の配管ドライバから踏襲したもの

写像判断ゼロの配管という性格をそのまま維持している:

1. **テーマ宣言 → トークン rename 対の機械導出**（写像の正本は `CODEMOD_MAP_V1`）
2. **Tailwind v4 namespace→utility 規則で class rename へ翻訳** — `NAMESPACE_ROOTS` 表と namespace 照合順（`font-weight` を `font` より先に見る等）はドライバの表を**逐語で踏襲**
3. **単一パス・全パターン alternation 置換** — 逐次 replace だと `gap-inline-sm → gap-x-inline-sm → gap-x-x-inline-sm` の二重置換が起きる（payout 実測 35 件誤置換）
4. **class 境界 `(^|[^a-zA-Z0-9_-])<class>(?![a-zA-Z0-9_-])`**（variant コロン prefix 保持）
5. **未知トークンは reject**（silent drop 禁止）

ドライバから**改善**した点:
- 写像は `mapTokenName` の逐次呼びではなく **`mapTokenSet()`**（#24 で入った衝突検出付き API）へ委譲。**複数ソース→単一ターゲットの衝突で停止**する（ドライバには無かった）
- テーマのトークン収集は正規表現の再実装ではなく **`parser.ts` の宣言解析**に委譲
- namespace が変わる rename を silent skip せず **`unmapped` として開示**（ドライバは `continue` していた）
- class 走査は全文正規表現ではなく **AST スコープ**（コメント・import specifier を撃たない）

## 追加した CLI サブコマンド

```sh
# 何が起きるかを先に見る（M-1 の PR 本文へ貼る: codemod 名・version・写像表 version）
npx nene2-tokens codemod-plan --theme <theme.css> [--map common|origin|vault|suite]

# TSX/TS の class・var(--) 位置を撃つ
npx nene2-tokens codemod --theme <theme.css> [--map <table>] [--check] [--ext ts,tsx] <paths…>
```

素の jscodeshift からも叩ける（transform は標準署名・`./codemod-transform` サブパス export 済み）:

```sh
npx jscodeshift -t node_modules/@hideyukimori/nene2-tokens/dist/codemod-transform.js \
  --parser=tsx --theme=src/shared/ui/theme/themes/default.css --map=common src
```

**W1 の順序（README に明記）**: `codemod`（TSX）→ `extract --map | generate`（テーマ）→ `codemod --check`（no-op で緑固定）。計画はテーマから導出されるので**逆順にすると TSX が一切変換されない**。

## T-4 充足の実測根拠（配布物に入り CLI から叩けること）

`npm pack` した tarball を**クリーンな別ディレクトリへ実際に install して実行**した（`--dry-run` ではない）:

```
$ tar tzf hideyukimori-nene2-tokens-1.0.1.tgz | grep -i codemod
package/dist/codemod-map.js
package/dist/codemod-transform.js      ← 実行物
package/dist/codemod.js
package/dist/codemod-transform.d.ts
package/dist/codemod.d.ts

$ npx nene2-tokens help
usage: nene2-tokens <validate|fill|plain|unplain|extract|generate|contract|map|codemod|codemod-plan> …

$ npx nene2-tokens codemod --theme src/shared/ui/theme/themes/default.css --map common src
@hideyukimori/nene2-tokens/codemod@1.0.0 (mapping table v1.0.1, table='common')
plan: 12 token rename(s) → 267 class rename(s)
10	src/Panel.tsx
codemod — 1 file(s), 10 replacement(s)
```

入力に payout#159 の**移行前テーマ現物**と**実 diff の行**を与えた出力（= 既マージの payout diff と一致・引用符と `semi:false` が保存されている）:

```tsx
const base = 'block rounded-x-md px-x-inline-md py-x-stack-sm font-sans text-body'

<header className="flex items-center justify-between border-b border-border px-x-inline-md py-x-stack-sm">
  <div className="flex items-center gap-x-inline-sm">
    <button className="rounded-x-md bg-accent px-x-inline-md py-x-stack-sm font-sans text-body font-medium text-on-accent">
```

素の jscodeshift ランナー経由でも実行確認（ESM transform を worker が読める）: `1 ok / 0 errors`。

fail-closed も実測: 未知トークン → `exit 1`／`--theme` 未指定 → `exit 2`／構造 error → `exit 1`。

## 出力方式 — splice（**施主追認済み 2026-07-15**）

**AST を書き換えず、jscodeshift で class 文字列の位置を特定して原文の該当範囲だけ差し替える**（splice）。`root.toSource()` は使わない。統合リナ経由の施主裁定で追認済み: T-4 は **engine（jscodeshift）の指定であって recast printer の指定ではない**・splice の diff はリネームしか出ないので M-1 が狙うレビュー性を守る。

根拠（すべて実測）:

- recast の printer は変更した `StringLiteral` を `options.quote` で**必ず引用符ごと刷り直す**（`printer.js`: `case "StringLiteral": return fromString(nodeStr(n.value, options))` — `extra.raw` は参照されない）。
- recast の quote 設定は**1 つしかなく JSX 属性にも同じ物が効く**。フリートの prettier は JS 文字列 `'…'`（`singleQuote: true`）・JSX 属性 `"…"`（`jsxSingleQuote` 既定 false）。→ **`quote:'single'` でも `'double'` でも必ず片方が崩れる**（payout の現物には両方が同一ファイルに存在する）。

### prettier 固定点の検証（追加依頼分・実測 — over-claim を訂正）

> 指摘: リネームは +2 桁伸びる（`px-inline-md` → `px-x-inline-md`）。`printWidth: 100` を跨ぐ行があれば prettier が折り返したがる＝固定点でなくなる。

**両方の事実を実測し、テストで固定した。**

**① payout 実ツリーでは固定点（緑）** — 移行前ツリー（`eb5f7aa` = #159 の親）に**同梱 codemod を実際に流して** payout の実 `.prettierrc.json` で検査:

```
### [1] 前提: 移行前ツリーは prettier 固定点か
All matched files use Prettier code style!

### [2] 同梱 codemod を実 payout ツリーへ
@hideyukimori/nene2-tokens/codemod@1.0.0 (mapping table v1.0.1, table='common')
plan: 12 token rename(s) → 267 class rename(s)
NOTE  10 rename(s) are re-entrant (e.g. gap-inline-sm → gap-x-inline-sm → …).
codemod — 41 file(s), 133 replacement(s)      ← PR #159 実測「133 置換／41 ファイル」と一致

### [3] 本題: codemod 出力に prettier --check（payout 実 config）
All matched files use Prettier code style!
PRETTIER_EXIT=0

### [4] 100桁超の行数
lines >100 after codemod: 20
```

100 桁超が 20 行あっても緑なのは、**折り返せない class 文字列**は prettier が動かせないから（属性は既に自分の行にある）。

**② ただし一般には保証されない（反例あり — 正直な開示）**: **折り返せる**行が rename で `printWidth` を跨ぐと prettier は再整形したがる。実測した反例:

```
入力（99 桁・prettier 固定点）:
  export const D = () => <div id="yyy…38…yyy" className="px-inline-md" />
codemod 出力（101 桁・固定点でない）:
  export const D = () => <div id="yyy…38…yyy" className="px-x-inline-md" />
prettier が望む形:
  export const D = () => (
    <div id="yyy…38…yyy" className="px-x-inline-md" />
  )
```

→ **README と `codemod-transform.ts` の「入力が prettier 固定点なら出力も固定点」は over-claim だったので訂正した**（commit a21af70）。反例もテストに固定し、再発を防ぐ。この形が出る repo は codemod 後に pinned prettier を流す運用にする（codemod の diff と prettier の diff を別コミットに分ければ splice の利点＝レビュー性は失われない）。**`--format` フラグは足していない**（payout 実ツリーで不要・要相談事項のため独断で実装しない）。

### ③ 既マージ #159 の byte 単位再現

同梱 codemod の出力を **#159 マージ後の実ツリー（`7d1e537`）と全数比較**:

```
identical: 228 / 228        ← TS/TSX 全ファイルが byte 一致
差分があるファイル: src/shared/ui/theme/themes/default.css のみ
```

テーマ CSS だけが違うのは、そこが codemod ではなく `extract → generate` の管轄だから（この検証では未実行）。**同梱ランナーは既マージの実弾 PR を byte 単位で再現する。**

## ⚠ 要判断 — jscodeshift を `dependencies` に置いた影響（lock 全数開示）

`package-lock.json`: **ADDED 83 / REMOVED 0 / CHANGED 1**。

- **dev ではない追加 82 件**（= `@hideyukimori/nene2-tokens` を install する全員に入る）:
  `jscodeshift` `recast` `ast-types` `esprima` `flow-parser` `flow-estree` `tiny-invariant` `neo-async` `tmp` `source-map` `source-map-support` `buffer-from` `pirates` `clone-deep` `shallow-clone` `isobject` `commondir` `find-cache-dir` `pkg-dir`(+`find-up`/`locate-path`/`p-limit`/`p-locate`/`path-exists`) `make-dir`(+`semver`) `pify` `p-try` `lru-cache` `yallist` `gensync` `jsesc` `escalade` `convert-source-map` `browserslist` `baseline-browser-mapping` `caniuse-lite` `electron-to-chromium` `node-releases` `update-browserslist-db` `@jridgewell/{gen-mapping,remapping,resolve-uri,trace-mapping}` ＋ **`@babel/*` 33 件**（`core` `parser` `traverse` `types` `template` `generator` `register` `helpers` `compat-data` `helper-*`×11 `plugin-syntax-{flow,jsx,typescript}` `plugin-transform-*`×7 `preset-flow` `preset-typescript` ＋ネスト `semver`×3）
- **dev のみ追加 1 件**: `@types/jscodeshift@17.3.0`
- **CHANGED 1 件**: `packages/nene2-tokens` の lock 上の version が `1.0.0 → 1.0.1`。**これは私の変更ではなく既存ドリフトの是正** — #27 が package.json を 1.0.1 に上げた際 lock を更新しておらず、`npm install` が追随した（`git diff origin/main -- package.json` に version 行は無い）。

**論点**: T-4 の「同梱」を素直に読むと `dependencies`（install しただけで `npx nene2-tokens codemod` が動く）。ただし `validate` しか使わない repo にも babel/flow-parser 一式が入る。対案は `peerDependencies` ＋ `peerDependenciesMeta.optional`（軽い install・codemod 使用時のみ `npm i -D jscodeshift`・未導入なら fail-closed で案内）。**publish 前に要判断**。実消費者は全 repo とも devDependency 経由なので本番バンドルには入らない。

## テスト

`packages/nene2-tokens/src/codemod.test.ts`（26）・`codemod-transform.test.ts`（19）を追加。

**写像表から導出した rename 対が utility class に正しく当たることの実証**（#15 の要求）:

- `src/__fixtures__/payout-w1-before.css` = **payout#159 の移行前テーマ現物**（PR の diff から復元）
- そこから導出した計画が **PR #159 の実測と完全一致**することを固定:
  - **12 トークン rename**（`--color-accent-contrast → --color-on-accent` ＋ 非契約カテゴリ 11 件の x- 送り）を**順序込みで全数**アサート
  - 契約トークン 8 件（surface/text-primary/accent/danger/shadow-sm 等）が**不変**であること
  - class 翻訳: `px-inline-md → px-x-inline-md`・`py-stack-sm → py-x-stack-sm`・`gap-inline-sm → gap-x-inline-sm`・`rounded-md → rounded-x-md`（×14）・`text-accent-contrast → text-on-accent`（×10）
- **spacing utility 109 箇所**の実ケース模擬（payout 実測値）— 置換数がちょうど 109・全件が x- 送り後の綴りになり **dead 化しない**・`-x-x-` を含まない
- **二重置換の回帰テスト**（`gap-x-x-inline-sm` にならない）
- transform は **payout の実 diff の行を逐語で**入出力に使用（`const base = '…'` の非 JSX class 文字列・`className` 属性・`text-accent-contrast` ボタン）
- 引用符保存（`'…'` は single のまま・JSX は double のまま）・`semi:false` 不変
- AST スコープ: import specifier・コメント・識別子を撃たない
- fail-closed: 未知トークン・写像衝突・class 衝突・構造 error・宣言 0 件・theme 未指定

### 実際に流したコマンドと結果

```
$ npm run check    # type-check / eslint / prettier / vitest / check:cli / check:nene2-check / check:am2-gate
EXIT=0
All matched files use Prettier code style!
 Test Files  21 passed (21)
      Tests  282 passed (282)
AM-2 release gate: PASS — contract 1.0 (color 28 + shadow 4) は凍結記録と一致
```

さらに prettier 固定点テスト 4 本を追加（payout `Button.tsx` 移行前現物での実証・100 桁超の長い className が伸びても緑・反例の固定）。

## 既知の限界（開示）

- **二重実行は壊れる**: テーマ未移行のまま `codemod` を 2 回撃つと `gap-inline-sm → gap-x-inline-sm → gap-x-x-inline-sm`（`gap-x` が Tailwind の実在ルートである字面衝突 = #17）。**正順ならテーマ移行後の計画は空**になり `--check` は緑で固定される（実測）。CLI は該当する再入 rename を `NOTE` 行で開示し、README に順序を明記した。根治は #17 の管轄。
- **CSS ファイルは対象外**: jscodeshift は JS/TS のみ。テーマ本体は `extract → generate` が担当（payout#159 の変更も **41 tsx + テーマ 1 css のみ**で非テーマ CSS は 0 件だったので実害なし）。非テーマ CSS に `var(--)` 参照を持つ repo が出たら別途起票が要る。
- `unmapped`（namespace を跨ぐ rename）は**写像表 v1.0.1 の全 125 エントリでは到達しない**防御枝（機械確認済み）。表が育ったときに silent skip させないための座席で、`deriveClassRenames` の単体テストで固定してある。

## 触れなかったファイル

`codemod-map.ts` は**読むだけで変更していない**（写像判断の正本は表のまま）。`parser.ts` / `themegen.ts` / `validate.ts` / `grammar.ts` / `packages/nene2-standards/**` にも変更は不要だった（`parser.ts` は import のみ）。

## 未実施（誠実性ガード）

- **publish していない**（施主承認後）。`npm pack` は検証用にローカル生成しただけ。
- マージしていない。
- 実 repo（nene-payout 等）への再適用 PR は出していない。上記の payout 現物での一致確認は本リポのテストと tarball E2E の範囲。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

