### PR TITLE
fix: .claude/worktrees を lint と git の対象から外す — 施主の publish 前手順が赤だった (#59)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 dist/
 coverage/
 *.tsbuildinfo
+
+# agent の作業ツリー（このリポの checkout が丸ごと入る — `git add .` での混入を防ぐ）。
+# .claude/settings.local.json は意図的に追跡可能なまま残す（permission 設定の共有）。
+.claude/worktrees/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,10 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['**/dist/**', '**/node_modules/**', '**/*.d.ts'] },
+  // .claude/worktrees は agent の作業ツリー（このリポの checkout が丸ごと入る）。
+  // flat config は dot ディレクトリを既定で除外しないため、明示しないと自分自身を
+  // 二重に lint し、しかも files: ['scripts/**'] 等の相対パターンが当たらず誤検知する。
+  { ignores: ['**/dist/**', '**/node_modules/**', '**/*.d.ts', '.claude/worktrees/**'] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {


### PR DESCRIPTION
Closes #59

**施主の publish 前手順が赤だった。** `docs/publish.md:22` は publish 直前にこう指示する:

```bash
npm ci && npm run check   # AM-2 release gate 含む全緑を確認
```

## 実測（修正前・作業ツリー clean）

```
$ npm run check
✖ 18 problems (18 errors, 0 warnings)
```

**18件すべて** `.claude/worktrees/{fix-21-entrypoint-seam,task}/scripts/am2-release-gate.mjs` の
`'console' is not defined` / `'process' is not defined`。**実コードの赤はゼロ**。

## 実害

publish は**施主のローカル操作**なので、**施主がこの赤を踏む**。赤の中身は配布物と無関係な agent の置き土産だが、
「**AM-2 release gate 含む全緑を確認**」が全緑にならない以上、施主は publish してよいか判断できない。

**既に踏まれていた**: `67f476c` の担当は publish 直前の確認を「**素の checkout を `git archive` で再現・npm ci 後**」に行っている（commit message 実測）。
＝ **各自が回避策を発明していた。**

## 原因（3つ）

1. **flat config は dot ディレクトリを既定で除外しない**（eslintrc 時代と違う）。`ignores` は `dist` / `node_modules` / `*.d.ts` のみで `.claude/` が lint 対象だった。
2. globals の上書きが `files: ['scripts/**/*.mjs']` ＝ **リポ直下にしか当たらず**、worktree 内の同名ファイルは `console`/`process` が undef になる。
3. `.gitignore` に `.claude/` が無く `?? .claude/` が出続ける（**`git add .` での混入口** — 実測: `.claude/worktrees` 配下の `.test.ts` だけで **35本**）。

## なぜ CI は緑だったのか

`.github/workflows/check.yml` は `actions/checkout@v4` ＝ **素の checkout**。`.claude/` が存在しない。
**CI 緑・ローカル赤という乖離が構造的に起きる。CI はこの穴を永久に検出しない。**

## 粒度（施主判断 2026-07-16）

**`.claude/worktrees/` のみ**。`.claude/settings.local.json` は **permission 設定の共有のため追跡可能なまま残す**。
eslint 側も同じ粒度に揃えた（`.claude/worktrees/**`）。

## 実測（修正後）

| 検査 | 結果 |
|---|---|
| `npm run check` | ✅ **全緑**（`AM-2 release gate: PASS — contract 1.0 (color 28 + shadow 4) は凍結記録と一致`） |
| `git status` | ✅ `?? .claude/` が消え、`settings.local.json` は追跡可能なまま |

**設定2ファイル・8行。配布物のコード変更ゼロ。**
