### PR TITLE
docs: 配布物の版・publish 状態を実測へ — README :15/:16/:25 ＋ publish.md 対象表・初回手順 (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ NeNe フリート・フロント統一規約の**配布物（versioned 実行可
 
 | パス | 内容 | 状態 |
 |---|---|---|
-| `packages/nene2-tokens` | Core Token Contract v1（color 28＋shadow 4）・CONTRACT_TOKENS export・validate:themes・themegen・codemod 写像表 v1 | **契約凍結済み（2026-07-14 hide 承認・§6 全6項目・承認記録 = `docs/contract-freeze-review-2026-07-18.md` §7・以後の契約キー集合変更は stop-the-line ADR のみ=AM-2）＋ v1.0.0 確定・publish 待ち**（publish は施主実行） |
-| `packages/nene2-standards` | ESLint flat config 配布（合成規律=ルール単位1定義・plugin 同梱）・Stylelint 2枚組・known-utility lint・`nene2-check`（conformance skeleton・fail-closed）・`init --scan` | **v1.0.0 確定・publish 待ち**（W0a stage2 #2/#8/#9。known-utility warn プレースホルダ等の暫定はパッケージ README 明記のまま） |
-| `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | **W0a 骨格 実装済**（型付きカタログ＋parity AM-17 最終形。plural/format/react/vault JSON 形は W0b — パッケージ README 参照） |
+| `packages/nene2-tokens` | Core Token Contract v1（color 28＋shadow 4）・CONTRACT_TOKENS export・validate:themes・themegen・codemod 写像表 v1 | **契約凍結済み（2026-07-14 hide 承認・§6 全6項目・承認記録 = `docs/contract-freeze-review-2026-07-18.md` §7・以後の契約キー集合変更は stop-the-line ADR のみ=AM-2）＋ npm 公開済み 1.0.1**（1.0.0 = 2026-07-14T14:24:27Z / 1.0.1 = 同 18:51:15Z。**ローカルは 1.0.2 で未 publish** — `21ce902` #17/#18 の是正） |
+| `packages/nene2-standards` | ESLint flat config 配布（合成規律=ルール単位1定義・plugin 同梱）・Stylelint 2枚組・known-utility lint・`nene2-check`（conformance skeleton・fail-closed）・`init --scan` | **npm 公開済み 1.0.1・ローカル版と一致**（1.0.0 = 2026-07-14T14:24:56Z / 1.0.1 = 同 18:51:18Z。W0a stage2 #2/#8/#9。known-utility warn プレースホルダ等の暫定はパッケージ README 明記のまま） |
+| `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | **W0a 骨格 実装済・0.1.0 確定・publish 待ち**（`private` 解除済み = #45・版は 2026-07-16 施主裁定 = #46。型付きカタログ＋parity AM-17 最終形。plural/format/react/vault JSON 形は W0b — パッケージ README 参照） |
 | `packages/nene2-standards/registries/` | 構造レジストリ（恒久公認差異）＋負債台帳（lint-baseline / legacy-manifest）＋waiver — kind 判別ユニオン jsonc（スキーマ = `src/registries/schema.ts`・配置は 05 §1.1 準拠でパッケージ同梱＝製品は pinned 版で消費） | **v1 発効時点の現物 登録済**（経過措置2件は kind=transition・批准レビュー送り） |
 | `fleet-baseline.json` | 基盤4パッケージ semver の単一マニフェスト（スキーマ = `docs/fleet-baseline.schema.json`） | **雛形作成済み**（発効済みは nene2-client ^1.1.0 のみ。tokens/standards/i18n は null=未発効 — 実版数は publish 成功後の別 PR で記入・未公開版を書かない） |
 
@@ -22,7 +22,7 @@ NeNe フリート・フロント統一規約の**配布物（versioned 実行可
 
 - publish は `.github/workflows/publish.yml`（nene2-js と同型: OIDC Trusted Publishing・provenance・workflow_dispatch・dry_run 既定 true・パッケージ選択 input）。手順と npm 側の事前設定は `docs/publish.md`。
 - **AM-2 release gate**: 契約キー集合が凍結記録（`packages/nene2-tokens/contract-freeze.json`）と一致しない限り publish 拒否（`scripts/am2-release-gate.mjs`・`npm run check` にも組込み・fail-closed）。契約進化は stop-the-line ADR＋codemod 同梱のみ。diff 粒度の changeset 検査は未実装（W1 の fg→text 予行演習で実装 — release-gate.ts 冒頭の TODO 参照）。
-- `nene2-i18n` は W0a 骨格につき publish 対象外（`private: true`・W0b で解除）。
+- `nene2-i18n` は **0.1.0 で publish 待ち**（`private` 解除済み = #45・版は 2026-07-16 施主裁定 = #46。rc を採らない根拠は `67f476c` の semver 実測）。**初回 publish は施主のローカル操作**（Trusted Publisher は既存パッケージにしか設定できないため — `docs/publish.md`）。
 
 ## 規律
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NeNe フリート・フロント統一規約の**配布物（versioned 実行可
 |---|---|---|
 | `packages/nene2-tokens` | Core Token Contract v1（color 28＋shadow 4）・CONTRACT_TOKENS export・validate:themes・themegen・codemod 写像表 v1 | **契約凍結済み（2026-07-14 hide 承認・§6 全6項目・承認記録 = `docs/contract-freeze-review-2026-07-18.md` §7・以後の契約キー集合変更は stop-the-line ADR のみ=AM-2）＋ npm 公開済み 1.0.1**（1.0.0 = 2026-07-14T14:24:27Z / 1.0.1 = 同 18:51:15Z。**ローカルは 1.0.2 で未 publish** — `21ce902` #17/#18 の是正） |
 | `packages/nene2-standards` | ESLint flat config 配布（合成規律=ルール単位1定義・plugin 同梱）・Stylelint 2枚組・known-utility lint・`nene2-check`（conformance skeleton・fail-closed）・`init --scan` | **npm 公開済み 1.0.1・ローカル版と一致**（1.0.0 = 2026-07-14T14:24:56Z / 1.0.1 = 同 18:51:18Z。W0a stage2 #2/#8/#9。known-utility warn プレースホルダ等の暫定はパッケージ README 明記のまま） |
-| `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | **W0a 骨格 実装済・0.1.0 確定・publish 待ち**（`private` 解除済み = #45・版は 2026-07-16 施主裁定 = #46。型付きカタログ＋parity AM-17 最終形。plural/format/react/vault JSON 形は W0b — パッケージ README 参照） |
+| `packages/nene2-i18n` | 型付き i18n（ja 権威カタログ・parity・同値率検査） | **W0a 骨格 実装済・npm 公開済み 0.1.0**（0.1.0 = 2026-07-16T05:46:12Z。`private` 解除 = #45・版は施主裁定 = #46。型付きカタログ＋parity AM-17 最終形。plural/format/react/vault JSON 形は W0b — パッケージ README 参照） |
 | `packages/nene2-standards/registries/` | 構造レジストリ（恒久公認差異）＋負債台帳（lint-baseline / legacy-manifest）＋waiver — kind 判別ユニオン jsonc（スキーマ = `src/registries/schema.ts`・配置は 05 §1.1 準拠でパッケージ同梱＝製品は pinned 版で消費） | **v1 発効時点の現物 登録済**（経過措置2件は kind=transition・批准レビュー送り） |
 | `fleet-baseline.json` | 基盤4パッケージ semver の単一マニフェスト（スキーマ = `docs/fleet-baseline.schema.json`） | **雛形作成済み**（発効済みは nene2-client ^1.1.0 のみ。tokens/standards/i18n は null=未発効 — 実版数は publish 成功後の別 PR で記入・未公開版を書かない） |
 
@@ -22,7 +22,7 @@ NeNe フリート・フロント統一規約の**配布物（versioned 実行可
 
 - publish は `.github/workflows/publish.yml`（nene2-js と同型: OIDC Trusted Publishing・provenance・workflow_dispatch・dry_run 既定 true・パッケージ選択 input）。手順と npm 側の事前設定は `docs/publish.md`。
 - **AM-2 release gate**: 契約キー集合が凍結記録（`packages/nene2-tokens/contract-freeze.json`）と一致しない限り publish 拒否（`scripts/am2-release-gate.mjs`・`npm run check` にも組込み・fail-closed）。契約進化は stop-the-line ADR＋codemod 同梱のみ。diff 粒度の changeset 検査は未実装（W1 の fg→text 予行演習で実装 — release-gate.ts 冒頭の TODO 参照）。
-- `nene2-i18n` は **0.1.0 で publish 待ち**（`private` 解除済み = #45・版は 2026-07-16 施主裁定 = #46。rc を採らない根拠は `67f476c` の semver 実測）。**初回 publish は施主のローカル操作**（Trusted Publisher は既存パッケージにしか設定できないため — `docs/publish.md`）。
+- `nene2-i18n` は **0.1.0 が npm 公開済み**（2026-07-16 施主が初回 publish 実行 = #46 の裁定どおり。`private` 解除 = #45・rc を採らない根拠は `67f476c` の semver 実測）。**基盤4パッケージの初回 publish はこれで全て完了**（残る初回なし）。
 
 ## 規律
 

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -8,8 +8,8 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 
 | パッケージ | 版 | 状態 |
 | --- | --- | --- |
-| `@hideyukimori/nene2-tokens` | 1.0.0 | 契約凍結済み（2026-07-14 hide 承認）・publish 待ち |
-| `@hideyukimori/nene2-standards` | 1.0.0 | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）・publish 待ち |
+| `@hideyukimori/nene2-tokens` | ローカル **1.0.2** / npm **1.0.1** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:27Z / 18:51:15Z）。**1.0.2 は未 publish**（`21ce902` #17/#18 の是正）＝ 2回目以降の手順（下記）で出す |
+| `@hideyukimori/nene2-standards` | ローカル **1.0.1** / npm **1.0.1** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:56Z / 18:51:18Z）＝ **未 publish の差分なし** |
 | `@hideyukimori/nene2-i18n` | 0.1.0 | `private` 解除済み・**publish 待ち**（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記） |
 
 ## 初回 publish（パッケージごとに1回・hide のローカル操作）
@@ -17,16 +17,19 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 Trusted Publisher は **既存パッケージにしか設定できない**（npm の package settings 画面が
 初回 publish 後にしか存在しない）ため、初回はローカルから account 2FA で publish する:
 
+**残る初回は `nene2-i18n` のみ**（tokens / standards は 2026-07-14 に初回 publish 済み — 上の対象表）。
+
 ```bash
 cd nene2-fleet-tooling
 npm ci && npm run check   # AM-2 release gate 含む全緑を確認
-npm publish --dry-run --workspace packages/nene2-tokens   # pack 内容の最終確認
-npm publish --workspace packages/nene2-tokens             # 2FA: --otp=<code>
-npm publish --dry-run --workspace packages/nene2-standards
-npm publish --workspace packages/nene2-standards
+npm publish --dry-run --workspace packages/nene2-i18n   # pack 内容の最終確認
+npm publish --workspace packages/nene2-i18n             # 2FA: --otp=<code>
 ```
 
-確認: `npm view @hideyukimori/nene2-tokens version` / `npm view @hideyukimori/nene2-standards version`
+確認: `npm view @hideyukimori/nene2-i18n version` → `0.1.0` が返ること。
+
+> この publish は `fleet-baseline.json` の `"@hideyukimori/nene2-i18n": "^0.1.0"` を**実在させる**。
+> 現状その版は npm に無く（実測 E404）、baseline を消費すると install が壊れる。**窓は publish で閉じる**。
 
 注: ローカル publish でも provenance は生成されない（provenance は CI の OIDC 経由のみ）。
 `publishConfig.provenance: true` はローカルでは警告になる場合があるが、その際は

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -10,26 +10,24 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 | --- | --- | --- |
 | `@hideyukimori/nene2-tokens` | ローカル **1.0.2** / npm **1.0.1** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:27Z / 18:51:15Z）。**1.0.2 は未 publish**（`21ce902` #17/#18 の是正）＝ 2回目以降の手順（下記）で出す |
 | `@hideyukimori/nene2-standards` | ローカル **1.0.1** / npm **1.0.1** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:56Z / 18:51:18Z）＝ **未 publish の差分なし** |
-| `@hideyukimori/nene2-i18n` | 0.1.0 | `private` 解除済み・**publish 待ち**（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記） |
+| `@hideyukimori/nene2-i18n` | ローカル **0.1.0** / npm **0.1.0** | `private` 解除済み（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。**0.1.0 は publish 済み**（2026-07-16T05:46:12Z・`dist-tags latest=0.1.0`・`shasum 36d06bcd65854543c8af1ef971b36eccc1dcb3db`）＝ **未 publish の差分なし**。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記） |
 
 ## 初回 publish（パッケージごとに1回・hide のローカル操作）
 
-Trusted Publisher は **既存パッケージにしか設定できない**（npm の package settings 画面が
-初回 publish 後にしか存在しない）ため、初回はローカルから account 2FA で publish する:
+> ✅ **基盤3パッケージとも初回 publish 済み＝残る初回はない**（tokens / standards = 2026-07-14・i18n = 2026-07-16）。
+> 以後の版上げは全て「2回目以降（GitHub Actions）」の手順。本節は**来歴の記録**として残す。
 
-**残る初回は `nene2-i18n` のみ**（tokens / standards は 2026-07-14 に初回 publish 済み — 上の対象表）。
+Trusted Publisher は **既存パッケージにしか設定できない**（npm の package settings 画面が
+初回 publish 後にしか存在しない）ため、初回はローカルから account 2FA で publish した:
 
 ```bash
 cd nene2-fleet-tooling
 npm ci && npm run check   # AM-2 release gate 含む全緑を確認
-npm publish --dry-run --workspace packages/nene2-i18n   # pack 内容の最終確認
-npm publish --workspace packages/nene2-i18n             # 2FA: --otp=<code>
+npm publish --dry-run --workspace packages/<pkg>   # pack 内容の最終確認
+npm publish --workspace packages/<pkg>             # 2FA: --otp=<code>
 ```
 
-確認: `npm view @hideyukimori/nene2-i18n version` → `0.1.0` が返ること。
-
-> この publish は `fleet-baseline.json` の `"@hideyukimori/nene2-i18n": "^0.1.0"` を**実在させる**。
-> 現状その版は npm に無く（実測 E404）、baseline を消費すると install が壊れる。**窓は publish で閉じる**。
+確認: `npm view @hideyukimori/<pkg> version`
 
 注: ローカル publish でも provenance は生成されない（provenance は CI の OIDC 経由のみ）。
 `publishConfig.provenance: true` はローカルでは警告になる場合があるが、その際は
@@ -46,8 +44,8 @@ Settings → Trusted Publisher）:
 | Repository        | `hideyukiMORI/nene2-fleet-tooling` |
 | Workflow filename | `publish.yml`                      |
 
-`nene2-standards` も同じ値で設定する（Workflow filename は共通 — パッケージ選択は
-workflow_dispatch の input で行う）。
+`nene2-standards` と `nene2-i18n` も同じ値で設定する（Workflow filename は共通 — パッケージ選択は
+workflow_dispatch の input で行う）。**3パッケージとも初回 publish 済み＝npm 側の settings 画面は既に存在する。**
 
 ## 2回目以降（GitHub Actions）
 


### PR DESCRIPTION
Closes #55

**方針変更ゼロ・実測の反映のみ。** README は最後に触られた `64f6ce8`（2026-07-14 23:12 JST）の時点では**正しかった**。
以後 19 commit・2日ぶんが一度も反映されず、**腐り始めたのは README commit の15分後**（`054cee8` 07-14 23:27 = fleet-baseline 発効）。
誰かが怠けたのではなく、**更新の同乗が構造的に無い**。

## 実測（2026-07-16 — `npm view <pkg> time --json`）

| パッケージ | npm 実公開 | ローカル | 差分 |
|---|---|---|---|
| tokens | **1.0.0**（`2026-07-14T14:24:27Z`）・**1.0.1**（同 `18:51:15Z`） | 1.0.2 | **1.0.2 が未 publish** |
| standards | **1.0.0**（`2026-07-14T14:24:56Z`）・**1.0.1**（同 `18:51:18Z`） | 1.0.1 | なし |
| i18n | **E404（未公開）** | 0.1.0 | **0.1.0 が未 publish** |

## 直したもの

- **README:15 / :16** — 「**v1.0.0 確定・publish 待ち**」。実際には**2日前から npm にある**（1.0.1）。「publish 待ち」なのは tokens の 1.0.2 のみ。
- **README:25** — 「**publish 対象外**（`private: true`・W0b で解除）」。#45 で private 解除・#46 で 0.1.0 確定済み。
- **publish.md :11 / :12** — 同じ嘘（`1.0.0`・publish 待ち）。`67f476c` は i18n 行だけ直して**2行を残した**。
- **publish.md 「初回 publish」節** — 🔴 **既に公開済みの tokens/standards を publish しろ、と施主に指示していた**。残る初回は i18n のみなので手順を差し替え、この publish が `fleet-baseline.json` の `^0.1.0` を**実在させる**（現状 E404 = 消費すると install が壊れる窓）ことを明記。

## 触っていないもの

- **README:19 の規範**（「**未公開版を書かない**」）— **施主裁定 2026-07-16 でガードが正と確定**（#55 のコメント）。順序の明文化は**別 Issue**（「充填 PR の準備は同時でよいが、**マージは npm 実在の実測後**」）。本 PR は規範に触らない。
- **README:17**（i18n 構成行）— 記述が偽ではないので触っていない。

## 検査（実測・正直な限界つき）

| 工程 | 結果 |
|---|---|
| type-check / format:check / check:cli / check:nene2-check / check:am2-gate | ✅ 全緑 |
| test | ✅ **326 passed / 22 files** |
| lint（実コード = `npx eslint . --ignore-pattern '.claude/**'`） | ✅ 緑 |
| **`npm run check`（そのまま）** | 🔴 **赤・18 errors** |

> `npm run check` の赤は**本 PR とは無関係**。全件 `.claude/worktrees/` 配下＝ agent の作業ツリーを ESLint が舐めている
> （`eslint.config.js` の ignores は `dist` / `node_modules` / `*.d.ts` のみ・flat config は dot ディレクトリを既定で除外しない）。
> **CI が緑なのは `actions/checkout@v4` が素の checkout だから。**
> ただし **`docs/publish.md:22` は publish 前に施主へ `npm run check` を叩かせる**ので実害がある → **別 Issue を立てる**。
> （`67f476c` の担当は `git archive` で素の checkout を再現して回避していた＝既に踏まれていた形跡）

**doc のみ・コード変更ゼロ。**
