### PR TITLE
fix(tokens): 拡張トークン検査を namespace 表からの導出へ — 道具が自分の生成物を拒否していた（W1 ブロッカー） (#49)

### DIFF
--- a/packages/nene2-tokens/src/codemod-map.ts
+++ b/packages/nene2-tokens/src/codemod-map.ts
@@ -14,7 +14,16 @@
  * x- 送りの個別名は tokens の技術判断（AM-3 の brand-violet 前例と同型 — AI-5 に載せない）。
  */
 
-import { EXCLUDED_NAMESPACES, isContractTokenName, isExtensionTokenName } from './contract.js';
+import {
+  EXCLUDED_NAMESPACES,
+  isContractTokenName,
+  isExtensionTokenName,
+  TAILWIND_V4_NAMESPACES,
+  tailwindNamespaceOf,
+} from './contract.js';
+
+// 表と照合関数の正本は contract.ts（葉）— ここは再輸出のみ（#49。1枚を3つが見る不変条件）
+export { TAILWIND_V4_NAMESPACES, tailwindNamespaceOf };
 
 export const CODEMOD_MAP_VERSION = '1.0.2';
 
@@ -34,41 +43,11 @@ export const CODEMOD_MAP_VERSION = '1.0.2';
  *  - `--font-weight-x-medium` → `.font-x-medium { font-weight: … }`（意味論 保存）
  *  - `--font-x-weight-medium` → `.font-x-weight-medium { font-family: … }`（意味論 破壊）
  */
-export const TAILWIND_V4_NAMESPACES: readonly string[] = [
-  // multi-segment（naive な「先頭セグメント直後に x-」だと割れる — #17 の本体）
-  'inset-shadow',
-  'text-shadow',
-  'drop-shadow',
-  'font-weight',
-  // single-segment
-  'shadow',
-  'color',
-  'spacing',
-  'radius',
-  'font',
-  'text',
-  'leading',
-  'tracking',
-  'breakpoint',
-  'container',
-  'ease',
-  'animate',
-  'blur',
-  'perspective',
-  'aspect',
-];
 
 /**
  * トークン名の namespace を返す（既知 v4 namespace を長い順に照合 → 失敗時は先頭セグメント）。
  * 未知 namespace（`--z-*` 等）は先頭セグメントを返す＝従来挙動を保存する。
  */
-export function tailwindNamespaceOf(token: string): string | null {
-  for (const ns of TAILWIND_V4_NAMESPACES) {
-    if (token.startsWith(`--${ns}-`)) return ns;
-  }
-  const m = /^--([a-z][a-z0-9]*(?:-[a-z0-9]+)*?)-/.exec(token);
-  return m ? m[1]! : null;
-}
 
 export type MappingTableId = 'common' | 'origin' | 'vault' | 'suite';
 

--- a/packages/nene2-tokens/src/contract.test.ts
+++ b/packages/nene2-tokens/src/contract.test.ts
@@ -64,6 +64,19 @@ describe('Core Token Contract v1', () => {
     expect(isExtensionTokenName('--color-x-approved')).toBe(true);
     expect(isExtensionTokenName('--shadow-x-glow')).toBe(true);
     expect(isExtensionTokenName('--color-approved')).toBe(false);
+
+    // #49 回帰: multi-segment namespace。#35 が生成側を --font-weight-x-medium へ是正した後、
+    // 検査側だけが独自 regex（cat 部 [a-z][a-z0-9]*）のままで**自分の生成物を拒否**していた
+    expect(isExtensionTokenName('--font-weight-x-medium')).toBe(true);
+    expect(isExtensionTokenName('--inset-shadow-x-glow')).toBe(true);
+    expect(isExtensionTokenName('--text-shadow-x-sm')).toBe(true);
+
+    // namespace は表の実在名のみ — color-text は v4 namespace ではない
+    expect(isExtensionTokenName('--color-text-x-foo')).toBe(false);
+
+    // font namespace の合法な拡張トークン名。codemod が今この形を生成しない（#17 で
+    // --font-weight-x-medium へ是正）だけで、「旧実装が吐いた形だから拒否」ではない
+    expect(isExtensionTokenName('--font-x-weight-medium')).toBe(true);
   });
 
   it('contrast pair table only references contract keys', () => {
@@ -71,6 +84,33 @@ describe('Core Token Contract v1', () => {
       expect(COLOR_KEYS).toContain(p.fg);
       expect(COLOR_KEYS).toContain(p.bg);
       expect([3, 4.5]).toContain(p.min);
+    }
+  });
+});
+
+describe('#49 — 生成側の出力を検査側が受理する（道具が自分の生成物を拒否しない）', () => {
+  it('mapTokenName の x- 送り出力は isExtensionTokenName を通る', async () => {
+    const { mapTokenName } = await import('./codemod-map.js');
+    for (const src of [
+      '--font-weight-medium',
+      '--font-weight-bold',
+      '--inset-shadow-glow',
+      '--text-shadow-sm',
+    ]) {
+      const mapped = mapTokenName(src);
+      const name = typeof mapped === 'string' ? mapped : (mapped?.name ?? null);
+      expect(name, `${src} が写像されない`).not.toBeNull();
+      expect(
+        isExtensionTokenName(name as string),
+        `生成側が ${src} → ${name} を出すのに検査側が拒否する`,
+      ).toBe(true);
+    }
+  });
+
+  it('EXTENSION_TOKEN_PATTERN は namespace 表から導出される（手書き regex へ戻さない）', async () => {
+    const { TAILWIND_V4_NAMESPACES } = await import('./contract.js');
+    for (const ns of TAILWIND_V4_NAMESPACES) {
+      expect(isExtensionTokenName(`--${ns}-x-probe`), `${ns} が拡張形を作れない`).toBe(true);
     }
   });
 });

