### PR TITLE
fix(publish): nene2-i18n を publish 可能にする — private 解除＋prepack 欠落の是正（#13 の取りこぼし） (#44)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,9 @@
 #   その後 npm package settings で Trusted Publisher を
 #   Repository=hideyukiMORI/nene2-fleet-tooling / Workflow filename=publish.yml に設定する。
 #
-# nene2-i18n は W0a 骨格につき publish 対象外（package.json も private:true）— W0b で追加。
+# nene2-i18n は W0a 骨格（catalog+parity のみ・translate/plural/format/react は W0b）だが、
+# 実装済みの expectCatalogParity が配られず消費側が手書きテストを量産していたため public 化する
+# （施主 hide 2026-07-15 指示・#44）。API 面が規約 04 §51-55 と食い違う点は同 issue の施主判断待ち。
 name: Publish npm
 
 on:
@@ -19,6 +21,7 @@ on:
         options:
           - nene2-tokens
           - nene2-standards
+          - nene2-i18n
       dry_run:
         description: 'npm publish --dry-run only'
         required: false

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -1,4 +1,4 @@
-# Publish 手順 — nene2-tokens / nene2-standards
+# Publish 手順 — nene2-tokens / nene2-standards / nene2-i18n
 
 `nene2-js` の release flow と同型（[nene2-js docs/development/publish.md](https://github.com/hideyukiMORI/nene2-js/blob/main/docs/development/publish.md)）。
 CI は [Trusted Publishing](https://docs.npmjs.com/trusted-publishers/)（OIDC）— 長命 `NPM_TOKEN` は使わない。
@@ -10,7 +10,7 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 | --- | --- | --- |
 | `@hideyukimori/nene2-tokens` | 1.0.0 | 契約凍結済み（2026-07-14 hide 承認）・publish 待ち |
 | `@hideyukimori/nene2-standards` | 1.0.0 | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）・publish 待ち |
-| `@hideyukimori/nene2-i18n` | — | **W0a 骨格につき publish 対象外**（`private: true`）。W0b で解除 |
+| `@hideyukimori/nene2-i18n` | 0.1.0-rc.1 | `private` 解除済み（#44 — 施主 hide 2026-07-15「パブリックにするべき」）。**版・API 面は施主判断待ち**: 規約 04 §51-55 が要求する `translate` / `/testing` サブパスが実装に存在しない（実装は `.` から `createTranslator` / `expectCatalogParity` を export）。**初回 publish 前に #44 の判断を要する** |
 
 ## 初回 publish（パッケージごとに1回・hide のローカル操作）
 

--- a/packages/nene2-i18n/package.json
+++ b/packages/nene2-i18n/package.json
@@ -16,7 +16,16 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "prepack": "tsc --build"
   },
-  "private": true
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hideyukiMORI/nene2-fleet-tooling.git",
+    "directory": "packages/nene2-i18n"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
 }


### PR DESCRIPTION
Closes #44

施主 hide（2026-07-15）**「nene2-i18n はパブリックにするべきだよ」**。
実装は済んでいるのに `private: true` で誰も使えず、payout は `expectCatalogParity` があるのに**手書き3テスト**を書いていた。

**publish はしない。この PR は「publish できる状態にする」ところまで。版と API の判断は施主待ち。**

## 🔴 最重要: `private` を外すだけでは空パッケージが npm に出る

`#13`（`92040a4`）が他2パッケージで直した実事故が、**nene2-i18n だけ取りこぼされていた**。`private: true` で publish 経路に乗らず、露見しなかった。

> `#13`: `fix(publish): prepack で tsc --build を実行——素の checkout からの publish が dist 欠落の空 tarball になる実事故の修正`
> hide の初回 publish 実測で発覚（**6 files/8.7kB・No bin file found**）

### 実測（素の checkout を再現）

| | prepack 無し（**修正前**） | prepack あり（**本 PR**） |
|---|---|---|
| `npm pack --dry-run` | **2 files / 1.6 kB** | **11 files / 5.8 kB** |
| 中身 | `README.md`・`package.json` のみ — **`dist` 無し** | `dist/` 9ファイル入り |

```
git archive origin/main | tar -x -C <clean>   # dist は .gitignore:2 で未追跡 → 存在しない
cd <clean> && npm ci && npm pack --dry-run --workspace packages/nene2-i18n
```

**`npm publish` は取り消せない**（unpublish は 72h 以内かつ制約付き・以後は不可）。修正前の状態で publish していたら、空パッケージが恒久的に残った。

## 他2パッケージと同形に揃えた（いずれも i18n だけ欠けていた）

