### PR TITLE
feat(standards): @layer base の家を作る — base.css の場所閉鎖＋element-only 閉文法（ST-08）

### DIFF
--- a/packages/nene2-standards/src/stylelint/index.ts
+++ b/packages/nene2-standards/src/stylelint/index.ts
@@ -21,6 +21,7 @@ const config: Config = {
     'nene2/data-theme-selector-location': true, // [data-theme] は themes/*.css 内のみ（会議R2⑥決定）
     'nene2/layer-components-allowlist': true, // registries 許可リスト（完全一致列挙 — 会議R4 AM-10決定）
     'nene2/layer-legacy-manifest-only': true, // @layer legacy は manifest 列挙ファイルのみ（会議R3⑩M-2決定）
+    'nene2/layer-base-location': true, // @layer base ブロックは base.css 内のみ（ST-08 — base の家は1つ）
     'color-no-hex': true, // 生 hex の theme 外直書き MUST NOT（会議R1⑤決定）
     'function-disallowed-list': ['rgb', 'rgba', 'hsl', 'hsla'], // 色は oklch/color-mix（会議R1⑤決定）
   },
@@ -44,6 +45,12 @@ const config: Config = {
       // .components 対は全ルール @layer components 内（会議R4 AM-9決定）
       files: ['**/src/shared/ui/theme/themes/*.components.css'],
       rules: { 'nene2/all-rules-in-components-layer': true },
+    },
+    {
+      // base.css: @layer base の唯一の家（ST-08）。element-only 閉文法 = AM-9 token-only の双対。
+      // layer-base-location はこのファイルでは当然 green になるため null 化は不要（自己一致）。
+      files: ['**/src/shared/ui/theme/base.css'],
+      rules: { 'nene2/base-element-only': true },
     },
   ],
 };

--- a/packages/nene2-standards/src/stylelint/plugin.ts
+++ b/packages/nene2-standards/src/stylelint/plugin.ts
@@ -317,6 +317,168 @@ themesTokenOnly.ruleName = themesTokenOnlyName;
 themesTokenOnly.messages = themesTokenOnlyMessages;
 
 // ---------------------------------------------------------------------------