--- a/packages/nene2-tokens/src/contract.ts
+++ b/packages/nene2-tokens/src/contract.ts
@@ -85,15 +85,79 @@ export const CONTRACT_TOKENS = {
   names: [...COLOR_TOKEN_NAMES, ...SHADOW_TOKEN_NAMES] as readonly ContractTokenName[],
 } as const;
 
-/** 拡張トークンの登録名前空間 — カテゴリ一般形 `--<cat>-x-<name>`（AM-3） */
-export const EXTENSION_TOKEN_PATTERN = /^--([a-z][a-z0-9]*)-x-([a-z0-9]+(?:-[a-z0-9]+)*)$/;
+/**
+ * Tailwind v4 の namespace 表 — **フリート唯一の1枚**（#17・#35・#49）。
+ *
+ * x- 送り（`codemod-map.ts`）・class 翻訳（`codemod.ts namespaceOf`）・**契約検査（本ファイルの
+ * `isExtensionTokenName`）** の3つがこの1枚を正本にすることが不変条件。二重定義すると
+ * 「片方だけが `font-weight` を知っている」状態が生まれ、namespace が x- 送りで割れても
+ * もう片方が気づけない（#17 の本体）。
+ *
+ * #49 まで契約検査だけが独立の正規表現でカテゴリ形を決めており（`--<cat>-x-<name>` の
+ * cat がハイフンを含めない形）、**#35 が生成側を是正した後も追随せず、道具が自分の生成物を
+ * 拒否していた**（`--font-weight-x-medium` → false）。本ファイル（何も import しない葉）へ
+ * 表を置くことで、`codemod-map.ts` からの import で循環参照にならずに1枚を共有できる。
+ *
+ * multi-segment を先に並べる（`font-weight` が `font` より先にマッチする必要がある）。
+ */
+export const TAILWIND_V4_NAMESPACES: readonly string[] = [
+  // multi-segment（naive な「先頭セグメント直後に x-」だと割れる — #17 の本体）
+  'inset-shadow',
+  'text-shadow',
+  'drop-shadow',
+  'font-weight',
+  // single-segment
+  'shadow',
+  'color',
+  'spacing',
+  'radius',
+  'font',
+  'text',
+  'leading',
+  'tracking',
+  'breakpoint',
+  'container',
+  'ease',
+  'animate',
+  'blur',
+  'perspective',
+  'aspect',
+];
+
+/** トークン名の先頭にある v4 namespace（表に無ければ先頭セグメント群を返す — 写像表の fallback）。 */
+export function tailwindNamespaceOf(token: string): string | null {
+  for (const ns of TAILWIND_V4_NAMESPACES) {
+    if (token.startsWith(`--${ns}-`)) return ns;
+  }
+  const m = /^--([a-z][a-z0-9]*(?:-[a-z0-9]+)*?)-/.exec(token);
+  return m ? m[1]! : null;
+}
+
+/**
+ * 拡張トークンの登録名前空間 — `--<v4 namespace>-x-<key>`（AM-3）。**表から導出する**（#49）。
+ *
+ * 手書きの正規表現に戻さないこと: #49 まで cat 部を `[a-z][a-z0-9]*` と独自に決めていたため
+ * multi-segment namespace（`font-weight`）を弾き、**#35 が是正した生成側の出力 `--font-weight-x-medium`
+ * を検査側が拒否していた**（道具が自分の生成物を拒否する）。表から導出すれば構造的に追随する。
+ */
+export const EXTENSION_TOKEN_PATTERN = new RegExp(
+  `^--(${TAILWIND_V4_NAMESPACES.join('|')})-x-([a-z0-9]+(?:-[a-z0-9]+)*)$`,
+);
+
+/**
+ * 拡張トークン名か。namespace は**表の実在名のみ**
+ * （`--color-text-x-foo` は `color-text` が v4 namespace でないので false）。
+ *
+ * 逆に `--font-x-weight-medium` は `font` namespace の**合法な拡張トークン名**なので true —
+ * codemod が今それを生成しない（#17 で `--font-weight-x-medium` へ是正した）だけであり、
+ * 「旧実装が吐いた形だから拒否する」わけではない。
+ */
+export function isExtensionTokenName(name: string): boolean {
+  return EXTENSION_TOKEN_PATTERN.test(name);
+}
 
 export function isContractTokenName(name: string): name is ContractTokenName {
   return (CONTRACT_TOKENS.names as readonly string[]).includes(name);
-}
-
-export function isExtensionTokenName(name: string): boolean {
-  return EXTENSION_TOKEN_PATTERN.test(name);
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Closes #49

**W1 6リポのブロッカー。** 未 publish の `1.0.2` で **道具が自分の生成物を自分の検査器で拒否する**:

```
生成側 mapTokenName('--font-weight-medium')          → '--font-weight-x-medium'   （#35 で是正済み）
検査側 isExtensionTokenName('--font-weight-x-medium') → false                      （拒否）
```

`board:50`「font-weight 400/500/600/700（全リポ一致）」＝ **W1 対象6リポ全部が該当**。今撃つと 27箇所が `font-medium` → `font-x-medium` に変わり、対応トークンを `generate` が出せず**定義の無い utility になって font-weight を失う**。

## 🔴 前提の訂正: 「publish 済み 1.0.2 のバグ」ではない

```
npm view @hideyukimori/nene2-tokens versions  → [1.0.0, 1.0.1]   ← 1.0.2 は存在しない
npm pack @hideyukimori/nene2-tokens@1.0.2     → npm error notarget
```

**npm から実物を取って測った publish 済み 1.0.1 は自己矛盾していない**:

| | 生成側 | 検査側 `--font-x-weight-medium` | 検査側 `--font-weight-x-medium` |
|---|---|---|---|
| **1.0.1（publish 済み）** | `--font-x-weight-medium`（旧形） | **true** | false |
| **1.0.2（ローカル・未 publish）** | `--font-weight-x-medium`（#35 で是正） | true | **false** ← 割れる |

**npm に壊れた publish は無く、patch release（1.0.3）は不要。** `1.0.2` のまま直して初めて publish すればよい。急ぐ理由は「npm が壊れている」ではなく「**壊れたまま publish しかけている**」— #45 の空パッケージと同型で、**publish 前に捕まえた**。

## 原因: `contract.ts` が namespace 表を見ない「3枚目」だった

`codemod.ts:175-177` が**不変条件を明記している**:

> 正本は写像表側の `TAILWIND_V4_NAMESPACES`（#17）。**x- 送りと class 翻訳が同じ1枚を見る**ことが不変条件 — かつてここだけが `font-weight` を知っていて写像表が知らなかったため、namespace が x- 送りで割れても class 側は気づけなかった。

`contract.ts:89` は表を見ず**独自 regex**（cat 部 `[a-z][a-z0-9]*` ＝ハイフン不可）で namespace 形を決めていた。**＝ #35 が塞いだ当の穴（複数箇所が独立に namespace を知る）の3箇所目。**

cat 部を `[a-z][a-z0-9-]*` に広げるだけの対処は不十分 — `--color-text-x-foo`（`color-text` は v4 namespace でない）も通るうえ、**4枚目にならないだけで「表を見ない」構造が残る**。

## 是正: 表を葉へ移し、3つが同じ1枚を見る

`codemod-map.ts` → `contract.ts` の import が既にあり、`contract.ts` は**何も import しない葉**。逆向き import は**循環参照**になる。よって:

- **`TAILWIND_V4_NAMESPACES` / `tailwindNamespaceOf` を `contract.ts` へ移す**（既に `EXCLUDED_NAMESPACES` という namespace 語彙を持つので同居は自然・依存の向きも正しくなる）
- `codemod-map.ts` は import して **re-export**（公開 API は不変）
- **`EXTENSION_TOKEN_PATTERN` は publish 済み 1.0.1 の公開 export なので消さず**、**表から導出**する形で維持（判定も導出 pattern に一本化 — 実装を2つ持てば同じ罪）

不変条件は「x- 送りと class 翻訳が1枚を見る」→ **「契約検査も含めて3つが1枚を見る」**に強化。

## 実測（対照実験）

```
旧実装: validate → 2 errors
  [contract-vocabulary] '--font-weight-x-medium' is neither a contract v1 token nor a declared extension token
  [contract-vocabulary] '--inset-shadow-x-glow'  is neither a contract v1 token nor a declared extension token
是正後: validate → 0 errors
```
（同梱 `themes/reference.css`＝契約32キー完備＋x- トークン2本の probe）

```
mapTokenName('--font-weight-medium') → '--font-weight-x-medium' → isExtensionTokenName → true
```

### 判定の検算（全一致）

| 名前 | 結果 | 根拠 |
|---|---|---|
| `--font-weight-x-medium` | true | `font-weight` ∈ 表 |
| `--color-x-brand` | true | `color` ∈ 表 |
| `--color-text-x-foo` | **false** | `color-text` は v4 namespace でない |
| `--font-x-weight-medium` | **true** | `font` namespace の**合法な拡張名**。codemod が今その形を生成しない（#17 で是正）だけで、**「旧実装が吐いた形だから拒否」ではない** |

## テスト（変異検査済み）

旧 regex に戻すと新テスト3件が落ち、**エラーが症状そのものを言語化する**:

```
× 生成側が --font-weight-medium → --font-weight-x-medium を出すのに検査側が拒否する
× inset-shadow が拡張形を作れない
```

`EXTENSION_TOKEN_PATTERN` が表から導出されることも、**表の全 namespace で `--<ns>-x-probe` が通る**ことで固定した（手書き regex へ戻すと落ちる）。

## AM-2 release ゲート

**触れない**（実測確認済み）: 契約キー集合は不変（`CONTRACT_TOKENS` に変更なし・検査器の判定を表に寄せるだけ）。`check:am2-gate` → **PASS**（contract 1.0・color 28 + shadow 4 が凍結記録と一致）。

## 検査

type-check / eslint / format:check / **test 328 passed (22 files)** / check:cli / check:am2-gate すべて緑。

## 出典

Payout リナ発見・統合リナが独立実測確認（2026-07-16）。`codemod.ts:175-177`（不変条件）／`codemod-map.ts:365-372`（#17 の是正コメントと Chromium 実測）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)