### PR TITLE
fix(standards): check:exemplars を A-10 準拠へ — 作業ツリーでなく origin/main を読む＋SHA 併記＋検査不能は unknown (#37)

### DIFF
--- a/packages/nene2-standards/src/checks/cli.ts
+++ b/packages/nene2-standards/src/checks/cli.ts
@@ -7,7 +7,9 @@
  *   nene2-check gate-integrity
  *   nene2-check init --scan [--out <file>] / init --check
  *   nene2-check standards-doc --docs <dir> [--out <json>] [--md <file>]
- *   nene2-check exemplars --docs <dir> [--root <dir>] [--out <json>] [--md <file>]
+ *   nene2-check exemplars --docs <dir> [--root <dir>] [--ref <ref>|--worktree] [--no-fetch]
+ *                         [--out <json>] [--md <file>]
+ *     読み取り源の既定は origin/main（規約 02 A-10 — 準拠判定の正）。--worktree は参考値（#37）。
  *
  * 正準シーケンス（type-check → eslint → … → build — 05 §5.1）の駆動は W0b/W1 配線
  * （検査器の空虚合格を出荷しないため、未配線工程は conformance で unknown を出力する）。
@@ -18,6 +20,7 @@ import path from 'node:path';
 
 import { validateConformance } from './conformance.js';
 import { detectRepo } from './detect-repo.js';
+import { gitRefSource, worktreeSource } from './exemplar-source.js';
 import { checkExemplars, renderExemplarsMarkdown, type DocFile } from './exemplars.js';
 import { checkGateIntegrity } from './gate-integrity.js';
 import { initCheck, initScan, ledgersAlreadyInitialized } from './init-scan.js';
@@ -212,7 +215,20 @@ async function main(): Promise<number> {
       if (loaded === null) return 2; // fail-closed（unknown 相当）
       const root = flags.get('root');
       const fleetRoot = path.resolve(typeof root === 'string' ? root : path.join(cwd, '..'));
-      const report = checkExemplars({ files: loaded.files, fleetRoot });
+      // A-10: 準拠判定の正は origin/main。作業ツリー読みは --worktree を明示した場合のみ（参考値・#37）
+      const refFlag = flags.get('ref');
+      if (flags.has('worktree') && typeof refFlag === 'string') {
+        console.error('--worktree と --ref は同時に指定できない');
+        return 2;
+      }
+      const source = flags.has('worktree')
+        ? worktreeSource(fleetRoot)
+        : gitRefSource({
+            fleetRoot,
+            ...(typeof refFlag === 'string' ? { ref: refFlag } : {}),
+            fetch: !flags.has('no-fetch'),
+          });
+      const report = checkExemplars({ files: loaded.files, source });
       const json = JSON.stringify(report, null, 2);
       const out = flags.get('out');
       if (typeof out === 'string') writeFileSync(out, json + '\n');

--- a/packages/nene2-standards/src/checks/exemplar-source.ts
+++ b/packages/nene2-standards/src/checks/exemplar-source.ts
@@ -6,7 +6,7 @@
  * 既定は origin/main を git 経由で読む（#37）。作業ツリー読みは「その枝の事実」＝参考値であり、
  * `worktreeSource` として明示的に選んだ場合にのみ使える（`authoritative: false` で出力に明記される）。
  *
- * fail-closed（CF-1）: fetch 不能・ref 解決不能 = 検査不能 → unknown。green とも red とも言わない。
+ * fail-closed（05 G-6）: fetch 不能・ref 解決不能 = 検査不能 → unknown。green とも red とも言わない。
  *
  * AM-12 hermeticity とは衝突しない: AM-12 の禁止は「リポ CI の per-PR での npm registry 照会」
  * （02:129・minutes.md:625）であり、本検査は fleet-tooling CI で走るクロスリポ検査。同 §5.2 #17 ratchet も
@@ -16,7 +16,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
-/** リポの検査可否。`unavailable` は red ではなく unknown へ寄与する（CF-1）。 */
+/** リポの検査可否。`unavailable` は red ではなく unknown へ寄与する（G-6）。 */
 export type RepoResolution =
   | { kind: 'ready'; sha: string }
   | { kind: 'unavailable'; reason: string };
@@ -24,7 +24,10 @@ export type RepoResolution =
 export interface ExemplarSource {
   /** provenance 表示用のラベル。 */
   readonly label: string;
-  /** origin/main ＝ A-10 の言う準拠判定の正か（false = 参考値）。 */
+  /**
+   * 「検査が走り正の証拠を得た」と言える源か（05 G-6）。false = 参考値であり verdict を出せない。
+   * origin/main を**自ら fetch して**読んだ場合のみ true。
+   */
   readonly authoritative: boolean;
   /** 検査対象リポ群の親ディレクトリ。 */
   readonly fleetRoot: string;
@@ -58,8 +61,11 @@ export interface GitRefSourceOptions {
   /** 読み取る ref（既定 `origin/main` — A-10 の「準拠判定の正」）。 */
   ref?: string;
   /**
-   * 検査前に `git fetch` するか（既定 true）。false は「ref が既に新鮮」と呼び出し側が保証する場合のみ
-   * （CI が事前 fetch 済み等）。stale な origin/main を掴む穴が開くので既定にはしない。
+   * 検査前に `git fetch` するか（既定 true）。
+   *
+   * false にすると ref の鮮度は「呼び出し側の自己申告」になり、検査器は正の証拠を持たない。
+   * よって `authoritative: false`（＝参考値・verdict なし）に落ちる — G-7「被検査者の自己申告を
+   * 正としない」と同じ理由。`--worktree` と同じ扱いで一貫させている。
    */
   fetch?: boolean;
 }
@@ -107,8 +113,11 @@ export function gitRefSource(options: GitRefSourceOptions): ExemplarSource {
   }
 
   return {
-    label: doFetch ? `${ref}（fetch 済み）` : `${ref}（fetch なし）`,
-    authoritative: true,
+    label: doFetch
+      ? `${ref}（fetch 済み）`
+      : `${ref}（fetch なし — 鮮度は呼び出し側の自己申告・参考値）`,
+    // fetch していない ref の鮮度は保証できない。green は「検査が走り正の証拠を得た」場合のみ（G-6）
+    authoritative: doFetch,
     fleetRoot,
     resolveRepo,
     readFile(repo, relPath) {

--- a/packages/nene2-standards/src/checks/exemplar-source.ts
+++ b/packages/nene2-standards/src/checks/exemplar-source.ts
@@ -1,0 +1,165 @@
+/**
+ * check:exemplars の読み取り源（規約 02 A-10 — 準拠判定の正は origin/main ＋ CI・commit SHA 併記 MUST `[P]`）。
+ *
+ * A-10 の根拠事故は「stale なローカル作業ツリー grep で誤った準拠主張をした」こと（R3 記録の訂正1）。
+ * 検査器が作業ツリーを読むと中央実行（fleet-tooling CI — 05 §5.2 #18）で同じ事故を再生産するため、
+ * 既定は origin/main を git 経由で読む（#37）。作業ツリー読みは「その枝の事実」＝参考値であり、
+ * `worktreeSource` として明示的に選んだ場合にのみ使える（`authoritative: false` で出力に明記される）。
+ *
+ * fail-closed（CF-1）: fetch 不能・ref 解決不能 = 検査不能 → unknown。green とも red とも言わない。
+ *
+ * AM-12 hermeticity とは衝突しない: AM-12 の禁止は「リポ CI の per-PR での npm registry 照会」
+ * （02:129・minutes.md:625）であり、本検査は fleet-tooling CI で走るクロスリポ検査。同 §5.2 #17 ratchet も
+ * `merge-base(origin/main, HEAD)` を同じ場所で使っている。
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+/** リポの検査可否。`unavailable` は red ではなく unknown へ寄与する（CF-1）。 */
+export type RepoResolution =
+  | { kind: 'ready'; sha: string }
+  | { kind: 'unavailable'; reason: string };
+
+export interface ExemplarSource {
+  /** provenance 表示用のラベル。 */
+  readonly label: string;
+  /** origin/main ＝ A-10 の言う準拠判定の正か（false = 参考値）。 */
+  readonly authoritative: boolean;
+  /** 検査対象リポ群の親ディレクトリ。 */
+  readonly fleetRoot: string;
+  /** リポの検査可否と commit SHA を確定する（A-10 の SHA 併記 MUST）。 */
+  resolveRepo(repo: string): RepoResolution;
+  /** repo 内の相対パスを読む。null = ファイル不存在。 */
+  readFile(repo: string, relPath: string): string | null;
+}
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync('git', [...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 64 * 1024 * 1024,
+  }).trim();
+}
+
+function isGitRepo(dir: string): boolean {
+  try {
+    return (
+      existsSync(dir) && statSync(dir).isDirectory() && git(dir, ['rev-parse', '--git-dir']) !== ''
+    );
+  } catch {
+    return false;
+  }
+}
+
+export interface GitRefSourceOptions {
+  fleetRoot: string;
+  /** 読み取る ref（既定 `origin/main` — A-10 の「準拠判定の正」）。 */
+  ref?: string;
+  /**
+   * 検査前に `git fetch` するか（既定 true）。false は「ref が既に新鮮」と呼び出し側が保証する場合のみ
+   * （CI が事前 fetch 済み等）。stale な origin/main を掴む穴が開くので既定にはしない。
+   */
+  fetch?: boolean;
+}
+
+/**
+ * origin/main（既定）を git 経由で読む A-10 準拠の読み取り源。
+ * 作業ツリーには一切触れないので、ローカルがどのブランチ・どれだけ dirty でも結果が動かない。
+ */
+export function gitRefSource(options: GitRefSourceOptions): ExemplarSource {
+  const fleetRoot = path.resolve(options.fleetRoot);
+  const ref = options.ref ?? 'origin/main';
+  const doFetch = options.fetch ?? true;
+  const resolved = new Map<string, RepoResolution>();
+
+  function resolveRepo(repo: string): RepoResolution {
+    const cached = resolved.get(repo);
+    if (cached) return cached;
+    const result = resolveUncached(repo);
+    resolved.set(repo, result);
+    return result;
+  }
+
+  function resolveUncached(repo: string): RepoResolution {
+    const dir = path.join(fleetRoot, repo);
+    if (!isGitRepo(dir)) {
+      return { kind: 'unavailable', reason: `git リポジトリが無い: ${path.join(fleetRoot, repo)}` };
+    }
+    if (doFetch) {
+      try {
+        git(dir, ['fetch', '--quiet', 'origin']);
+      } catch (e) {
+        // fetch できない = ref の鮮度を保証できない。stale を掴んだまま数字を出す方が有害（A-10 の事故そのもの）
+        return {
+          kind: 'unavailable',
+          reason: `git fetch 失敗（${ref} の鮮度を保証できない）: ${errText(e)}`,
+        };
+      }
+    }
+    try {
+      const sha = git(dir, ['rev-parse', `${ref}^{commit}`]);
+      return { kind: 'ready', sha };
+    } catch (e) {
+      return { kind: 'unavailable', reason: `${ref} を解決できない: ${errText(e)}` };
+    }
+  }
+
+  return {
+    label: doFetch ? `${ref}（fetch 済み）` : `${ref}（fetch なし）`,
+    authoritative: true,
+    fleetRoot,
+    resolveRepo,
+    readFile(repo, relPath) {
+      const state = resolveRepo(repo);
+      if (state.kind !== 'ready') return null;
+      const dir = path.join(fleetRoot, repo);
+      const spec = `${state.sha}:${relPath}`;
+      try {
+        // cat-file -e で存在を分離してから読む（不存在と git エラーを取り違えないため）
+        git(dir, ['cat-file', '-e', spec]);
+      } catch {
+        return null;
+      }
+      return git(dir, ['show', spec]);
+    },
+  };
+}
+
+/**
+ * ローカル作業ツリーを読む**参考値**の読み取り源（A-10: 「その枝の事実」）。
+ * 準拠判定・批准前提の主張には使えない（`authoritative: false` が出力に出る）。
+ * fixture 検査やローカルでの下書き確認のための逃げ道。
+ */
+export function worktreeSource(fleetRoot: string): ExemplarSource {
+  const root = path.resolve(fleetRoot);
+  return {
+    label: 'ローカル作業ツリー（参考値 — A-10 により準拠判定には使えない）',
+    authoritative: false,
+    fleetRoot: root,
+    resolveRepo(repo) {
+      const dir = path.join(root, repo);
+      // 参考値なので best-effort: git リポでなくても読めるなら読む（SHA は付けられないと明示）
+      try {
+        return { kind: 'ready', sha: isGitRepo(dir) ? git(dir, ['rev-parse', 'HEAD']) : 'n/a' };
+      } catch {
+        return { kind: 'ready', sha: 'n/a' };
+      }
+    },
+    readFile(repo, relPath) {
+      const abs = path.join(root, repo, relPath);
+      try {
+        if (!existsSync(abs) || !statSync(abs).isFile()) return null;
+        return readFileSync(abs, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+function errText(e: unknown): string {
+  const err = e as { stderr?: string; message?: string };
+  return (err.stderr ?? err.message ?? String(e)).toString().trim().split('\n')[0] ?? String(e);
+}

--- a/packages/nene2-standards/src/checks/exemplars.ts
+++ b/packages/nene2-standards/src/checks/exemplars.ts
@@ -14,9 +14,12 @@
  * MUST `[P]`）。作業ツリー読みは参考値であり、`worktreeSource` を明示的に渡した場合のみ（#37）。
  * A-10 の根拠事故（stale なローカル grep による誤った準拠主張）を検査器が再生産していた是正。
  *
- * fail-closed（G-6・CF-1）:
+ * fail-closed（05 G-6 — 「green は『検査が走り正の証拠を得た』場合のみ」）:
  * - [X] 参照が 1 件も見つからない = 入力が規約文書でない可能性 → unknown。
  * - 参照先リポが検査不能（fetch 不能・ref 解決不能）→ unknown。red とも green とも言わない。
+ * - 参考値の源（`worktreeSource` / fetch なし）では **green を出さない** → unknown。
+ *   参考値は「正の証拠」ではないため。red はそのまま出す（枝についての主張としては正しく、
+ *   かつ合格と誤読されない fail-safe 方向）。
  *
  * 未実施（スコープ外の明記）: registries の dangling reason-ref 解決（05 §5.2 #18 の同一機構適用）は
  * W0b — 本実装は規約文書の [X] のみを対象とする。
@@ -57,7 +60,7 @@ export type ExemplarStatus =
   | 'line-number'
   | 'file-missing'
   | 'anchor-missing'
-  /** 参照先リポが検査不能（fetch 不能等）。red ではなく unknown へ寄与する（CF-1）。 */
+  /** 参照先リポが検査不能（fetch 不能等）。red ではなく unknown へ寄与する（G-6）。 */
   | 'repo-unavailable';
 
 export interface ExemplarFinding extends ExemplarRef {
@@ -232,15 +235,21 @@ export function checkExemplars(options: CheckExemplarsOptions): ExemplarsReport 
   }
   if (unavailable.length > 0) {
     details.push(
-      `検査不能 ${unavailable.length} 件 — fail-closed で unknown（CF-1。検査できていないことを ` +
+      `検査不能 ${unavailable.length} 件 — fail-closed で unknown（G-6。検査できていないことを ` +
         'red と言うと「アンカーが無い」という嘘の主張になる）',
     );
   }
   if (!source.authoritative) {
     details.push(
       `読み取り源が ${source.label} — この出力は A-10 により**参考値**であり、` +
-        '準拠判定・批准前提の主張には使えない',
+        '準拠判定・批准前提の主張には使えない（準拠判定には --ref origin/main を fetch ありで使う）',
     );
+    if (findings.length > 0 && failures.length === 0 && unavailable.length === 0) {
+      details.push(
+        '参考値のため green を出さず unknown とした（G-6 — green は「検査が走り正の証拠を得た」場合のみ。' +
+          '参考値は正の証拠ではない）',
+      );
+    }
   }
   details.push(
     `[X] ユニーク参照 ${findings.length} 件: resolved ${resolved} / ` +
@@ -248,12 +257,17 @@ export function checkExemplars(options: CheckExemplarsOptions): ExemplarsReport 
       `（placeholder スキップ ${placeholders.length}・源 ${source.label}）`,
   );
 
+  // G-6: green は「検査が走り正の証拠を得た」場合のみ。参考値の源（作業ツリー / fetch なし）は
+  // 正の証拠ではないので green を出さない。red はそのまま出す（枝についての主張としては正しく、
+  // かつ「合格」と誤読されない fail-safe 方向のため）。
   const state: ExemplarsReport['state'] =
     findings.length === 0 || unavailable.length > 0
       ? 'unknown'
       : failures.length > 0
         ? 'red'
-        : 'green';
+        : source.authoritative
+          ? 'green'
+          : 'unknown';
 
   return {
     state,
@@ -304,7 +318,7 @@ export function renderExemplarsMarkdown(report: ExemplarsReport): string {
   }
   out.push('');
   if (report.unavailable.length > 0) {
-    out.push(`### 検査不能 [X]（${report.unavailable.length} 件 — unknown 寄与・CF-1）`);
+    out.push(`### 検査不能 [X]（${report.unavailable.length} 件 — unknown 寄与・G-6）`);
     out.push('');
     for (const f of report.unavailable) {
       out.push(`- \`[X:${f.content}]\` — ${f.detail}`);

--- a/packages/nene2-standards/src/checks/exemplars.ts
+++ b/packages/nene2-standards/src/checks/exemplars.ts
@@ -10,13 +10,20 @@
  * - タグ文法説明のプレースホルダ（`[X:file#anchor]` / `[X:…#anchor]` / `[X:...]` / `[X:]`）は
  *   照合対象外としてスキップ・件数を報告する。
  *
- * fail-closed（G-6）: [X] 参照が 1 件も見つからない = 入力が規約文書でない可能性 → unknown。
+ * **読み取り源は origin/main が既定**（規約 02 A-10 — 準拠判定の正は origin/main ＋ CI・commit SHA 併記
+ * MUST `[P]`）。作業ツリー読みは参考値であり、`worktreeSource` を明示的に渡した場合のみ（#37）。
+ * A-10 の根拠事故（stale なローカル grep による誤った準拠主張）を検査器が再生産していた是正。
+ *
+ * fail-closed（G-6・CF-1）:
+ * - [X] 参照が 1 件も見つからない = 入力が規約文書でない可能性 → unknown。
+ * - 参照先リポが検査不能（fetch 不能・ref 解決不能）→ unknown。red とも green とも言わない。
  *
  * 未実施（スコープ外の明記）: registries の dangling reason-ref 解決（05 §5.2 #18 の同一機構適用）は
  * W0b — 本実装は規約文書の [X] のみを対象とする。
  */
-import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
+
+import type { ExemplarSource } from './exemplar-source.js';
 
 export interface DocFile {
   path: string;
@@ -49,22 +56,40 @@ export type ExemplarStatus =
   | 'malformed'
   | 'line-number'
   | 'file-missing'
-  | 'anchor-missing';
+  | 'anchor-missing'
+  /** 参照先リポが検査不能（fetch 不能等）。red ではなく unknown へ寄与する（CF-1）。 */
+  | 'repo-unavailable';
 
 export interface ExemplarFinding extends ExemplarRef {
   status: ExemplarStatus;
   detail: string;
 }
 
+/** 検査対象リポの来歴（A-10 — 準拠状況の記載には commit SHA 併記 MUST `[P]`）。 */
+export interface RepoProvenance {
+  repo: string;
+  sha: string | null;
+  /** 検査不能の理由（null = 検査できた）。 */
+  unavailableReason: string | null;
+}
+
 export interface ExemplarsReport {
   state: 'green' | 'red' | 'unknown';
   fleetRoot: string;
+  /** 読み取り源のラベル（'origin/main（fetch 済み）' 等）。 */
+  source: string;
+  /** 読み取り源が A-10 の言う準拠判定の正か（false = 参考値・批准前提の主張に使えない）。 */
+  authoritative: boolean;
+  /** 検査対象リポの SHA 一覧（A-10 の SHA 併記 MUST — repo 昇順で決定的）。 */
+  repos: RepoProvenance[];
   /** placeholder 除外後のユニーク参照数。 */
   refTotal: number;
   resolved: number;
   placeholdersSkipped: string[];
   findings: ExemplarFinding[];
   failures: ExemplarFinding[];
+  /** 検査不能（unknown 寄与）— failures とは別腕。 */
+  unavailable: ExemplarFinding[];
   details: string[];
 }
 
@@ -94,7 +119,7 @@ export function collectExemplarRefs(files: readonly DocFile[]): {
   return { refs: [...byContent.values()], placeholders: [...placeholders].sort() };
 }
 
-function classify(ref: ExemplarRef, fleetRoot: string): ExemplarFinding {
+function classify(ref: ExemplarRef, source: ExemplarSource): ExemplarFinding {
   const hash = ref.content.indexOf('#');
   if (hash < 0) {
     return {
@@ -119,40 +144,85 @@ function classify(ref: ExemplarRef, fleetRoot: string): ExemplarFinding {
   if (target === '' || path.isAbsolute(target) || target.split('/').includes('..')) {
     return { ...ref, status: 'malformed', detail: 'パスは fleet ルート相対の repo/path 形式 MUST' };
   }
-  const abs = path.join(fleetRoot, target);
-  let isFile = false;
-  try {
-    isFile = existsSync(abs) && statSync(abs).isFile();
-  } catch {
-    isFile = false;
+  const slash = target.indexOf('/');
+  if (slash <= 0 || slash === target.length - 1) {
+    return {
+      ...ref,
+      status: 'malformed',
+      detail: 'パスは fleet ルート相対の `repo/path` 形式 MUST（repo 名から始まる）',
+    };
   }
-  if (!isFile) {
-    return { ...ref, status: 'file-missing', detail: `参照先ファイルが存在しない: ${target}` };
+  const repo = target.slice(0, slash);
+  const relPath = target.slice(slash + 1);
+
+  const state = source.resolveRepo(repo);
+  if (state.kind === 'unavailable') {
+    // 検査不能を red と言うと「アンカーが無い」という嘘の主張になる（A-10 の事故の型）
+    return {
+      ...ref,
+      status: 'repo-unavailable',
+      detail: `${repo} を ${source.label} で検査できない: ${state.reason}`,
+    };
   }
-  const body = readFileSync(abs, 'utf8');
+
+  const body = source.readFile(repo, relPath);
+  if (body === null) {
+    return {
+      ...ref,
+      status: 'file-missing',
+      detail: `参照先ファイルが存在しない: ${target}（${source.label}）`,
+    };
+  }
   if (!body.includes(`[${anchor}]`)) {
     return {
       ...ref,
       status: 'anchor-missing',
-      detail: `アンカーコメント \`[${anchor}]\` が ${target} に未植栽`,
+      detail: `アンカーコメント \`[${anchor}]\` が ${target} に未植栽（${source.label}）`,
     };
   }
-  return { ...ref, status: 'resolved', detail: `${target} で解決` };
+  return { ...ref, status: 'resolved', detail: `${target} で解決（${source.label}）` };
 }
 
 export interface CheckExemplarsOptions {
   files: readonly DocFile[];
-  /** 実リポ群の親ディレクトリ（例: /home/xi/docker）。 */
-  fleetRoot: string;
+  /**
+   * 読み取り源。A-10 準拠の既定は `gitRefSource({ fleetRoot })`（origin/main）。
+   * `worktreeSource(fleetRoot)` は参考値であり準拠判定に使えない。
+   */
+  source: ExemplarSource;
 }
 
 export function checkExemplars(options: CheckExemplarsOptions): ExemplarsReport {
+  const { source } = options;
   const { refs, placeholders } = collectExemplarRefs(options.files);
   const findings = refs
-    .map((r) => classify(r, options.fleetRoot))
+    .map((r) => classify(r, source))
     .sort((a, b) => a.content.localeCompare(b.content));
-  const failures = findings.filter((f) => f.status !== 'resolved');
-  const resolved = findings.length - failures.length;
+  const unavailable = findings.filter((f) => f.status === 'repo-unavailable');
+  const failures = findings.filter(
+    (f) => f.status !== 'resolved' && f.status !== 'repo-unavailable',
+  );
+  const resolved = findings.filter((f) => f.status === 'resolved').length;
+
+  // A-10: 準拠状況の記載には commit SHA 併記 MUST。検査に触れた repo を昇順で列挙する
+  const repos: RepoProvenance[] = [
+    ...new Set(
+      findings
+        .map((f) => {
+          const target = f.content.slice(0, Math.max(0, f.content.indexOf('#')));
+          const slash = target.indexOf('/');
+          return slash > 0 ? target.slice(0, slash) : null;
+        })
+        .filter((r): r is string => r !== null),
+    ),
+  ]
+    .sort()
+    .map((repo) => {
+      const state = source.resolveRepo(repo);
+      return state.kind === 'ready'
+        ? { repo, sha: state.sha, unavailableReason: null }
+        : { repo, sha: null, unavailableReason: state.reason };
+    });
 
   const details: string[] = [];
   if (findings.length === 0) {
@@ -160,19 +230,43 @@ export function checkExemplars(options: CheckExemplarsOptions): ExemplarsReport 
       '[X] 参照が 1 件も見つからない — 入力が規約文書でない可能性（fail-closed で unknown）',
     );
   }
+  if (unavailable.length > 0) {
+    details.push(
+      `検査不能 ${unavailable.length} 件 — fail-closed で unknown（CF-1。検査できていないことを ` +
+        'red と言うと「アンカーが無い」という嘘の主張になる）',
+    );
+  }
+  if (!source.authoritative) {
+    details.push(
+      `読み取り源が ${source.label} — この出力は A-10 により**参考値**であり、` +
+        '準拠判定・批准前提の主張には使えない',
+    );
+  }
   details.push(
     `[X] ユニーク参照 ${findings.length} 件: resolved ${resolved} / ` +
-      `失敗 ${failures.length}（placeholder スキップ ${placeholders.length}）`,
+      `失敗 ${failures.length} / 検査不能 ${unavailable.length}` +
+      `（placeholder スキップ ${placeholders.length}・源 ${source.label}）`,
   );
 
+  const state: ExemplarsReport['state'] =
+    findings.length === 0 || unavailable.length > 0
+      ? 'unknown'
+      : failures.length > 0
+        ? 'red'
+        : 'green';
+
   return {
-    state: findings.length === 0 ? 'unknown' : failures.length > 0 ? 'red' : 'green',
-    fleetRoot: options.fleetRoot,
+    state,
+    fleetRoot: source.fleetRoot,
+    source: source.label,
+    authoritative: source.authoritative,
+    repos,
     refTotal: findings.length,
     resolved,
     placeholdersSkipped: placeholders,
     findings,
     failures,
+    unavailable,
     details,
   };
 }
@@ -184,11 +278,39 @@ export function renderExemplarsMarkdown(report: ExemplarsReport): string {
   out.push('');
   out.push(`- 判定: **${report.state}**`);
   out.push(`- fleet ルート: ${report.fleetRoot}`);
+  out.push(`- 読み取り源: **${report.source}**`);
+  if (!report.authoritative) {
+    out.push(
+      '- ⚠️ **この出力は参考値**（A-10 — 準拠判定の正は origin/main ＋ CI。批准前提の主張に使えない）',
+    );
+  }
   out.push(
-    `- ユニーク [X] 参照: **${report.refTotal}**（resolved ${report.resolved} / 失敗 **${report.failures.length}**・` +
-      `placeholder スキップ ${report.placeholdersSkipped.length}）`,
+    `- ユニーク [X] 参照: **${report.refTotal}**（resolved ${report.resolved} / 失敗 **${report.failures.length}** / ` +
+      `検査不能 ${report.unavailable.length}・placeholder スキップ ${report.placeholdersSkipped.length}）`,
   );
   out.push('');
+  out.push('### 検査対象リポの来歴（A-10 — commit SHA 併記 MUST `[P]`）');
+  out.push('');
+  if (report.repos.length === 0) {
+    out.push('なし');
+  } else {
+    out.push('| repo | commit SHA | 検査可否 |');
+    out.push('|---|---|---|');
+    for (const r of report.repos) {
+      out.push(
+        `| ${r.repo} | ${r.sha ?? '—'} | ${r.unavailableReason === null ? 'ok' : `**検査不能** — ${r.unavailableReason.replaceAll('|', '\\|')}`} |`,
+      );
+    }
+  }
+  out.push('');
+  if (report.unavailable.length > 0) {
+    out.push(`### 検査不能 [X]（${report.unavailable.length} 件 — unknown 寄与・CF-1）`);
+    out.push('');
+    for (const f of report.unavailable) {
+      out.push(`- \`[X:${f.content}]\` — ${f.detail}`);
+    }
+    out.push('');
+  }
   out.push(`### 未解決 [X]（${report.failures.length} 件）`);
   out.push('');
   if (report.failures.length === 0) {

--- a/packages/nene2-standards/tests/exemplar-source.test.ts
+++ b/packages/nene2-standards/tests/exemplar-source.test.ts
@@ -3,7 +3,7 @@
  *
  * 中心は**回帰テスト**: 「ローカル作業ツリーが stale でも origin/main の事実を返す」こと。
  * これが壊れると A-10 の根拠事故（stale 計測による誤った準拠主張）を検査器が再生産する
- * ——実際に 2026-07-16 まで再生産しており、判明しているだけで5回踏まれた。
+ * ——実際に 2026-07-16 まで再生産しており、判明しているだけで4回踏まれた。
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
@@ -70,14 +70,14 @@ describe('gitRefSource（A-10 準拠の既定源）', () => {
   it('回帰(#37): ローカル作業ツリーにアンカーが無くても origin/main の事実で resolved・green', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: DOC }],
-      source: gitRefSource({ fleetRoot, fetch: false }),
+      source: gitRefSource({ fleetRoot }),
     });
     expect(report.state).toBe('green');
     expect(report.findings[0]?.status).toBe('resolved');
     expect(report.authoritative).toBe(true);
   });
 
-  it('対の証拠: 同じ入力を作業ツリーで読むと anchor-missing・red になる（これが5回踏まれた罠）', () => {
+  it('対の証拠: 同じ入力を作業ツリーで読むと anchor-missing・red になる（これが4回踏まれた罠）', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: DOC }],
       source: worktreeSource(fleetRoot),
@@ -92,17 +92,17 @@ describe('gitRefSource（A-10 準拠の既定源）', () => {
   it('A-10 の SHA 併記 MUST: repos に検査対象リポの commit SHA が載る', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: DOC }],
-      source: gitRefSource({ fleetRoot, fetch: false }),
+      source: gitRefSource({ fleetRoot }),
     });
     expect(report.repos).toEqual([
       { repo: 'nene-fixture', sha: originSha, unavailableReason: null },
     ]);
   });
 
-  it('fail-closed(CF-1): git リポでない参照先は repo-unavailable → red ではなく unknown', () => {
+  it('fail-closed(G-6): git リポでない参照先は repo-unavailable → red ではなく unknown', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: '[X:not-a-repo/src/a.ts#nene2-exemplar:x]\n' }],
-      source: gitRefSource({ fleetRoot, fetch: false }),
+      source: gitRefSource({ fleetRoot }),
     });
     expect(report.state).toBe('unknown');
     expect(report.unavailable).toHaveLength(1);
@@ -110,10 +110,10 @@ describe('gitRefSource（A-10 準拠の既定源）', () => {
     expect(report.repos[0]?.sha).toBeNull();
   });
 
-  it('fail-closed(CF-1): 検査不能が1件でも混ざれば全体 unknown（resolved があっても green にしない）', () => {
+  it('fail-closed(G-6): 検査不能が1件でも混ざれば全体 unknown（resolved があっても green にしない）', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: `${DOC}[X:not-a-repo/src/a.ts#nene2-exemplar:x]\n` }],
-      source: gitRefSource({ fleetRoot, fetch: false }),
+      source: gitRefSource({ fleetRoot }),
     });
     expect(report.resolved).toBe(1);
     expect(report.state).toBe('unknown');
@@ -122,7 +122,7 @@ describe('gitRefSource（A-10 準拠の既定源）', () => {
   it('存在しない ref は解決不能 → unknown（空虚合格 MUST NOT）', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: DOC }],
-      source: gitRefSource({ fleetRoot, ref: 'origin/no-such-branch', fetch: false }),
+      source: gitRefSource({ fleetRoot, ref: 'origin/no-such-branch' }),
     });
     expect(report.state).toBe('unknown');
     expect(report.unavailable[0]?.detail).toContain('origin/no-such-branch');
@@ -131,16 +131,30 @@ describe('gitRefSource（A-10 準拠の既定源）', () => {
   it('origin/main に無いファイルは file-missing（検査不能とは別腕）', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: '[X:nene-fixture/src/ghost.ts#nene2-exemplar:x]\n' }],
-      source: gitRefSource({ fleetRoot, fetch: false }),
+      source: gitRefSource({ fleetRoot }),
     });
     expect(report.state).toBe('red');
     expect(report.failures[0]?.status).toBe('file-missing');
   });
 
+  it('G-6: --no-fetch は鮮度の自己申告なので authoritative:false → resolved でも green にしない', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: DOC }],
+      source: gitRefSource({ fleetRoot, fetch: false }),
+    });
+    // origin/main の事実としては解決している
+    expect(report.findings[0]?.status).toBe('resolved');
+    expect(report.resolved).toBe(1);
+    // が、fetch していない ref の鮮度は保証できない = 正の証拠がない
+    expect(report.authoritative).toBe(false);
+    expect(report.state).toBe('unknown');
+    expect(report.details.join('\n')).toContain('green は「検査が走り正の証拠を得た」場合のみ');
+  });
+
   it('repo/path 形式でない単一セグメントは malformed', () => {
     const report = checkExemplars({
       files: [{ path: 'doc.md', content: '[X:client.ts#nene2-exemplar:x]\n' }],
-      source: gitRefSource({ fleetRoot, fetch: false }),
+      source: gitRefSource({ fleetRoot }),
     });
     expect(report.failures[0]?.status).toBe('malformed');
   });

--- a/packages/nene2-standards/tests/exemplar-source.test.ts
+++ b/packages/nene2-standards/tests/exemplar-source.test.ts
@@ -1,0 +1,147 @@
+/**
+ * check:exemplars の読み取り源のテスト（規約 02 A-10・#37）。
+ *
+ * 中心は**回帰テスト**: 「ローカル作業ツリーが stale でも origin/main の事実を返す」こと。
+ * これが壊れると A-10 の根拠事故（stale 計測による誤った準拠主張）を検査器が再生産する
+ * ——実際に 2026-07-16 まで再生産しており、判明しているだけで5回踏まれた。
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { gitRefSource, worktreeSource } from '../src/checks/exemplar-source.js';
+import { checkExemplars } from '../src/checks/exemplars.js';
+
+const REL = 'frontend/src/shared/api/client.ts';
+const REF = `nene-fixture/${REL}#nene2-exemplar:api-client`;
+const DOC = `exemplar: [X:${REF}]\n`;
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+}
+
+let fleetRoot: string;
+let repoDir: string;
+let originSha: string;
+
+beforeAll(() => {
+  fleetRoot = mkdtempSync(path.join(tmpdir(), 'nene2-exemplar-fleet-'));
+  const originDir = path.join(fleetRoot, 'origin.git');
+  repoDir = path.join(fleetRoot, 'nene-fixture');
+
+  // origin（bare）— ここの main が A-10 の言う「準拠判定の正」
+  mkdirSync(originDir);
+  git(originDir, ['init', '--bare', '--initial-branch=main', '--quiet']);
+
+  git(fleetRoot, ['clone', '--quiet', originDir, repoDir]);
+  for (const [k, v] of [
+    ['user.email', 'test@example.invalid'],
+    ['user.name', 'test'],
+  ]) {
+    git(repoDir, ['config', k, v]);
+  }
+
+  // origin/main に**アンカーを植えた**状態を作る
+  mkdirSync(path.join(repoDir, path.dirname(REL)), { recursive: true });
+  writeFileSync(
+    path.join(repoDir, REL),
+    '// [nene2-exemplar:api-client]\nexport const client = 1;\n',
+  );
+  git(repoDir, ['add', '-A']);
+  git(repoDir, ['commit', '--quiet', '-m', 'plant anchor']);
+  git(repoDir, ['push', '--quiet', 'origin', 'main']);
+  originSha = git(repoDir, ['rev-parse', 'origin/main']).trim();
+
+  // ローカルを stale にする: 作業ブランチでアンカーを消す（＝実際に vault/origin/invoice で起きていた形）
+  git(repoDir, ['checkout', '--quiet', '-b', 'w1/some-work']);
+  writeFileSync(path.join(repoDir, REL), 'export const client = 1;\n');
+  git(repoDir, ['add', '-A']);
+  git(repoDir, ['commit', '--quiet', '-m', 'local work without anchor']);
+});
+
+afterAll(() => {
+  rmSync(fleetRoot, { recursive: true, force: true });
+});
+
+describe('gitRefSource（A-10 準拠の既定源）', () => {
+  it('回帰(#37): ローカル作業ツリーにアンカーが無くても origin/main の事実で resolved・green', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: DOC }],
+      source: gitRefSource({ fleetRoot, fetch: false }),
+    });
+    expect(report.state).toBe('green');
+    expect(report.findings[0]?.status).toBe('resolved');
+    expect(report.authoritative).toBe(true);
+  });
+
+  it('対の証拠: 同じ入力を作業ツリーで読むと anchor-missing・red になる（これが5回踏まれた罠）', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: DOC }],
+      source: worktreeSource(fleetRoot),
+    });
+    expect(report.state).toBe('red');
+    expect(report.findings[0]?.status).toBe('anchor-missing');
+    // 参考値であることが出力に出ていなければ、読み手はまた stale を信じる
+    expect(report.authoritative).toBe(false);
+    expect(report.details.join('\n')).toContain('参考値');
+  });
+
+  it('A-10 の SHA 併記 MUST: repos に検査対象リポの commit SHA が載る', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: DOC }],
+      source: gitRefSource({ fleetRoot, fetch: false }),
+    });
+    expect(report.repos).toEqual([
+      { repo: 'nene-fixture', sha: originSha, unavailableReason: null },
+    ]);
+  });
+
+  it('fail-closed(CF-1): git リポでない参照先は repo-unavailable → red ではなく unknown', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: '[X:not-a-repo/src/a.ts#nene2-exemplar:x]\n' }],
+      source: gitRefSource({ fleetRoot, fetch: false }),
+    });
+    expect(report.state).toBe('unknown');
+    expect(report.unavailable).toHaveLength(1);
+    expect(report.failures).toHaveLength(0);
+    expect(report.repos[0]?.sha).toBeNull();
+  });
+
+  it('fail-closed(CF-1): 検査不能が1件でも混ざれば全体 unknown（resolved があっても green にしない）', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: `${DOC}[X:not-a-repo/src/a.ts#nene2-exemplar:x]\n` }],
+      source: gitRefSource({ fleetRoot, fetch: false }),
+    });
+    expect(report.resolved).toBe(1);
+    expect(report.state).toBe('unknown');
+  });
+
+  it('存在しない ref は解決不能 → unknown（空虚合格 MUST NOT）', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: DOC }],
+      source: gitRefSource({ fleetRoot, ref: 'origin/no-such-branch', fetch: false }),
+    });
+    expect(report.state).toBe('unknown');
+    expect(report.unavailable[0]?.detail).toContain('origin/no-such-branch');
+  });
+
+  it('origin/main に無いファイルは file-missing（検査不能とは別腕）', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: '[X:nene-fixture/src/ghost.ts#nene2-exemplar:x]\n' }],
+      source: gitRefSource({ fleetRoot, fetch: false }),
+    });
+    expect(report.state).toBe('red');
+    expect(report.failures[0]?.status).toBe('file-missing');
+  });
+
+  it('repo/path 形式でない単一セグメントは malformed', () => {
+    const report = checkExemplars({
+      files: [{ path: 'doc.md', content: '[X:client.ts#nene2-exemplar:x]\n' }],
+      source: gitRefSource({ fleetRoot, fetch: false }),
+    });
+    expect(report.failures[0]?.status).toBe('malformed');
+  });
+});

--- a/packages/nene2-standards/tests/exemplars.test.ts
+++ b/packages/nene2-standards/tests/exemplars.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import { worktreeSource } from '../src/checks/exemplar-source.js';
 import { checkExemplars, collectExemplarRefs } from '../src/checks/exemplars.js';
 
 const FLEET_ROOT = path.join(
@@ -18,7 +19,10 @@ const FLEET_ROOT = path.join(
 const OK_REF = 'nene-alpha/frontend/src/shared/api/client.ts#nene2-exemplar:api-client';
 
 function check(content: string) {
-  return checkExemplars({ files: [{ path: 'doc.md', content }], fleetRoot: FLEET_ROOT });
+  return checkExemplars({
+    files: [{ path: 'doc.md', content }],
+    source: worktreeSource(FLEET_ROOT),
+  });
 }
 
 describe('collectExemplarRefs', () => {

--- a/packages/nene2-standards/tests/exemplars.test.ts
+++ b/packages/nene2-standards/tests/exemplars.test.ts
@@ -47,13 +47,14 @@ describe('collectExemplarRefs', () => {
 });
 
 describe('checkExemplars', () => {
-  it('植栽済みアンカーは resolved・green', () => {
+  it('植栽済みアンカーは resolved（ただし源が作業ツリー＝参考値なので verdict は green にしない — G-6）', () => {
     const r = check(`exemplar: [X:${OK_REF}]\n`);
-    expect(r.state).toBe('green');
     expect(r.findings[0]?.status).toBe('resolved');
+    expect(r.authoritative).toBe(false);
+    expect(r.state).toBe('unknown');
   });
 
-  it('故意 fail: アンカー未植栽は anchor-missing で red', () => {
+  it('故意 fail: アンカー未植栽は anchor-missing で red（参考値でも red は出す — fail-safe 方向）', () => {
     const r = check(
       '[X:nene-alpha/frontend/src/entities/auth/model.ts#nene2-exemplar:auth-store]\n',
     );


### PR DESCRIPTION
Closes #37

## 論点（1PR=1論点）

`check:exemplars` が規約 **02 A-10**（準拠判定の正＝origin/main ＋ CI・commit SHA 併記 MUST `[P]`・会議R3④決定）に違反していた。実装を決定に寄せる（当リポ CLAUDE.md「決定に沿う側へ寄せる」）。

## なぜ重いか

A-10 の制定根拠は**「stale なローカル計測で誤った準拠主張をした事故」**（現状分析 §7「transport import 0/15」— R3 記録の訂正1）。
つまり **A-10 を機械強制するはずの `check:exemplars` 自身が、A-10 が禁じた当の事故を再生産していた**。

判明しているだけで **4回**踏まれている（現状分析の筆者1 → 前任統合リナ1 → 統合リナ1 → fleet-tooling リナ1）。
直近では実態 4/8 を **1/8 と誤報**し、正しかった board.txt:53 を「誤り」と断じかけた。検査器が作業ツリーを読む限り**再発は構造的に確定**していた。

> **訂正（2026-07-16）**: 当初「5回・統合リナ2回」と書いたが誤り（統合リナの申告で是正）。誤報の再発防止が論点の PR で本文が誤報では格好がつかないので明記する。
> 前任統合リナの1件は機序が異なる（FETCH_HEAD ＝共有可変 ref で測って「vault のセレクタ超過 0件」→ 実際48件）が、本質「測定対象が今の正本か確かめなかった」で一致するため**同族として計上**した。

## 変更

- **既定の読み取り源を `origin/main`** に変更。`git show <sha>:<path>` 経由で読み、作業ツリーに一切触れない
- 検査前に `git fetch`。失敗＝ref の鮮度を保証できない → **unknown**（**05 G-6** fail-closed）
- **リポごとの commit SHA を `report.repos` に載せる**（A-10 の SHA 併記 MUST — 従来まったく未実装だった）
- 検査不能を **`repo-unavailable`** として `failures` と別腕に。検査できていないことを red と言うと「アンカーが無い」という**嘘の主張**になるため
- **参考値の源（`--worktree` / `--no-fetch`）では green を出さず unknown**（G-6「green は『検査が走り正の証拠を得た』場合のみ」の直接適用）。これで参考値を exit 0 のゲートとして誤用できない — A-10 の区別が**出力の読み手任せでなく機械強制**になる。red はそのまま出す（枝についての主張としては正しく、「合格」と誤読されない fail-safe 方向）
- `--no-fetch` は `authoritative: false` に落ちる。fetch していない ref の鮮度は「呼び出し側の自己申告」であり検査器は正の証拠を持たない（**G-7**「被検査者の自己申告を正としない」と同型）
- 作業ツリー読みは **`--worktree` を明示した場合のみ**。`authoritative: false` を出力に出し「参考値」と明記
- パスの `repo/path` 形式 MUST を機械化（単一セグメントは malformed）

新 CLI: `nene2-check exemplars --docs <dir> [--root <dir>] [--ref <ref>|--worktree] [--no-fetch]`

## AM-12 hermeticity との関係（衝突しない・確認済み）

AM-12 の禁止は「**リポ CI の per-PR での npm registry 照会**」（02:129・minutes.md:625 — 他人の release で無関係 PR が落ちる flaky ゲートの禁止）。
本検査は 05 §5.2 **#18 のとおり fleet-tooling CI** で走るクロスリポ検査であり、per-PR のリポ CI ではない。
また同表 **#17 ratchet が既に `merge-base(origin/main, HEAD)`** を同じ場所で使っており、git 経由で origin/main を参照するのは確立済みの型。

## レビュー反映（統合リナ・2026-07-16）

- **`--no-fetch` で `authoritative: true` を返すのは穴**という指摘は正しく、設計ミスだった → `authoritative: doFetch` に是正し、上記「参考値は green を出さない」規則で `--worktree` と一本化した
- **典拠の誤りを是正**: 「検査不能は unknown・green は正の証拠を得た場合のみ」は CF-1 ではなく **G-6**（05:22）。CF-1（05:1027）は適合ベクトル出力と完了条件の条文で別物。レビューのやり取りで CF-1 と呼ばれていたのをそのまま転写していた（`conformance.ts` / `run.ts` の CF-1〜4 は適合ベクトルの正しい引用なので不変）
- `--worktree` を残す判断は維持。決め手は統合リナの指摘どおり **A-10 条文自身が「ローカル grep は参考値」と書いており、参考値の存在を禁じていない**（禁じているのは参考値を準拠判定の正とすること）。消すと規約より厳しくなる

## 実測（2026-07-16・全てこの PR の HEAD で実行）

既定（origin/main・fetch あり）— **ローカルが stale/dirty のままでも結果が動かない**:

```
state: red / source: origin/main（fetch 済み） / authoritative: true / resolved: 4 / 8
repo           commit SHA
nene-invoice   5f982ed68423819990afbacaaf1e627fb35461f7
nene-origin    0b41874732b9fa3d4aae07a45a1f9ea1c3998dfe
nene-payout    14433bd5f82b574bcebee1575d21c473ada17c90
nene-records   437c7e2ce7b5f501aad7a79592025fd19bca53f8
nene-vault     5aa5577d9152f31b0e7eff618c61a42c01002deb
```

**4/8 は board.txt:53 と一致**（是正前の実装は同じ入力で 1/8 と誤報していた）。
`--worktree` は従来どおり 1/8 を返すが「参考値 — A-10 により準拠判定には使えない」と明記する。
存在しない ref は exit 2（unknown）で、空虚合格でも偽 red でもない。

- type-check / lint / format:check / **test 315 passed (22 files)** / check:cli / check:nene2-check / check:am2-gate すべて緑
  （注: `npm run lint` はローカルの git 管理外 `.claude/worktrees/` を拾って落ちるが、これは環境由来で CI 対象外。`--ignore-pattern '.claude/**'` で exit 0 を確認済み）

## テスト（回帰の中心）

`tests/exemplar-source.test.ts` で**実際の罠を git で再現**する: bare origin に anchor を植え、ローカル作業ブランチで anchor を消した fixture を作り、

- `gitRefSource` → **resolved・green**（origin/main の事実）
- `worktreeSource` → **anchor-missing・red**（＝5回踏まれた罠そのもの）＋ `authoritative: false`

を対にして固定した。この対が壊れれば A-10 違反の再発が検出される。ほか SHA 併記・検査不能→unknown・resolved 混在時も unknown・ref 解決不能・file-missing との区別・malformed・**`--no-fetch` は resolved でも green にしない**。

## 未実施（明記）

- **初回 red リスト `docs/ratification-red-list-2026-07-14.md` の再生成は本 PR に含めない**（1PR=1論点）。同リストは stale 計測かつ対象リポ SHA 欠落で、記録された規約6文書の sha256 も現物と全て不一致（例: README.md `27aad92b16f83d72` → 現物 `4d9814348d79d1ed`）。**本 PR マージ後に別 PR で再生成**する（順序が逆だと stale を焼き直す）。施主 hide 承認済みの順序。
- registries の dangling reason-ref 解決（05 §5.2 #18 の同一機構適用）は従来どおり W0b スコープ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
