### PR TITLE
fix(standards,tokens): @import の layer() 二重指定を塞ぐ — components.components の是正・severity=error (#42)

### DIFF
--- a/packages/nene2-standards/src/stylelint/index.ts
+++ b/packages/nene2-standards/src/stylelint/index.ts
@@ -23,6 +23,7 @@ const config: Config = {
     'nene2/layer-legacy-manifest-only': true, // @layer legacy は manifest 列挙ファイルのみ（会議R3⑩M-2決定）
     'nene2/layer-base-location': true, // @layer base ブロックは base.css 内のみ（ST-08 — base の家は1つ）
     'nene2/no-reserved-sublayer-name': true, // sub-layer 名にルート6レイヤ名の再利用 MUST NOT（ST-06）
+    'nene2/no-double-layer-import': true, // 自リポ CSS の @import に layer() を付けない（ST-06 — 二重指定）
     'color-no-hex': true, // 生 hex の theme 外直書き MUST NOT（会議R1⑤決定）
     'function-disallowed-list': ['rgb', 'rgba', 'hsl', 'hsla'], // 色は oklch/color-mix（会議R1⑤決定）
   },

--- a/packages/nene2-standards/src/stylelint/plugin.ts
+++ b/packages/nene2-standards/src/stylelint/plugin.ts
@@ -427,6 +427,49 @@ noReservedSublayerName.ruleName = reservedSublayerName;
 noReservedSublayerName.messages = reservedSublayerMessages;
 
 // ---------------------------------------------------------------------------
+// nene2/no-double-layer-import — 自リポ CSS の @import に layer() を付けない（ST-06）
+//
+// レイヤ指定は「@import の layer() か、ファイル内の @layer か、**どちらか一方だけ**」。
+// 自リポの css（相対パス import）は AM-9/ST-08 によりファイル内で `@layer … { … }` に
+// 包むことが MUST なので、@import 側の layer() は**二重指定**になり sub-layer
+// （`components.components` / `base.base`）へ落ちる。sub-layer は親レイヤ直下の規則に
+// **特異度と無関係に負ける**（Chromium 実測 2026-07-15: base は Tailwind preflight に負けて
+// h3 の font-weight 600→400・components は invoice の index.css 残骸に負けて移行時に silent flip）。
+//
+// 適用外（layer() が正しく必須な唯一の形）: vendor CSS の `@import url(…) layer(vendor)`
+// — 第三者 CSS はファイル内に `@layer` を持たないため layer() が唯一のレイヤ指定であり
+// 二重指定にならない【根拠: 会議 AM-8(b)（css RT-A2）— これは会議決定につき変更しない】。
+// ---------------------------------------------------------------------------
+const doubleLayerImportName = ruleName('no-double-layer-import');
+const doubleLayerImportMessages = ruleMessages(doubleLayerImportName, {
+  rejected: (params: string) =>
+    `自リポ CSS の @import に layer() を付けない（ST-06 — レイヤ指定は @import の layer() か ` +
+    `ファイル内の @layer か**どちらか一方だけ**。両方だと sub-layer に落ち、親レイヤ直下の ` +
+    `規則に特異度と無関係に負ける）: "@import ${params}"。ファイル内の @layer だけを残す ` +
+    `（vendor の @import url(…) layer(vendor) は AM-8(b) の適用外）`,
+});
+/** 相対パス（自リポ CSS）の @import か — `url(…)` 形と bare package 形は対象外。 */
+function isFirstPartyImport(params: string): boolean {
+  return /^\s*['"]\.{1,2}\//.test(params);
+}
+const noDoubleLayerImport: Rule = (primary) => (root, result) => {
+  if (!validateOptions(result, doubleLayerImportName, { actual: primary, possible: [true] }))
+    return;
+  root.walkAtRules('import', (atRule) => {
+    if (!isFirstPartyImport(atRule.params)) return;
+    if (!/\blayer\(/.test(atRule.params)) return;
+    report({
+      result,
+      ruleName: doubleLayerImportName,
+      node: atRule,
+      message: doubleLayerImportMessages.rejected(atRule.params),
+    });
+  });
+};
+noDoubleLayerImport.ruleName = doubleLayerImportName;
+noDoubleLayerImport.messages = doubleLayerImportMessages;
+
+// ---------------------------------------------------------------------------
 // nene2/base-element-only — base.css の閉文法（ST-08・AM-9 の双対）
 //
 // themes = custom property のみ・element 規則 MUST NOT（AM-9）
@@ -576,6 +619,7 @@ const plugins = [
   createPlugin(legacyManifestName, layerLegacyManifestOnly),
   createPlugin(layerBaseLocationName, layerBaseLocation),
   createPlugin(reservedSublayerName, noReservedSublayerName),
+  createPlugin(doubleLayerImportName, noDoubleLayerImport),
   createPlugin(baseElementOnlyName, baseElementOnly),
   createPlugin(themesTokenOnlyName, themesTokenOnly),
   createPlugin(allInComponentsName, allRulesInComponentsLayer),

--- a/packages/nene2-standards/src/stylelint/plugin.ts
+++ b/packages/nene2-standards/src/stylelint/plugin.ts
@@ -439,6 +439,13 @@ noReservedSublayerName.messages = reservedSublayerMessages;
 // 適用外（layer() が正しく必須な唯一の形）: vendor CSS の `@import url(…) layer(vendor)`
 // — 第三者 CSS はファイル内に `@layer` を持たないため layer() が唯一のレイヤ指定であり
 // 二重指定にならない【根拠: 会議 AM-8(b)（css RT-A2）— これは会議決定につき変更しない】。
+//
+// 自リポ／vendor の判別は **パスが相対か**で行う（`url()` で包まれているかでは行わない）。
+// 規約 03 §196-199 の表が「ファイル内に @layer が**ある**（自リポ）→ layer() なし」/
+// 「**ない**（第三者 CSS）→ layer() 必須」で分けており、判別の実体は**中身の自己ラップの有無**
+// ＝ 自リポか否か。`url()` はその代理指標にすぎず、`@import url("./x.css") layer(components)` は
+// 自リポなのに vendor 扱いで素通りする（nene-vault リナの指摘 2026-07-16 で発覚。
+// origin/main 全リポ実測では該当 0 件＝実害はなかったが、代理指標のままでは取りこぼす）。
 // ---------------------------------------------------------------------------
 const doubleLayerImportName = ruleName('no-double-layer-import');
 const doubleLayerImportMessages = ruleMessages(doubleLayerImportName, {
@@ -448,9 +455,21 @@ const doubleLayerImportMessages = ruleMessages(doubleLayerImportName, {
     `規則に特異度と無関係に負ける）: "@import ${params}"。ファイル内の @layer だけを残す ` +
     `（vendor の @import url(…) layer(vendor) は AM-8(b) の適用外）`,
 });
-/** 相対パス（自リポ CSS）の @import か — `url(…)` 形と bare package 形は対象外。 */
+/**
+ * 自リポ CSS（＝ファイル内で自己ラップしている側）の @import か。
+ *
+ * 判別は **`url()` の有無ではなくパス**で行う: `url("./x.css")` も `"./x.css"` も同じ自リポ CSS で、
+ * `url()` を vendor の代理指標にすると前者が素通りする。ただし `node_modules` への相対パス
+ * （`url('../../node_modules/katex/dist/katex.css')`）は**相対だが第三者 CSS** なので除外する
+ * — 代理指標を素朴に捨てると、今度は正当な vendor を落とす。
+ *
+ * 対象外: bare package（`'tailwindcss'`）・絶対 URL・`node_modules` 配下。
+ */
 function isFirstPartyImport(params: string): boolean {
-  return /^\s*['"]\.{1,2}\//.test(params);
+  const specifier = /^\s*url\(\s*(.*?)\s*\)/is.exec(params)?.[1] ?? params.trim();
+  const path = specifier.replace(/^\s*['"]|['"]\s*$/g, '');
+  if (!/^\.{1,2}\//.test(path)) return false;
+  return !/(^|\/)node_modules\//.test(path);
 }
 const noDoubleLayerImport: Rule = (primary) => (root, result) => {
   if (!validateOptions(result, doubleLayerImportName, { actual: primary, possible: [true] }))

--- a/packages/nene2-standards/tests/fixtures/styles/src/shared/ui/theme/themes/brand.css
+++ b/packages/nene2-standards/tests/fixtures/styles/src/shared/ui/theme/themes/brand.css
@@ -1,5 +1,5 @@
 /* @nene2-contract 1.0 @themegen 1.0.0 */
-@import './brand.components.css' layer(components);
+@import './brand.components.css';
 
 @theme {
   --color-accent: oklch(0.55 0.15 250);

--- a/packages/nene2-standards/tests/stylelint-config.test.ts
+++ b/packages/nene2-standards/tests/stylelint-config.test.ts
@@ -257,6 +257,62 @@ describe('sub-layer（ST-06 — ルート名予約・nene-vault#212 実測由来
   });
 });
 
+describe('@import の二重レイヤ指定（ST-06 — components.components / base.base の閉鎖）', () => {
+  async function lintAs(code: string, rel: string) {
+    const { results } = await stylelint.lint({
+      code,
+      config,
+      codeFilename: path.join(fixtureDir, rel),
+    });
+    return (results[0]?.warnings ?? []).map((w) => ({ rule: w.rule ?? '', text: w.text }));
+  }
+
+  it('自リポ CSS の @import に layer(components) を付けると FAIL（vault themes/default.css:14 の現物形）', async () => {
+    const warnings = await lintAs(
+      "@import './default.components.css' layer(components);\n@theme {\n  --color-surface: oklch(97% 0.006 75);\n}\n",
+      'src/shared/ui/theme/themes/default.css',
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(true);
+  });
+
+  it('layer() を落とした形は green（是正後）', async () => {
+    const warnings = await lintAs(
+      "@import './default.components.css';\n@theme {\n  --color-surface: oklch(97% 0.006 75);\n}\n",
+      'src/shared/ui/theme/themes/default.css',
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(false);
+  });
+
+  it('index.css の components 群 @import に layer(components) を付けると FAIL', async () => {
+    const warnings = await lintAs(
+      "@import './components/data-table.css' layer(components);\n",
+      'src/shared/ui/theme/index.css',
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(true);
+  });
+
+  it('base.css の @import に layer(base) を付けると FAIL（ST-06 是正の機械強制）', async () => {
+    const warnings = await lintAs("@import './base.css' layer(base);\n", 'src/index.css');
+    expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(true);
+  });
+
+  it('適用外: vendor の @import url(…) layer(vendor) は green（会議 AM-8(b) 決定）', async () => {
+    const warnings = await lintAs(
+      "@import url('../../../node_modules/katex/dist/katex.css') layer(vendor);\n",
+      'src/shared/ui/theme/index.css',
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(false);
+  });
+
+  it("適用外: bare package の @import 'tailwindcss' theme(static) は green", async () => {
+    const warnings = await lintAs(
+      "@import 'tailwindcss' theme(static);\n@import './active.css';\n",
+      'src/shared/ui/theme/index.css',
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(false);
+  });
+});
+
 describe('一般 CSS（テーマ外）', () => {
   it('故意 fail unlayered.css — 無レイヤ・!important・ID・hex・rgb()・[data-theme] 場所違反', async () => {
     const warnings = await lintFile('src/app/unlayered.css');

--- a/packages/nene2-standards/tests/stylelint-config.test.ts
+++ b/packages/nene2-standards/tests/stylelint-config.test.ts
@@ -311,6 +311,33 @@ describe('@import の二重レイヤ指定（ST-06 — components.components / b
     );
     expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(false);
   });
+
+  // 判別は url() の有無でなくパス — url() を vendor の代理指標にすると自リポが素通りする
+  // （nene-vault リナの指摘 2026-07-16。origin/main 全リポ実測では該当 0 件＝実害はなかった）
+  it('url() で包んだ自リポ CSS も FAIL — url() は vendor の代理指標にならない', async () => {
+    for (const params of [
+      'url("./default.components.css") layer(components)',
+      "url('./default.components.css') layer(components)",
+      'url(./default.components.css) layer(components)', // 引用符なし url() も CSS 上は有効
+    ]) {
+      const warnings = await lintAs(
+        `@import ${params};\n`,
+        'src/shared/ui/theme/themes/default.css',
+      );
+      expect(
+        warnings.some((w) => w.rule === 'nene2/no-double-layer-import'),
+        `素通りした: @import ${params}`,
+      ).toBe(true);
+    }
+  });
+
+  it('対の証拠: node_modules への相対 url() は vendor なので green（正当な vendor を落とさない）', async () => {
+    const warnings = await lintAs(
+      "@import url('../../../node_modules/katex/dist/katex.css') layer(vendor);\n",
+      'src/shared/ui/theme/index.css',
+    );
+    expect(warnings.some((w) => w.rule === 'nene2/no-double-layer-import')).toBe(false);
+  });
 });
 
 describe('一般 CSS（テーマ外）', () => {

--- a/packages/nene2-tokens/src/themegen.test.ts
+++ b/packages/nene2-tokens/src/themegen.test.ts
@@ -172,3 +172,27 @@ describe('fill (AM-1 — 局所スコープの充足はツール維持)', () => 
     expect(filled).toContain('@nene2-fill:start');
   });
 });
+
+describe('.components.css の @import — layer() 二重指定の是正（TH-02・2026-07-15）', () => {
+  const OLD = `/* @nene2-contract 1.0 @themegen 1.0.0 */
+@import './default.components.css' layer(components);
+@theme {
+  --color-surface: oklch(97% 0.006 75);
+}
+`;
+  const NEW = OLD.replace("' layer(components)", "'");
+
+  it('寛容な reader: 旧形（layer(components) 付き・移行前の現物）を読める', () => {
+    expect(extractTheme(OLD).componentsImport).toBe('./default.components.css');
+  });
+
+  it('寛容な reader: 新形（layer() 無し）も読める', () => {
+    expect(extractTheme(NEW).componentsImport).toBe('./default.components.css');
+  });
+
+  it('厳格な writer: generate は常に layer() 無しで書く（旧形は再生成で自動是正）', () => {
+    const out = generateTheme(extractTheme(OLD));
+    expect(out).toContain("@import './default.components.css';");
+    expect(out).not.toContain('layer(components)');
+  });
+});

--- a/packages/nene2-tokens/src/themegen.ts
+++ b/packages/nene2-tokens/src/themegen.ts
@@ -152,7 +152,12 @@ export function generateTheme(doc: ThemeDocument, opts: GenerateOptions = {}): s
   }
   const parts: string[] = [`/* @nene2-contract ${doc.contract} @themegen ${THEMEGEN_VERSION} */`];
   if (doc.componentsImport !== undefined) {
-    parts.push(`@import '${doc.componentsImport}' layer(components);`);
+    // `layer(components)` を**付けない**（TH-02 是正・2026-07-15）。.components.css は
+    // ファイル内で全ルールを `@layer components { … }` に包む（AM-9）ため、@import 側にも
+    // layer() を付けると sub-layer `components.components` に入り、root `components` 直下の
+    // 規則に**特異度と無関係に負ける**（Chromium 実測）。レイヤ指定は「@import の layer() か
+    // ファイル内の @layer か、**どちらか一方だけ**」— ST-06 が base で是正したのと同じ形。
+    parts.push(`@import '${doc.componentsImport}';`);
   }
   parts.push(renderBlock(opts.plain ? ':root' : '@theme', rootEntries, []));
 
@@ -239,7 +244,13 @@ export function extractTheme(source: string, opts: ExtractOptions = {}): ThemeDo
     scopes[block.selector] = mapBlock(authoredOnly);
   }
   if (Object.keys(scopes).length > 0) doc.scopes = scopes;
-  const componentsImport = parsed.imports.find((imp) => /layer\(components\)/.test(imp.text));
+  // 寛容な reader / 厳格な writer: 是正前の現物（`… layer(components)` 付き — nene-vault
+  // themes/default.css 等）と是正後（layer() 無し）の**両方**を読む。判別は「対になる
+  // .components.css を指す @import」— TH-02/TH-03 の定義そのもの（layer() の有無に依存しない）。
+  // 生成は常に是正後の形（generateTheme）— 読めた現物は再生成で自動的に是正される。
+  const componentsImport = parsed.imports.find((imp) =>
+    /\.components\.css'\s*(?:layer\()?/.test(imp.text),
+  );
   if (componentsImport) {
     const m = /@import\s+'([^']+)'/.exec(componentsImport.text);
     if (m) doc.componentsImport = m[1]!;


### PR DESCRIPTION
Closes #42

## 論点（1PR=1論点）

ST-06 が `base` で是正したのと**同一構造の欠陥**が components 側に残っている。規約は 2026-07-15 に一般則へ昇格済みで、`[S:no-double-layer-import]` というタグまで書いてあるのに、**配布 config にルールが無い**。それを実装する。

## 規約がルールの存在を前提にしている（実測）

`check:standards-doc` は `[S:no-double-layer-import]` を **3箇所**（03:192・468・747）で **不存在 rule-id（`status: "missing"`）** として検出している。本 PR はこの3件を解消し、**批准前提 (a) の red 内訳を減らす**。

- **03:192** 一般則「レイヤ指定は『`@import` の `layer()`』か『ファイル内の `@layer`』の**どちらか一方だけ**」
- **03:196-199** の表: ファイル内に `@layer` が**ある**（自リポ）→ `layer()` なし / **ない**（第三者 CSS）→ `layer()` 必須
- **03:189** の表に Chromium 実測が採録済み（`base` 側の同型事故: 旧形は preflight に負けて h3 が font-weight **400**、現行形は 600）

## severity=error で入れられる（実測で前提を確認済み）

origin/main 全リポ実測（2026-07-16・A-10 準拠）:

| repo | 違反 |
|---|---|
| nene-vault | 1件 → **vault#214（`08b21bd`）で解消済み** |
| nene2-fleet-tooling | 1件（テスト fixture `brand.css:2`）→ **本 PR で同梱修正** |
| **他の実プロダクト全リポ** | **0件** |

nene-vault リナと **「vault 先 → lint 後」** の順序で合意し、vault 側が先に着地した。よって **warning 先行が不要** — KU-1 が警戒する「後で error に上げ忘れる＝恒久偽 green」を自作せずに済む。

## url() の穴を塞いだ（vault リナの質問から発覚）

vault リナの Q「中身が無ラップなら `layer()` が正しい場面まで落ちないか」を確かめる過程で、逆向きの穴を発見した:

```css
@import url("./x.css") layer(components);   /* 自リポなのに url() 形というだけで素通りしていた */
```

判別を **「url() で包まれているか」→「パスが相対か」** へ寄せた。`url()` は代理指標にすぎない。

**ただし素朴にパスだけで判別すると正当な vendor を落とす** — `url('../../node_modules/katex/dist/katex.css') layer(vendor)` は**相対パスだが第三者 CSS**。ブランチの既存テストがこれを検出したので、`node_modules` 配下を除外している。代理指標を捨てる際に逆の誤りを作りかけた実例。

実測: **url() 形の相対 import は fleet の origin/main に 0 件**＝実害はなかった潜在バグの是正。

## テスト（変異検査済み）

新テストに牙があることを確認した:

- **旧実装**（`url()` = vendor）で新テストが失敗 → `素通りした: @import url("./default.components.css") layer(components)`
- **新実装**で 36 件全緑
- **katex の vendor テストは新旧どちらでも green** ＝ 正当な vendor を落としていない

カバー: vault `themes/default.css:14` の現物形 / 是正後の形 / index.css の components 群 / `base.css` の `layer(base)`（ST-06 是正の機械強制）/ vendor `url(…) layer(vendor)` 適用外 / bare package `'tailwindcss' theme(static)` 適用外 / **url() 3形（`"…"` / `'…'` / 引用符なし）** / node_modules 相対 url()。

## ADR 不要と判定した根拠

- 議事録 `minutes.md:619` の **AM-9 決定文は「`.components.css` は全ルール `@layer components` 内」という*ファイルの文法*のみ**を決めており、`@import` の `layer()` 形は決めていない（議事録に `layer(components)` の語が存在しない）
- 当該行は TH-02 が「（具体化）」と明示した**起草者裁量** → README §改訂経路の**通常改訂＝standards patch レーン**
- stop-the-line ADR は「契約＝トークン語彙の変更」用・ADR 専用レーンは「新レイヤ新設・封印解除」用。本件はどちらでもなく、むしろ**意図せず生まれた sub-layer を消して AM-8(a) 宣言の6レイヤ構造へ戻す是正**
- 会議決定である内側の `@layer components`（AM-9）と vendor の `@import url(…) layer(vendor)`（AM-8(b)）は**変更していない**

## 検査

type-check / eslint / format:check / **test 326 passed (22 files)** / check:cli / check:am2-gate すべて緑（`.claude/` はローカルの git 管理外・CI 対象外）。

## 未実施（明記）

- **このルールが実際に製品リポで走るわけではない**。フリートの **stylelint 配線は 0 リポ**（css を持つ実プロダクト20本・css 227ファイルすべてに依存も設定も無い — 2026-07-16 実測。痕跡があるのは config を書いている fleet-tooling のみ）。配線は **W0b のゲート導入 PR** の仕事であり、本 PR は必要条件であって十分条件ではない。conformance は未配線ゲートを `unknown(not-installed)` として出しており（G-6）、空虚合格は作っていない。
- #39（vendor CSS の行き先が機械強制されていない）は隣接するが別論点で、別レーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)