+// nene2/layer-base-location — @layer base ブロックは base.css 内のみ（ST-08）
+//
+// AM-9 が themes を token-only に閉じたのと同型の**場所の閉鎖**。これが無いと ST-08 の
+// element-only 閉文法は任意の css で `@layer base { .anything {} }` と書くだけで迂回でき、
+// K-7（規約が用意したカスケード位置に任意スタイルを差し込める）が base 経由で再来する。
+// ---------------------------------------------------------------------------
+export const CANONICAL_BASE_ENTRY = 'src/shared/ui/theme/base.css';
+
+const layerBaseLocationName = ruleName('layer-base-location');
+const layerBaseLocationMessages = ruleMessages(layerBaseLocationName, {
+  rejected: (file: string) =>
+    `@layer base ブロックは ${CANONICAL_BASE_ENTRY} 内のみ（ST-08 — base の家は1つ。` +
+    `index.css は canonical header＋@import のみ〔ST-06〕・themes/*.css は token-only〔AM-9〕）: ${file}`,
+});
+const layerBaseLocation: Rule<true, { file?: string }> = (primary, secondary) => (root, result) => {
+  if (
+    !validateOptions(
+      result,
+      layerBaseLocationName,
+      { actual: primary, possible: [true] },
+      {
+        actual: secondary,
+        possible: { file: [(v: unknown) => typeof v === 'string'] },
+        optional: true,
+      },
+    )
+  ) {
+    return;
+  }
+  const baseEntry = secondary?.file ?? CANONICAL_BASE_ENTRY;
+  const sourceFile = root.source?.input.file?.replaceAll('\\', '/');
+  root.walkAtRules('layer', (atRule) => {
+    // ブロックを持たない @layer 文は順序宣言（canonical cascade header の必須行 — AM-8(a)）
+    // であり base レイヤへのルール投入ではない（#19 と同じ分界）。
+    if (atRule.nodes === undefined) return;
+    if (!layerParamsInclude(atRule.params, 'base')) return;
+    // fail-closed: ファイル名が特定できない（コード断片 lint）場合も場所違反扱い
+    const inBaseEntry = sourceFile !== undefined && sourceFile.endsWith(baseEntry);
+    if (!inBaseEntry) {
+      report({
+        result,
+        ruleName: layerBaseLocationName,
+        node: atRule,
+        message: layerBaseLocationMessages.rejected(sourceFile ?? '(unknown file)'),
+      });
+    }
+  });
+};
+layerBaseLocation.ruleName = layerBaseLocationName;
+layerBaseLocation.messages = layerBaseLocationMessages;
+
+// ---------------------------------------------------------------------------
+// nene2/base-element-only — base.css の閉文法（ST-08・AM-9 の双対）
+//
+// themes = custom property のみ・element 規則 MUST NOT（AM-9）
+// base   = element 規則のみ・custom property MUST NOT（本ルール）
+// の二領域で、両者は排他かつ網羅。class は @layer components の許可リスト制（AM-10）が
+// 唯一の家であり、base に class を書けると許可リスト完全一致列挙が迂回できる（＝K-7 再来）。
+// ---------------------------------------------------------------------------
+const baseElementOnlyName = ruleName('base-element-only');
+const baseElementOnlyMessages = ruleMessages(baseElementOnlyName, {
+  badTopLevel: (desc: string) =>
+    `base.css のトップレベルは @layer base ブロック1個とコメントのみ（ST-08 — ` +
+    `@import による任意 CSS の呼び込み・無レイヤ規則を塞ぐ）: ${desc}`,
+  badAtRule: (name: string) =>
+    `base.css の @layer base 内に @${name} MUST NOT（ST-08 — 許可は @media / @supports のみ）`,
+  badSelector: (selector: string, token: string) =>
+    `base.css は element / universal セレクタのみ・class / id / 属性セレクタ MUST NOT（ST-08 — ` +
+    `class の家は @layer components の許可リスト制〔AM-10 完全一致列挙〕。base に書けると迂回できる）: ` +
+    `"${selector}" の "${token}"`,
+  customProperty: (prop: string) =>
+    `base.css に custom property 宣言 MUST NOT（ST-08 — トークンの家は themes/*.css の @theme。` +
+    `AM-9 token-only の双対）: "${prop}"`,
+});
+
+/** element/universal 以外のセレクタ成分（class / id / 属性）を検出する。 */
+function nonElementTokens(selector: string): string[] {
+  const found: string[] = [];
+  found.push(...classTokens(selector));
+  found.push(...[...selector.matchAll(/#-?[A-Za-z_][\w-]*/g)].map((m) => m[0]));
+  found.push(...[...selector.matchAll(/\[[^\]]*\]/g)].map((m) => m[0]));
+  return found;
+}
+
+const baseElementOnly: Rule = (primary) => (root, result) => {
+  if (!validateOptions(result, baseElementOnlyName, { actual: primary, possible: [true] })) return;
+
+  // (1) トップレベルは @layer base ブロック（＋コメント）のみ
+  let layerBlocks = 0;
+  for (const node of topLevelNodes(root)) {
+    if (node.type === 'comment') continue;
+    if (node.type === 'atrule' && node.name === 'layer' && node.nodes !== undefined) {
+      if (node.params.trim() !== 'base') {
+        report({
+          result,
+          ruleName: baseElementOnlyName,
+          node,
+          message: baseElementOnlyMessages.badTopLevel(`@layer ${node.params}`),
+        });
+        continue;
+      }
+      layerBlocks++;
+      if (layerBlocks > 1) {
+        report({
+          result,
+          ruleName: baseElementOnlyName,
+          node,
+          message: baseElementOnlyMessages.badTopLevel('@layer base ブロックが2個以上'),
+        });
+      }
+      continue;
+    }
+    report({
+      result,
+      ruleName: baseElementOnlyName,
+      node,
+      message: baseElementOnlyMessages.badTopLevel(
+        node.type === 'atrule' ? `@${node.name}` : node.type === 'rule' ? node.selector : node.type,
+      ),
+    });
+  }
+
+  // (2) @layer base 内の at-rule は @media / @supports のみ（@keyframes / 入れ子 @layer / @import を塞ぐ）
+  root.walkAtRules((atRule) => {
+    if (atRule.parent?.type === 'root') return; // (1) の管轄
+    if (atRule.name === 'media' || atRule.name === 'supports') return;
+    report({
+      result,
+      ruleName: baseElementOnlyName,
+      node: atRule,
+      message: baseElementOnlyMessages.badAtRule(atRule.name),
+    });
+  });
+
+  // (3) セレクタは element / universal のみ
+  root.walkRules((rule) => {
+    for (const token of nonElementTokens(rule.selector)) {
+      report({
+        result,
+        ruleName: baseElementOnlyName,
+        node: rule,
+        message: baseElementOnlyMessages.badSelector(rule.selector, token),
+      });
+    }
+  });
+
+  // (4) custom property 宣言 MUST NOT（AM-9 の双対）
+  root.walkDecls((decl) => {
+    if (decl.prop.startsWith('--')) {
+      report({
+        result,
+        ruleName: baseElementOnlyName,
+        node: decl,
+        message: baseElementOnlyMessages.customProperty(decl.prop),
+      });
+    }
+  });
+};
+baseElementOnly.ruleName = baseElementOnlyName;
+baseElementOnly.messages = baseElementOnlyMessages;
+
+// ---------------------------------------------------------------------------
 // nene2/all-rules-in-components-layer — .components 対は全ルール @layer components 内（AM-9）
 // ---------------------------------------------------------------------------
 const allInComponentsName = ruleName('all-rules-in-components-layer');
@@ -354,6 +516,8 @@ const plugins = [
   createPlugin(dataThemeLocationName, dataThemeSelectorLocation),
   createPlugin(componentsAllowlistName, layerComponentsAllowlist),
   createPlugin(legacyManifestName, layerLegacyManifestOnly),
+  createPlugin(layerBaseLocationName, layerBaseLocation),
+  createPlugin(baseElementOnlyName, baseElementOnly),
   createPlugin(themesTokenOnlyName, themesTokenOnly),
   createPlugin(allInComponentsName, allRulesInComponentsLayer),
 ];

--- a/packages/nene2-standards/tests/fixtures/styles/src/shared/ui/theme/base.css
+++ b/packages/nene2-standards/tests/fixtures/styles/src/shared/ui/theme/base.css
@@ -1,0 +1,37 @@
+/* base.css 正例（ST-08） — @layer base の唯一の家。
+   element / universal セレクタのみ・custom property 宣言なし（AM-9 token-only の双対）。
+   内容は nene-vault の現物 @layer base（themes/default.css L123-152・AM-9 違反の置き場）を
+   正準の家へ移した形。値はすべて契約トークン経由。 */
+@layer base {
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  html {
+    -webkit-text-size-adjust: 100%;
+  }
+
+  body {
+    font-family: var(--font-sans);
+    background: var(--color-surface);
+    color: var(--color-text-primary);
+    font-size: var(--text-body);
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  h1,
+  h2,
+  h3 {
+    color: var(--color-x-ink-deep);
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  a {
+    color: inherit;
+  }
+}

--- a/packages/nene2-standards/tests/stylelint-config.test.ts
+++ b/packages/nene2-standards/tests/stylelint-config.test.ts
@@ -99,6 +99,99 @@ describe('canonical cascade header と @theme ブロック（#19 正例較正）
   });
 });
 
+describe('base.css — @layer base の唯一の家（ST-08・K-7 の base 経由再来の閉鎖）', () => {
+  const baseEntry = 'src/shared/ui/theme/base.css';
+
+  async function lintBaseCode(code: string) {
+    const { results } = await stylelint.lint({
+      code,
+      config,
+      codeFilename: path.join(fixtureDir, baseEntry),
+    });
+    return (results[0]?.warnings ?? []).map((w) => ({ rule: w.rule ?? '', text: w.text }));
+  }
+
+  it('正例 base.css（vault 現物の @layer base を正準の家へ移した形）は違反 0', async () => {
+    expect(await lintFile(baseEntry)).toEqual([]);
+  });
+
+  it('class セレクタは FAIL — allowlist 迂回の閉鎖（field 現物 .tnum が該当）', async () => {
+    const warnings = await lintBaseCode(
+      '@layer base {\n  .tnum {\n    font-variant-numeric: tabular-nums;\n  }\n}\n',
+    );
+    const byRule = warnings.filter((w) => w.rule === 'nene2/base-element-only');
+    expect(byRule.some((w) => w.text.includes('.tnum'))).toBe(true);
+  });
+
+  it("子孫位置の class も FAIL（全 class トークン照合 — AM-25' と同型）", async () => {
+    const warnings = await lintBaseCode(
+      '@layer base {\n  body .wrapper {\n    margin: 0;\n  }\n}\n',
+    );
+    expect(
+      warnings.some((w) => w.rule === 'nene2/base-element-only' && w.text.includes('.wrapper')),
+    ).toBe(true);
+  });
+
+  it('id / 属性セレクタも FAIL', async () => {
+    const idWarnings = await lintBaseCode('@layer base {\n  #app {\n    margin: 0;\n  }\n}\n');
+    expect(idWarnings.some((w) => w.rule === 'nene2/base-element-only')).toBe(true);
+    const attrWarnings = await lintBaseCode('@layer base {\n  a[href] {\n    margin: 0;\n  }\n}\n');
+    expect(
+      attrWarnings.some((w) => w.rule === 'nene2/base-element-only' && w.text.includes('[href]')),
+    ).toBe(true);
+  });
+
+  it('custom property 宣言は FAIL — トークンの家は themes/*.css（AM-9 の双対）', async () => {
+    const warnings = await lintBaseCode(
+      '@layer base {\n  html {\n    --color-accent: oklch(0.5 0.1 250);\n  }\n}\n',
+    );
+    expect(
+      warnings.some(
+        (w) => w.rule === 'nene2/base-element-only' && w.text.includes('--color-accent'),
+      ),
+    ).toBe(true);
+  });
+
+  it('トップレベルの @import / 無レイヤ規則 / @layer base 以外は FAIL', async () => {
+    const importWarnings = await lintBaseCode("@import './anything.css';\n");
+    expect(importWarnings.some((w) => w.rule === 'nene2/base-element-only')).toBe(true);
+    const unlayered = await lintBaseCode('body {\n  margin: 0;\n}\n');
+    expect(unlayered.some((w) => w.rule === 'nene2/base-element-only')).toBe(true);
+    const otherLayer = await lintBaseCode(
+      '@layer components {\n  body {\n    margin: 0;\n  }\n}\n',
+    );
+    expect(otherLayer.some((w) => w.rule === 'nene2/base-element-only')).toBe(true);
+  });
+
+  it('@layer base 内の @keyframes は FAIL・@media は許可', async () => {
+    const kf = await lintBaseCode(
+      '@layer base {\n  @keyframes fade {\n    0% {\n      opacity: 0;\n    }\n  }\n}\n',
+    );
+    expect(
+      kf.some((w) => w.rule === 'nene2/base-element-only' && w.text.includes('@keyframes')),
+    ).toBe(true);
+    const media = await lintBaseCode(
+      '@layer base {\n  @media (prefers-reduced-motion: reduce) {\n    * {\n      animation-duration: 0.01ms;\n    }\n  }\n}\n',
+    );
+    expect(media.some((w) => w.rule === 'nene2/base-element-only')).toBe(false);
+  });
+
+  it('base.css 以外の @layer base ブロックは FAIL（場所の閉鎖 — 閉文法の迂回不能化）', async () => {
+    const { results } = await stylelint.lint({
+      code: '@layer base {\n  .anything {\n    margin: 0;\n  }\n}\n',
+      config,
+      codeFilename: path.join(fixtureDir, 'src/app/somewhere.css'),
+    });
+    expect((results[0]?.warnings ?? []).some((w) => w.rule === 'nene2/layer-base-location')).toBe(
+      true,
+    );
+  });
+
+  it('canonical header の @layer 順序宣言文は場所違反にならない（#19 と同じ分界）', async () => {
+    expect(await lintFile('src/index.css')).toEqual([]);
+  });
+});
+
 describe('一般 CSS（テーマ外）', () => {
   it('故意 fail unlayered.css — 無レイヤ・!important・ID・hex・rgb()・[data-theme] 場所違反', async () => {
     const warnings = await lintFile('src/app/unlayered.css');


### PR DESCRIPTION
## 何を直すか

ST-06 の canonical header は `@layer theme, base, vendor, legacy, components, utilities;` を宣言するが、**規約は `base` の authoring 先を1つも定義していない**（起草時の欠落）。`@layer components` には家がある（`themes/*.components.css`＝TH-03・`components/` 群＝ST-04）が、`@layer base` には無い。しかも ST-06 は index.css を「header＋@import のみ」に縛るので、そこにも書けない。

結果、**`@layer base` を持つリポは全員どこかで違反している**（2026-07-15 実測・各リポ origin/main）:

| repo | `@layer base` の場所 | 違反 |
|---|---|---|
| nene-field | `frontend/src/shared/ui/theme/index.css`（`body` ＋ `.tnum`・16行） | ST-06 |
| nene-invoice | `frontend/src/shared/ui/theme/index.css`（`body` 1規則） | ST-06 |
| nene-vault | `frontend/src/shared/ui/theme/themes/default.css` L123-152（`*`/`html`/`body`/`h1,h2,h3`/`a`） | AM-9（themes は token-only） |
| nene-corpus | `frontend/apps/admin/src/index.css`（`html`/`body`） | ST-06（starter レイアウト） |

これは fleet#26（vault 分割）の前提でもある — **base の家が無いままだと分割しても行き場が無い**。

## 設計

`base` の家は **`frontend/src/shared/ui/theme/base.css` ただ1つ**（任意・0 or 1 ファイル）。**2ルールで一組**にして閉じる:

- **`nene2/layer-base-location`**（場所の閉鎖）— `@layer base { … }` ブロックは base.css 内のみ。順序宣言文（ブロックを持たない `@layer …;`）は対象外＝canonical header の必須行（#19 と同じ分界）。
- **`nene2/base-element-only`**（閉文法）— トップレベルは `@layer base` ブロック1個＋コメントのみ／セレクタは element・universal のみ／custom property 宣言 MUST NOT／入れ子 at-rule は `@media`・`@supports` のみ。

場所閉鎖が無いと閉文法は**任意の css で `@layer base { … }` と書くだけで迂回できる**ので、2つで一組です。

## K-7 を base 経由で開け直していないことの検証（この PR の主眼）

AM-9 は dx の指摘 K-7「規約が用意した最強カスケード位置に任意スタイルを差し込める」を塞ぐために themes を token-only にした決定。base で同じ穴を開け直さないことが必須条件でした。

**K-7 の本体はカスケードの強弱ではない**（base は theme の次に弱く、components にも utilities にも負ける）。本体は「**列挙されない authoring 面が生まれること**」です。base に任意の class を書けると、`@layer components` の**許可リスト完全一致列挙（AM-10）が「base に書けばよい」で迂回できる** — カスケードでは負けても、ガバナンス（語彙の列挙）が破れます。よって:

- **class の家は `@layer components` の許可リスト制ただ1つ**（AM-10）→ base は **element-only**
- **トークンの家は `@theme` ただ1つ**（TH-03）→ base は **custom property 宣言不可**（これが無いと `html { --color-x: … }` で token-only 検査を通さずトークンを定義できる）
- **無レイヤの脱出路**（無レイヤは全レイヤに常勝＝literal K-7）→ トップレベル規則を禁止＋`no-unlayered-css` が二重に効く

この2条により **themes（custom property のみ・element 規則は不可）と base（element 規則のみ・custom property は不可）は排他かつ網羅**で、AM-9 の**双対**をなします。

**現物較正**: 実測した4件の `@layer base` のうち本閉文法で red になるのは **field の `.tnum` 1件のみ**で、それは実際に許可リスト外の class（＝真陽性・K-7 パターンが現に野生で発生していた）。残り3件（vault の `*`/`html`/`body`/`h1,h2,h3`/`a`・invoice の `body`・corpus の `html`/`body`）は全て element セレクタで green。

## 台帳を設けない理由（ST-04 との差・意識的な設計判断）

components 群が `{path, maxLines, maxBytes}` の台帳登録制なのは **class 名という無限の語彙**を人間の記憶で列挙させないため（AM-10）。base の語彙は **HTML 要素という有限集合**で、閉文法自体が上界を与えます。さらに base は**正準パス1本・0 or 1 ファイル**で path の可変性が無い（`checks/scan-coverage.ts` の正準許可 `^src/shared/ui/theme/` に既に含まれる — 実測）。登録すべき自由度が無いので台帳は設けず、ST-06 の1:1整合は**ファイル実在**で足ります。

副次的な利点として、**ST-04 の許可リスト台帳（`components-allowlist`）は現時点で未実装**（`registries/schema.ts` の kind 列挙11種に無く、`checks/init-scan.ts` に「許可リストの正本台帳は W1 配線 — skeleton では中央台帳が未定義」と明記）なので、台帳非依存の設計は**配布物と文書が今日同時に成立**します。

## 実装上の分かったこと

`base.css` は `@import './base.css' layer(base);` と**ファイル内 `@layer base { … }` の両方**が要ります（冗長に見えて両方 MUST）。`nene2/no-unlayered-css` は AST 局所（`stylelint/helpers.ts` の `layerAncestorNames` は postcss の親のみを辿り `@import` の `layer()` を見ない）ため、内側の `@layer base` が無いと base.css が無レイヤ CSS として red になります。ST-04 の components 群と同じ形です。

## 検査

- `npm run check` green（type-check / lint / format:check / **246 tests** / check:cli / check:nene2-check / check:am2-gate）
- 新規テスト9本: 正例 green ／ class・子孫位置 class・id・属性・custom property・トップレベル @import・無レイヤ・@keyframes の各 FAIL ／ `@media` は許可 ／ 場所違反の FAIL ／ **canonical header の順序宣言文が場所違反にならないこと**（#19 の回帰防止）
- `check:standards-doc` の rule-id 実在照合: `[S:layer-base-location]` / `[S:base-element-only]` とも配布 config に解決（ok 80→83・**新規 missing 0**）

## 規約文書側（同時 patch 済み）

`_work/reports/2026-07-14-frontend-standards/03-styling-theming.md`（施主裁定「規約 patch は配布物と同時に」に従い同時に更新）:

- **ST-08 新設**（base.css の場所閉鎖＋閉文法＋台帳を持たない理由＋K-7 検証＋正負例）
- **ST-05** ディレクトリ図に `base.css`・欠落補修の実測注記
- **ST-06** 可変域を表に整理（`base.css` の @import ↔ ファイル実在の1:1／components 群 @import ↔ 台帳の1:1）・二重指定が要る理由
- **ST-07** 経路(a) を「index.css ＋ そこから @import される先」に明確化
- **§9** に実測の明示（後述）

## 誠実性の明示（重要）

**ST-06 の canonical header は「正本たる配布物」が存在しません**（実測）: `packages/nene2-standards` 配下に css アセット 0件・`package.json` の `files` は `["dist","registries"]`・`CANONICAL_HEADER` 相当の定数なし・`[C:AM-8(a) バイト同値検査]` の検査器も未実装（`CONFORMANCE_KEYS` に header 系キーが無い）。つまり ST-06 は現時点で**正本不在の条文**です。本 PR はこれを**修正していません**（同梱物・検査器の実装は W0 の未了作業・射程外）。文書 §9 にこの事実を明記しました。

この PR が同時性を満たす形: 文書が張る `[S:layer-base-location]` / `[S:base-element-only]` は**本 PR の配布物に実在**します（`check:standards-doc` の実在照合で確認済み）。

## 別途 issue 化が要る発見（本 PR では触っていません）

`nene2/layer-components-allowlist` に **@keyframes ガードが無い**（`no-unlayered-css` と `all-rules-in-components-layer` にはある）。`@layer components { @keyframes x { 0% {…} } }` は `0%` に class トークンが無いため「class "0%" が未登録」で誤 FAIL します。field の6つの `@keyframes`（現在 index.css トップレベル・ST-06 違反）の行き先を決めるときに当たるので、**`@keyframes` の家**とあわせて別途の論点です。

Refs #26