### PR TITLE
fix(tokens): validate:themes stops claiming fill repairs root @theme parity (#16)

### DIFF
--- a/packages/nene2-tokens/src/validate.test.ts
+++ b/packages/nene2-tokens/src/validate.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { validateThemeSource, type Diagnostic } from './validate.js';
+import { fillSource } from './themegen.js';
 
 const REFERENCE = readFileSync(
   fileURLToPath(new URL('../themes/reference.css', import.meta.url)),
@@ -26,11 +27,23 @@ describe('validate:themes — positive', () => {
 });
 
 describe('validate:themes — negative (each check actually fires)', () => {
-  it('missing contract key = parity error with repair command', () => {
+  it('missing root contract key = parity error that does NOT claim `fill` repairs it (#16 — fill is a no-op on root, TH-03/TH-07: root keys are hand-authored)', () => {
     const broken = REFERENCE.replace(/^\s*--color-scrim:.*$\n/m, '');
     const r = validateThemeSource('t.css', broken);
     expect(rules(r.diagnostics)).toContain('parity');
-    expect(r.diagnostics.find((d) => d.rule === 'parity')!.message).toContain('nene2-tokens fill');
+    const message = r.diagnostics.find((d) => d.rule === 'parity')!.message;
+    expect(message).not.toContain('nene2-tokens fill');
+    expect(message).toContain('no mechanical repair');
+    expect(message).toContain('reference.css');
+  });
+
+  it('#16 negative control: `fill` really is a no-op on root parity errors, so the old REPAIR_FILL message was fail-open (validate still red after "repair")', () => {
+    const broken = REFERENCE.replace(/^\s*--color-scrim:.*$\n/m, '');
+    expect(validateThemeSource('t.css', broken).ok).toBe(false);
+    // running the exact repair the old message advertised does not change the file at all
+    expect(fillSource(broken)).toBe(broken);
+    // ...and validate is therefore still red after "repair"
+    expect(validateThemeSource('t.css', fillSource(broken)).ok).toBe(false);
   });
 
   it('missing pragma = error (theme files are themegen-managed — AM-1)', () => {

--- a/packages/nene2-tokens/src/validate.ts
+++ b/packages/nene2-tokens/src/validate.ts
@@ -47,6 +47,21 @@ export interface ValidateResult {
 
 const REPAIR_FILL = (file: string) => `repair: npx nene2-tokens fill ${file}`;
 
+// root @theme/:root の parity（#5 below）には REPAIR_FILL を出さない: `fill` は局所スコープの
+// fill 領域（TH-06 — 上書きに追従する派生値の再計算）専用であり、root ブロックには何もしない
+// （themegen.ts generateTheme: `isRoot ? new Map() : computeFillForScope(...)` — root は常に
+// fill 領域ゼロ）。root の契約キーは TH-03/TH-07 の設計上「authored 直値」であり、fill 以前に
+// 人手で埋まっている前提（新ブランド手順①copy reference→②authored 編集→③fill）。欠けている
+// ということは、そのキーの値がどのソースにも一度も存在しなかった（例: 旧テーマに info ロールが
+// 無かった）ということであり、ツールに正当な値を発明させる手段がない（#16 — fail-open だった
+// 旧メッセージは `fill` を案内していたが exit 0・無変更で終わり、契約充足を偽装していた）。
+const NO_MECHANICAL_REPAIR_ROOT_PARITY =
+  'no mechanical repair: root @theme keys are authored by hand, not tool-derived (TH-03/TH-07) ' +
+  '— fill only recomputes derived values in local-scope overrides (TH-06), it does not invent ' +
+  'brand base colors for root. Author the missing keys directly, using the closed grammar (TK-04) ' +
+  '— see the packaged reference theme (themes/reference.css) for the expected shape and a ' +
+  'starting value per key, then replace with brand-correct colors.';
+
 function declMap(block: Block): Map<string, string> {
   const m = new Map<string, string>();
   for (const d of block.decls) m.set(d.name, d.value);
@@ -202,7 +217,7 @@ export function validateThemeSource(
     if (missing.length > 0) {
       error(
         'parity',
-        `contract v${CONTRACT_VERSION} keys missing from ${rootBlock.selector} block (${missing.length}): ${missing.join(', ')} — ${REPAIR_FILL(file)}`,
+        `contract v${CONTRACT_VERSION} keys missing from ${rootBlock.selector} block (${missing.length}): ${missing.join(', ')} — ${NO_MECHANICAL_REPAIR_ROOT_PARITY}`,
         rootBlock.line,
       );
     }


### PR DESCRIPTION
## 何を直したか

`validate:themes` は root `@theme` の parity エラー（契約キー欠損）に対して `repair: npx nene2-tokens fill <file>` を案内していたが、`fillSource`/`generateTheme`（`themegen.ts`）は **root ブロックに対して常に fill 領域を空にする**設計（`isRoot ? new Map() : computeFillForScope(...)`）。案内どおり `fill` を実行しても **exit 0・ファイル無変更・エラーは消えない** — 修復コマンドが成功を報告しながら何も直さない fail-open だった。

`validate.ts:205`（parity 検査）のメッセージを、この class のエラーには機械修復が無いことを正直に述べる内容へ変更した。同ファイル内の `contrast` 診断（人間の色判断が要るため元々 REPAIR_FILL を付けていない）と同じ扱いに揃えた形。

## なぜ「fill を root にも効くようにする」ではなく「メッセージ修正」を選んだか（設計判断）

規約現物（`_work/reports/2026-07-14-frontend-standards/03-styling-theming.md`）を読解した結論:

- **TH-03.3**: root `@theme` ブロックは「契約28+4キー＋拡張トークンの**直値**定義」— generator ではなく authored な直値。
- **TH-06**: 「局所スコープブロックの充足は…ツール維持」— fill の対象は**局所スコープのみ**と明記。root には言及がない。
- **TH-07 新ブランド手順**: ①参照テーマを複製 → ②**authored 領域の値を編集**（人手） → ③ fill → ④ check。fill は**authoring の後**に走る工程であり、root の値そのものを生成する工程ではない。
- **README.md**（`packages/nene2-tokens/README.md:17`）: 「`fill`（**局所スコープの**ツール維持）」と配布物自身が明記。

つまり root parity に機械修復パスが無いのは実装の手落ちではなく、規約が意図した設計（brand の基本色はツールが発明できないので人手で埋める）。**T-2 (MUST)**「FAIL メッセージは修復コマンドを含む」は、この implementation の `contrast` エラー（人間の色判断が要る）で既に例外運用されている — root parity も同じ理由でこの前例に倣うのが整合的。

**選択肢として検討したが採らなかった案**: root 版 fill（参照テーマ `themes/reference.css` の値を欠損キーへ機械的に注入）。理由で見送り:
1. 契約の色キー（danger/success/warn/info 等）はブランド固有の色相であり、参照テーマの汎用色を無言で注入すると「直った」ように見えて実は間違ったブランド色が本番に混入するリスクがある（今回のバグより悪い fail-open になりうる）。
2. 実装には `themegen.ts`（`fillSource`/`generateTheme`/`computeFillForScope`）の変更が要る。**このタスクの file ownership は `validate.ts` と対応テストのみ**（`themegen.ts` は並走中の別ブランチ `fix/17-18-24-map-generate` が所有）。
3. shadow/scrim 等ブランド非依存のキーは形式的に導出可能そうだが、それを「部分的にだけ機械補完し残りは拒否する」設計は境界判断（どのキーを機械補完対象にするか）が要り、施主判断が要る規模の変更。

→ **本 PR はこの設計変更を提案する new issue の材料を用意する位置づけ**（必要なら followup issue 化を推奨）。今回のスコープは「壊れた repair 案内を消して正直な案内に置き換える」に限定した。

## 再現（修正前）

```
$ node dist/cli.js validate default.css
ERROR ... [parity] contract v1.0 keys missing from @theme block (13): ... — repair: npx nene2-tokens fill default.css
exit=1

$ node dist/cli.js fill default.css
(no output — file byte-identical, confirmed via diff)
exit=0

$ node dist/cli.js validate default.css
ERROR ... [parity] ... (same 13 keys)   ← 修復と称したコマンドの後もエラーは消えない
exit=1
```

## 実測（修正後）

```
$ node dist/cli.js validate default.css
ERROR ... [parity] contract v1.0 keys missing from @theme block (13): ... — no mechanical repair: root @theme
keys are authored by hand, not tool-derived (TH-03/TH-07) — fill only recomputes derived values in
local-scope overrides (TH-06), it does not invent brand base colors for root. Author the missing keys
directly, using the closed grammar (TK-04) — see the packaged reference theme (themes/reference.css) for
the expected shape and a starting value per key, then replace with brand-correct colors.
exit=1
```

`fill` 自体の挙動は変えていない（root には触れない・依然 no-op）— メッセージがもう嘘をつかないだけ。

## テスト

- 既存の parity テスト（旧: `.toContain('nene2-tokens fill')`）を更新し、新メッセージが `fill` を案内**しない**こと・`no mechanical repair` と `reference.css` を含むことを検証。
- 新規の negative control テストを追加: `fillSource(broken) === broken`（真の no-op であることの実測）と、fill 後も `validate` が red のままであることを直接アサート — このバグのメカニズムそのものを固定化するテスト。
- `closure`（TH-06 W-5・局所スコープ）と `fill`（AM-1 F-1・局所スコープ再生成比較）の既存 REPAIR_FILL 経路は変更していない（root 以外は元々正しく動作している）。

```
$ npm run build     → clean
$ npm test          → 21 files / 292 tests passed（validate.test.ts: 20/20、新規2件含む）
$ npm run lint      → clean
$ npm run format:check → clean（prettier --write 適用済み）
```

## ファイル所有権の遵守

`packages/nene2-tokens/src/validate.ts` と `validate.test.ts` のみ変更。`themegen.ts` / `parser.ts` / `grammar.ts` / `cli.ts` / `codemod*.ts` / `index.ts` / `package.json` / `nene2-standards/**` は未変更（git diff で確認済み・並走ブランチとの衝突なし）。

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)