### PR TITLE
chore(publish): nene2-i18n 0.1.0 確定＋fleet-baseline の座席を埋める（AM-12 の結合） (#44)

### DIFF
--- a/docs/fleet-baseline.test.ts
+++ b/docs/fleet-baseline.test.ts
@@ -41,10 +41,12 @@ describe('fleet-baseline.json', () => {
     }
   });
 
-  it('発効済み: client ^1.1.0・tokens/standards ^1.0.0（2026-07-14 npm 公開実測: 39/79 files）・i18n は骨格につき null', () => {
+  it('発効済み: client ^1.1.0・tokens/standards ^1.0.0（2026-07-14 npm 公開実測: 39/79 files）・i18n ^0.1.0（2026-07-16 施主裁定・publish 待ち）', () => {
     expect(baseline.packages['@hideyukimori/nene2-client']).toBe('^1.1.0');
     expect(baseline.packages['@hideyukimori/nene2-tokens']).toBe('^1.0.0');
     expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^1.0.0');
-    expect(baseline.packages['@hideyukimori/nene2-i18n']).toBeNull();
+    // null（座席のみ）→ ^0.1.0。rc で出すと範囲が ^0.1.0-rc.1 になり、それは 0.1.0 も 0.1.1 も
+    // 拾う（semver 実測）ため、版が進んでも全消費リポに prerelease 範囲が残り続ける（#44）
+    expect(baseline.packages['@hideyukimori/nene2-i18n']).toBe('^0.1.0');
   });
 });

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -10,7 +10,7 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 | --- | --- | --- |
 | `@hideyukimori/nene2-tokens` | 1.0.0 | 契約凍結済み（2026-07-14 hide 承認）・publish 待ち |
 | `@hideyukimori/nene2-standards` | 1.0.0 | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）・publish 待ち |
-| `@hideyukimori/nene2-i18n` | 0.1.0-rc.1 | `private` 解除済み（#44 — 施主 hide 2026-07-15「パブリックにするべき」）。**版・API 面は施主判断待ち**: 規約 04 §51-55 が要求する `translate` / `/testing` サブパスが実装に存在しない（実装は `.` から `createTranslator` / `expectCatalogParity` を export）。**初回 publish 前に #44 の判断を要する** |
+| `@hideyukimori/nene2-i18n` | 0.1.0 | `private` 解除済み・**publish 待ち**（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記） |
 
 ## 初回 publish（パッケージごとに1回・hide のローカル操作）
 

--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -5,6 +5,6 @@
     "@hideyukimori/nene2-client": "^1.1.0",
     "@hideyukimori/nene2-tokens": "^1.0.0",
     "@hideyukimori/nene2-standards": "^1.0.0",
-    "@hideyukimori/nene2-i18n": null
+    "@hideyukimori/nene2-i18n": "^0.1.0"
   }
 }

--- a/packages/nene2-i18n/package.json
+++ b/packages/nene2-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-i18n",
-  "version": "0.1.0-rc.1",
+  "version": "0.1.0",
   "description": "NeNe fleet typed i18n — typed catalog + parity (AM-17 final form). W0a skeleton: translate/plural/format/react are W0b.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
#44 の (a)(c)。施主 hide 2026-07-16 裁定: **0.1.0 で publish**（rc ではなく）。

**publish はしていない**（施主のローカル操作・初回のみ）。この PR は版とマニフェストの確定まで。

## 変更

| ファイル | 変更 |
|---|---|
| `packages/nene2-i18n/package.json` | `0.1.0-rc.1` → **`0.1.0`** |
| `fleet-baseline.json` | `"@hideyukimori/nene2-i18n": null` → **`"^0.1.0"`**（AM-12 の座席が埋まる） |
| `docs/fleet-baseline.test.ts` | 腐敗防止ガードを裁定後の値へ（既存の作法どおり来歴を併記） |
| `docs/publish.md` | 対象表を更新 |

