### PR TITLE
fix(standards): sub-layer を規約の形にする — ルート名予約＋layer-base-location の誤検知是正（ST-06'）

### DIFF
--- a/packages/nene2-standards/src/stylelint/index.ts
+++ b/packages/nene2-standards/src/stylelint/index.ts
@@ -22,6 +22,7 @@ const config: Config = {
     'nene2/layer-components-allowlist': true, // registries 許可リスト（完全一致列挙 — 会議R4 AM-10決定）
     'nene2/layer-legacy-manifest-only': true, // @layer legacy は manifest 列挙ファイルのみ（会議R3⑩M-2決定）
     'nene2/layer-base-location': true, // @layer base ブロックは base.css 内のみ（ST-08 — base の家は1つ）
+    'nene2/no-reserved-sublayer-name': true, // sub-layer 名にルート6レイヤ名の再利用 MUST NOT（ST-06）
     'color-no-hex': true, // 生 hex の theme 外直書き MUST NOT（会議R1⑤決定）
     'function-disallowed-list': ['rgb', 'rgba', 'hsl', 'hsla'], // 色は oklch/color-mix（会議R1⑤決定）
   },

--- a/packages/nene2-standards/src/stylelint/plugin.ts
+++ b/packages/nene2-standards/src/stylelint/plugin.ts
@@ -325,6 +325,16 @@ themesTokenOnly.messages = themesTokenOnlyMessages;
 // ---------------------------------------------------------------------------
 export const CANONICAL_BASE_ENTRY = 'src/shared/ui/theme/base.css';
 
+/** ルート6レイヤ（ST-06 canonical header の順序宣言）。sub-layer 名への再利用は MUST NOT。 */
+export const ROOT_LAYERS = [
+  'theme',
+  'base',
+  'vendor',
+  'legacy',
+  'components',
+  'utilities',
+] as const;
+
 const layerBaseLocationName = ruleName('layer-base-location');
 const layerBaseLocationMessages = ruleMessages(layerBaseLocationName, {
   rejected: (file: string) =>
@@ -352,6 +362,11 @@ const layerBaseLocation: Rule<true, { file?: string }> = (primary, secondary) =>
     // ブロックを持たない @layer 文は順序宣言（canonical cascade header の必須行 — AM-8(a)）
     // であり base レイヤへのルール投入ではない（#19 と同じ分界）。
     if (atRule.nodes === undefined) return;
+    // 入れ子の `@layer base` は sub-layer（例 `components.base`）であって**ルート base
+    // レイヤではない** — 場所違反ではなく「ルート名の sub-layer への再利用」であり、
+    // 診断は no-reserved-sublayer-name の管轄（#33 で本ルールが誤検知し、nene-vault#212 が
+    // sub-layer を base → main へ改名させられた実害の是正）。
+    if (isInAnyLayer(atRule)) return;
     if (!layerParamsInclude(atRule.params, 'base')) return;
     // fail-closed: ファイル名が特定できない（コード断片 lint）場合も場所違反扱い
     const inBaseEntry = sourceFile !== undefined && sourceFile.endsWith(baseEntry);
@@ -367,6 +382,49 @@ const layerBaseLocation: Rule<true, { file?: string }> = (primary, secondary) =>
 };
 layerBaseLocation.ruleName = layerBaseLocationName;
 layerBaseLocation.messages = layerBaseLocationMessages;
+
+// ---------------------------------------------------------------------------
+// nene2/no-reserved-sublayer-name — sub-layer 名にルート6レイヤ名を再利用 MUST NOT（ST-06）
+//
+// 根拠は実測（2026-07-15）: 配布ルールのうち layer-components-allowlist /
+// layer-legacy-manifest-only / layer-base-location の3本は helpers の layerParamsInclude で
+// **レイヤ名を額面どおり**に解釈する。sub-layer がルート名を再利用すると、この3本が
+// 「別レイヤ」を対象レイヤと誤認する:
+//   - `@layer components { @layer base { … } }`   → layer-base-location が誤検知（実測）
+//   - `@layer components { @layer legacy { … } }` → layer-legacy-manifest-only が誤検知（実測）
+// 名前を予約すれば「@layer の param に現れる base は常にルート base」が不変条件として保て、
+// 3本とも祖先を辿らずに健全でいられる。nene-vault#212 は実際に main / responsive を採用済み。
+// ---------------------------------------------------------------------------
+const reservedSublayerName = ruleName('no-reserved-sublayer-name');
+const reservedSublayerMessages = ruleMessages(reservedSublayerName, {
+  rejected: (name: string) =>
+    `sub-layer 名にルートレイヤ名 "${name}" を再利用 MUST NOT（ST-06 — ルート6レイヤ ` +
+    `[${ROOT_LAYERS.join(', ')}] は予約語。"${name}" を sub-layer 名にすると ` +
+    `"<親>.${name}" はルート "${name}" レイヤではないのに、レイヤ名を額面どおり照合する ` +
+    `配布ルール〔layer-components-allowlist / layer-legacy-manifest-only / layer-base-location〕が` +
+    `誤検知する。意匠上の別名〔main / responsive 等〕を使う）`,
+});
+const noReservedSublayerName: Rule = (primary) => (root, result) => {
+  if (!validateOptions(result, reservedSublayerName, { actual: primary, possible: [true] })) return;
+  root.walkAtRules('layer', (atRule) => {
+    // ルート直下の @layer（順序宣言文・ルートレイヤブロック）は sub-layer ではない
+    if (!isInAnyLayer(atRule)) return;
+    // 入れ子の `@layer a, b;`（sub-layer 順序宣言）と `@layer a { … }` の両方を見る
+    for (const raw of atRule.params.split(',')) {
+      const name = raw.trim().split('.')[0]?.trim();
+      if (name !== undefined && (ROOT_LAYERS as readonly string[]).includes(name)) {
+        report({
+          result,
+          ruleName: reservedSublayerName,
+          node: atRule,
+          message: reservedSublayerMessages.rejected(name),
+        });
+      }
+    }
+  });
+};
+noReservedSublayerName.ruleName = reservedSublayerName;
+noReservedSublayerName.messages = reservedSublayerMessages;
 
 // ---------------------------------------------------------------------------
 // nene2/base-element-only — base.css の閉文法（ST-08・AM-9 の双対）
@@ -517,6 +575,7 @@ const plugins = [
   createPlugin(componentsAllowlistName, layerComponentsAllowlist),
   createPlugin(legacyManifestName, layerLegacyManifestOnly),
   createPlugin(layerBaseLocationName, layerBaseLocation),
+  createPlugin(reservedSublayerName, noReservedSublayerName),
   createPlugin(baseElementOnlyName, baseElementOnly),
   createPlugin(themesTokenOnlyName, themesTokenOnly),
   createPlugin(allInComponentsName, allRulesInComponentsLayer),

--- a/packages/nene2-standards/tests/stylelint-config.test.ts
+++ b/packages/nene2-standards/tests/stylelint-config.test.ts
@@ -192,6 +192,71 @@ describe('base.css — @layer base の唯一の家（ST-08・K-7 の base 経由
   });
 });
 