| 追加 | 理由 |
|---|---|
| `prepack: "tsc --build"` | 上記の空 tarball 防止 |
| `publishConfig: {access: "public", provenance: true}` | **scoped package は `access` 指定が無いと restricted 扱い＝「public にする」が成立しない**。provenance は OIDC Trusted Publishing で実際に機能している（npm 上の attestation を実測確認: `_npmUser: GitHub Actions / trustedPublisher: github`） |
| `repository`（`directory` つき） | provenance の要件・npm からソースへ辿れる |

## publish 経路も i18n を対象にしていなかった

- **`.github/workflows/publish.yml`**: `package` choice が `nene2-tokens` / `nene2-standards` のみで **i18n を選べなかった** → 追加。「publish 対象外」のコメントを撤回
- **`docs/publish.md`**: 対象表を更新。初回 publish はローカル（Trusted Publisher は既存パッケージにしか設定できない）・provenance は `--provenance=false` で回避、という既存手順がそのまま適用される

## AM-12 の「結合の実体」を実測した（指示書 §2 — 統合リナが未検証と申告した箇所）

**結論: `fleet-baseline.json` は nene2-standards の配布物に同梱されていない。よって fleet-baseline の bump に nene2-standards の再 publish は不要。**

- `packages/nene2-standards/package.json` の `files`: `["dist", "registries"]`
- `npm pack --dry-run` 実測: **85 files** — `dist/**` と `registries/fleet.jsonc` のみ。**`fleet-baseline.json` は入っていない**
- `fleet-baseline.json` は**リポのルート**（`packages/nene2-standards/` の外）＝ **npm は package ディレクトリ外を tarball に入れられない。構造上、同梱は不可能**

### ⚠️ ただし規約 02 A-3 と食い違う（別 issue 相当・本 PR では判定のみ）

> **A-3** semver 範囲は **nene2-standards 配布の** `fleet-baseline.json` 単一マニフェストに一致していること `[C:check:fleet-baseline]`

**「配布の」と書いてあるが配布されていない。** 消費側リポは npm 経由でこのマニフェストを取得できない。
加えて `check:fleet-baseline`（conformance キー `api.fleet-baseline`）は**未実装** — 実測 `unknown(not-installed)`「検査器未配線（W0a skeleton）」。

## 🔴 施主判断が要る論点（本 PR では触っていない）

### (a) 版: `0.1.0-rc.1` のままか `0.1.0` か

### (b) 規約が文書化している API と実装が食い違っている

規約 04-i18n.md:51-55 のエントリポイント表 vs 実装（`src/index.ts` / `exports` は `"."` のみ）:

| 規約が要求 | 実装 |
|---|---|
| `@hideyukimori/nene2-i18n` → `translate`, `plural`, 型 `Locale` | **どれも存在しない**（実体は `createTranslator`） |
| `/format` → `formatNumber` 他 | サブパス不在（W0b・想定内） |
| `/react` → `I18nProvider` 他 | サブパス不在（W0b・想定内） |
| `/testing` → `expectCatalogParity`, `renderWithI18n` | **サブパス不在。ただし `expectCatalogParity` は実装済みで `.` から export されている** |

**このまま publish すると、規約の正例に書かれた import 文が1つも解決しない**:
- `import { translate } from '@hideyukimori/nene2-i18n'`（04:70）→ `translate` は無い
- `import { expectCatalogParity } from '@hideyukimori/nene2-i18n/testing'`（04:432）→ `/testing` が無い

**「API が半分」ではなく「存在する半分も名前とパスが違う」。** `/testing` サブパスを足せば実装済みの `expectCatalogParity` は規約どおりの import で使えるようになるが、同表は `renderWithI18n`（W0b・react）も `/testing` に置いており、部分的なサブパスになる。**設計判断につき実装せず報告する**（指示書 §3-2・CLAUDE.md「設計判断で迷ったら実装せず選択肢と根拠を報告して止まる」）。

### (c) `fleet-baseline.json` の `"@hideyukimori/nene2-i18n": null` → 版範囲

AM-12 の結合。**(a) に従属する**ので触っていない。0.x は minor が破壊的で `^0.1.0` の意味が 1.x と違う。

## 本 PR に含めなかったもの

- **規約 patch**（`05:1080` の後に AM-12 の「publish 手順に fleet-baseline bump を結合」が転記漏れ）: **規約文書は xi-workspace リポにあり、本リポの PR では扱えない** → 統合リナへ回した

## 検査

type-check / eslint / format:check / **test 315 passed (22 files)** / check:am2-gate すべて緑（`.claude/` はローカルの git 管理外・CI 対象外）。
`fleet-baseline.json` は**触っていない**（`null` のまま＝AM-12 の座席は維持）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)