## rc でなく 0.1.0 とする根拠（semver で実測・独立に裏取り）

```
^0.1.0      vs 0.1.0-rc.1  → ❌ 拾わない
^0.1.0-rc.1 vs 0.1.0       → ✅ 拾う
^0.1.0-rc.1 vs 0.1.1       → ✅ 拾う
^0.1.0      vs 0.2.0       → ❌（0.x では minor が breaking）
```

**rc で出すと `fleet-baseline` に `^0.1.0-rc.1` と書くしかなく、その範囲は 0.1.0 も 0.1.1 も拾う。** 版が進んでも全消費リポに prerelease 範囲が残り続ける（「ずっと rc」に見える）。`fleet-baseline` は `check:fleet-baseline` が読む**フリートの正本マニフェスト**なので、prerelease 範囲を刻むのは筋が悪い。

加えて:

- rc は「0.1.0 が来る」という約束だが、**W0b で来るのは `/format` `/react` `/testing` のサブパス追加＝0.2.0 相当**（0.x では minor が breaking）。**`rc.1 → 0.1.0` という段階に中身が無い** — 今の API は W0a の**完成形**であって 0.1.0 の候補ではない
- **不完全さは版でなく規約が宣言した**（04 §0 の API 表が「W0a 実装済み / W0b 目標形」を明記 — xi-workspace `320d427`）＝**版に2つの仕事をさせない**
- 0.x 自体が既に「安定保証なし」の signal。rc を重ねると範囲の面倒だけが増える
- 他3本は全部 stable（client 1.1.0 / tokens 1.0.1 / standards 1.0.1）。**i18n だけ rc だと「まだ触るな」に読める**が、実態は逆で **payout に `expectCatalogParity` を今すぐ使わせる**のが publish の目的

## publish 直前の全数目視（`npm pack --dry-run`）

素の checkout を `git archive` で再現し `npm ci` 後に実行（#45 で止めた空パッケージ事故の再発防止 — **`npm publish` は取り消せない**）:

```
📦  @hideyukimori/nene2-i18n@0.1.0
 1.7kB README.md
 1.3kB dist/catalog.d.ts     1.3kB dist/catalog.js     679B dist/catalog.js.map
 456B  dist/index.d.ts       344B  dist/index.js       210B dist/index.js.map
 2.1kB dist/parity.d.ts      3.7kB dist/parity.js      3.5kB dist/parity.js.map
 748B  package.json
filename: hideyukimori-nene2-i18n-0.1.0.tgz
package size: 5.8 kB / unpacked size: 16.1 kB / total files: 11
```

**dist 同梱を確認**（#45 の `prepack` が効いている）・**src 混入なし**・**秘密なし**。

## 落ちたテストを直した（機械的に反転させていない）

`docs/fleet-baseline.test.ts` の腐敗防止ガードが `i18n は骨格につき null` で落ちた。これは**決定された値を実測つきで固定するガード**（タイトルに `2026-07-14 npm 公開実測: 39/79 files` と来歴が入っている）なので、同じ作法で裁定の来歴を併記して更新した。

**追加を見送ったもの**: 「fleet-baseline の範囲が package.json の version を実際に拾う」検査（AM-12 の結合の実効検査）を書いたが、`semver` が**直接依存でなく eslint-plugin-import-x 経由の推移的依存**だったため取り下げた。推移的依存にテストを載せるのは脆く、直接依存を足すのは別論点（1PR=1論点）。**フォローアップ候補**。

## 検査

type-check / eslint / format:check / **test 326 passed (22 files)** / AM-2 release gate PASS（`.claude/` はローカルの git 管理外・CI 対象外）。

## 次（この PR の後）

`docs/publish.md` の手順どおり、**施主のローカル操作で初回 publish** → npm package settings で Trusted Publisher 設定 → 以後は `publish.yml`（#45 で `nene2-i18n` を選べるようにした）。初回はローカルなので provenance は付かない（`--provenance=false`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)