+describe('sub-layer（ST-06 — ルート名予約・nene-vault#212 実測由来）', () => {
+  async function lintAs(code: string, rel: string) {
+    const { results } = await stylelint.lint({
+      code,
+      config,
+      codeFilename: path.join(fixtureDir, rel),
+    });
+    return (results[0]?.warnings ?? []).map((w) => ({ rule: w.rule ?? '', text: w.text }));
+  }
+
+  const COMPONENTS_FILE = 'src/shared/ui/theme/themes/corporate.components.css';
+
+  it('vault 現物の sub-layer 形（main / responsive）は sub-layer 系の違反 0', async () => {
+    const warnings = await lintAs(
+      '@layer components {\n  @layer main, responsive;\n  @layer main { .badge { color: red } }\n' +
+        '  @layer responsive { @media (max-width: 640px) { .badge { color: blue } } }\n}\n',
+      COMPONENTS_FILE,
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-reserved-sublayer-name')).toBe(false);
+    expect(warnings.some((w) => w.rule === 'nene2/layer-base-location')).toBe(false);
+  });
+
+  it('sub-layer 名 base は no-reserved-sublayer-name で落ちる（layer-base-location の誤検知ではなく）', async () => {
+    const warnings = await lintAs(
+      '@layer components {\n  @layer base { .badge { color: red } }\n}\n',
+      COMPONENTS_FILE,
+    );
+    expect(
+      warnings.some((w) => w.rule === 'nene2/no-reserved-sublayer-name' && w.text.includes('base')),
+    ).toBe(true);
+    // #33 の誤検知回帰: 入れ子 base は components.base であってルート base ではない
+    expect(warnings.some((w) => w.rule === 'nene2/layer-base-location')).toBe(false);
+  });
+
+  it('sub-layer 名 legacy も予約語として落ちる（layer-legacy-manifest-only の誤検知も同時に説明）', async () => {
+    const warnings = await lintAs(
+      '@layer components {\n  @layer legacy { .badge { color: red } }\n}\n',
+      COMPONENTS_FILE,
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-reserved-sublayer-name')).toBe(true);
+  });
+
+  it('入れ子の sub-layer 順序宣言文でも予約語を検知する', async () => {
+    const warnings = await lintAs(
+      '@layer components {\n  @layer base, responsive;\n  @layer responsive { .badge { color: red } }\n}\n',
+      COMPONENTS_FILE,
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-reserved-sublayer-name')).toBe(true);
+  });
+
+  it('回帰: base.css 以外のトップレベル @layer base は従来どおり layer-base-location で落ちる', async () => {
+    const warnings = await lintAs(
+      '@layer base {\n  body { margin: 0 }\n}\n',
+      'src/app/somewhere.css',
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/layer-base-location')).toBe(true);
+    expect(warnings.some((w) => w.rule === 'nene2/no-reserved-sublayer-name')).toBe(false);
+  });
+
+  it('回帰: base.css 正例と canonical header 順序宣言文は違反 0 のまま', async () => {
+    expect(await lintFile('src/shared/ui/theme/base.css')).toEqual([]);
+    expect(await lintFile('src/index.css')).toEqual([]);
+  });
+});
+
 describe('一般 CSS（テーマ外）', () => {
   it('故意 fail unlayered.css — 無レイヤ・!important・ID・hex・rgb()・[data-theme] 場所違反', async () => {
     const warnings = await lintFile('src/app/unlayered.css');


### PR DESCRIPTION
施主裁定（2026-07-15）に基づく #33 の是正2件。**#33 で私が入れた条文の欠陥です。**

## (A) ST-06 の `layer(base)` を削除 — **文書のみ・配布物の変更不要（実測）**

#33 で私はこう書きました:

> `base.css` の `@import` は `layer(base)` を伴い、**かつ base.css 内も `@layer base { … }` で包む**（**二重指定は冗長に見えるが**両方 MUST）

**「冗長に見えるが」と違和感を言語化しながら、実測せずに MUST にした**のが誤りでした。冗長ではなく**有害**です。

### 独立実測（Chromium 実 DOM・computed style・preflight は tailwindcss@4.3.2 同梱の実物）

| 形 | `h3` の font-weight |
|---|---|
| `@import './base.css';` ＋ ファイル内 `@layer base`（**是正後**） | **600** ✅ |
| `@import './base.css' layer(base);` ＋ ファイル内 `@layer base`（#33 の形） | **400** ❌ |

CSS Cascade 5 のとおり sub-layer は親レイヤ直下の宣言より**弱く**、Tailwind の preflight は `base` 直下にいるため `base.base` が負けます。nene-vault#212 の報告（14,155 pair 中この1件のみ flip・実 DOM では全 `<h1>` が `.page-title` を持っていたため画面では気づけない）を再現しました。

### 配布物側に検査が要るか → **不要（実測）**

- `git grep layer(base)` → 配布物に**この形を強制する検査は存在しない**（`layer(components)` の実体は `themegen.ts:155` の生成と test fixture のみ）
- canonical header の**同梱物・バイト同値検査は今も未実装**（#33 で報告したとおり。最新 main を再確認 — css アセット 0件・`CONFORMANCE_KEYS` に header 系キーなし）

→ **(A) は文書のみの是正で足ります。** 本 PR に (A) 由来のコード変更はありません。

## (B) sub-layer 形の追認 — ここは配布物の変更が要りました

### 誤検知の実測

`@layer components { @layer base { … } }` を **#33 の `layer-base-location` が「場所違反」として誤検知**します（nene-vault#212 が sub-layer を `base` → `main` へ改名させられた原因）。入れ子の `@layer base` は `components.base` であって**ルート base ではない**ので、これは誤検知です。

**さらに、base だけの問題ではないことが実測で判明しました**:

| 書いた形 | 実測で鳴ったルール | 正しいか |
|---|---|---|
| `@layer components { @layer main, responsive; … }`（vault 現物） | sub-layer 系 **0件** | ✅ |
| `@layer components { @layer base { … } }` | `layer-base-location` | ❌ 誤検知 |
| `@layer components { @layer legacy { … } }` | `layer-legacy-manifest-only` | ❌ 誤検知 |

`layer-components-allowlist` / `layer-legacy-manifest-only` / `layer-base-location` の3本は `helpers.ts` の `layerParamsInclude` で**レイヤ名を額面どおり**に解釈するためです。

### 判断: sub-layer 名の規約は **要る**（ルート6レイヤ名を予約する）

- **`nene2/no-reserved-sublayer-name`（新規）** — sub-layer 名に `theme` / `base` / `vendor` / `legacy` / `components` / `utilities` の再利用を MUST NOT。予約すれば「**`@layer` の param に現れる `base` は常にルート base**」が不変条件として成立し、3本とも祖先を辿らずに健全でいられます。代替案（全ルールを祖先解決へ書き換える）より小さく、将来の検査器も同じ前提に乗れます。vault は既に `main` / `responsive` を採用済みで移行コストは 0。
- **`layer-base-location` を是正** — ルート直下の `@layer base` ブロックのみを見る。入れ子の診断は `no-reserved-sublayer-name` の管轄（1違反1診断）。

### 閉文法との整合の検証

- **base.css 内の sub-layer は ST-08 の閉文法により不可**（入れ子 at-rule は `@media` / `@supports` のみ）— 抵触なし
- `@layer legacy` 内の sub-layer は legacy manifest 制の射程内 — 本条は追加の許可を与えない
- **回帰テスト**: base.css 正例・canonical header の順序宣言文（#19）・非 base.css のトップレベル `@layer base` は従来どおりの判定

## 実物較正（今回の教訓の適用）

**新しい記述はすべて実物1つに当ててから書きました。**

1. **nene-vault#212 の現物テーマ4ファイル**を本 PR の配布 config で lint:

| vault PR#212 現物 | sub-layer/base/文法系 | 台帳系（既知 fail-closed） |
|---|---|---|
| `theme/index.css` | **0** | 0 |
| `theme/base.css` | **0** | 0 |
| `theme/themes/default.css` | **0** | 0 |
| `theme/themes/default.components.css` | **0** | 473（allowlist 未配線＝G-6 既知） |

2. **Chromium 実 DOM** で sub-layer 形の必要性も独立再現:

| 形 | `.tbl.tbl-cards td`（0,2,1） vs `table.tbl td.right`（0,2,2） |
|---|---|
| sub-layer 形（`main` → `responsive`） | **left** — 分割前の意匠を再現 ✅ |
| 平坦な `@layer components` | **right** — 特異度で決まり意匠が壊れる ❌ |

vault 報告の「126要素が右寄せに反転」と整合。代替案「特異度を上げる」は ST-02 の上限 `0,2,0` に抵触するため採れません。

## 🔴 新たに見つけた同種の欠陥（本 PR では直していません・要判断）

**`components.components` も同じ二重指定です。** TH-02/TH-03 が定める `.components.css` の `@import … layer(components)` ＋ ファイル内 `@layer components { … }` は base と同一構造。

**実測**:
- 構造: `components` 直下 vs `components.components` → **直下が勝つ**（base と同じ）
- ただし **Tailwind v4 は `components` 直下に何も出力しない**（`@layer theme, base, components, utilities;` を宣言し実体は theme / base / utilities のみ — tailwindcss@4.3.2 で実測）

→ **現時点で実害なし（latent）**。`components` 直下に規則が現れた時点（プラグインの `addComponents` 等）で base と同じ silent flip が起きます。**TH-02/TH-03 は会議 AM-9 決定の文法**につき本 PR では変更せず、§9 に起票しました。是正の要否は施主・会議の判断事項です。

## 規約文書側（同時 patch 済み）

`_work/reports/2026-07-14-frontend-standards/03-styling-theming.md`:

- **ST-06**: `layer(base)` を削除（:162 表・:173 参照形・:180 条文）。旧条文が誤りだったことと実測表を明記
- **ST-06' 新設**: sub-layer の許可形（vault 現物）＋必要性の実測＋**ルート名予約**
- **§9**: `components.components` の latent な同種欠陥を起票

`check:standards-doc`: rule-id 照合 **ok 83→88・新規 missing 0**（`[S:no-reserved-sublayer-name]` は配布 config に実在）。タグ欠落 MUST は 213→213（増やしていない）。

## 検査

`npm run check` green（type-check / lint / format:check / **306 tests** / check:cli / check:nene2-check / check:am2-gate）。新規テスト6本（vault 現物形 green・予約語 base/legacy の検知・入れ子順序宣言文・回帰3本）。

Refs #26