### PR TITLE
feat(standards): A1 hooks→model 移行 codemod を同梱（migration-only・pilot 緑+変異で赤） (#66)

### DIFF
--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hideyukimori/nene2-standards",
-  "version": "1.0.1",
-  "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules",
+  "version": "1.1.0",
+  "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules, A1 hooks→model migration codemod",
   "type": "module",
   "license": "MIT",
   "main": "./dist/index.js",
@@ -18,6 +18,10 @@
     "./stylelint-plugin": {
       "types": "./dist/stylelint/plugin.d.ts",
       "default": "./dist/stylelint/plugin.js"
+    },
+    "./migrations/hooks-to-model": {
+      "types": "./dist/migrations/hooks-to-model/index.d.ts",
+      "default": "./dist/migrations/hooks-to-model/index.js"
     }
   },
   "files": [
@@ -36,9 +40,13 @@
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-testing-library": "^7.6.1",
+    "jscodeshift": "^17.3.0",
     "postcss": "^8.5.6",
     "prettier": "3.6.2",
     "typescript-eslint": "^8.35.0"
+  },
+  "devDependencies": {
+    "@types/jscodeshift": "^17.3.0"
   },
   "peerDependencies": {
     "eslint": ">=9",
@@ -50,7 +58,8 @@
     }
   },
   "bin": {
-    "nene2-check": "dist/checks/cli.js"
+    "nene2-check": "dist/checks/cli.js",
+    "nene2-a1-hooks-to-model": "dist/migrations/hooks-to-model/cli.js"
   },
   "repository": {
     "type": "git",

--- a/packages/nene2-standards/src/migrations/hooks-to-model/cli.ts
+++ b/packages/nene2-standards/src/migrations/hooks-to-model/cli.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * A1 codemod CLI — hooks→model 移行（fleet#66）。各リナが自リポで叩く versioned 実行物。
+ *
+ *   npx nene2-a1-hooks-to-model <frontend/src> [--dry-run]
+ *
+ * `--dry-run` は fs を触らず plan（move 対象・movedHooks）だけを出力する。
+ * 本適用は per-product PR で（手作業移設 MUST NOT＝#15/W1）。マージは施主承認後。
+ */
+import { applyA1 } from './move.js';
+
+function main(): number {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const srcRoot = args.find((a) => !a.startsWith('--'));
+  if (!srcRoot) {
+    console.error('usage: nene2-a1-hooks-to-model <frontend/src ディレクトリ> [--dry-run]');
+    return 2;
+  }
+  const result = applyA1(srcRoot, { dryRun });
+  console.log(JSON.stringify(result, null, 2));
+  console.error(
+    `A1 ${dryRun ? '(dry-run) ' : ''}move ${result.moves.length} 件 / rewrite ${result.rewritten.length} ファイル`,
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/packages/nene2-standards/src/migrations/hooks-to-model/index.ts
+++ b/packages/nene2-standards/src/migrations/hooks-to-model/index.ts
@@ -1,0 +1,11 @@
+/**
+ * A1 codemod（hooks→model 横断移行・fleet#66）の公開 API。
+ * migration-only（ロジック不変・move + import rewrite だけ）。施主裁定 07-17: DOM hook も (A) model/ 一律。
+ */
+export { applyA1, planMoves, type A1Result, type MoveEntry } from './move.js';
+export {
+  default as hooksToModelTransform,
+  moveKeyOf,
+  rewriteHooksSegment,
+  type HooksToModelOptions,
+} from './transform.js';

--- a/packages/nene2-standards/src/migrations/hooks-to-model/move.test.ts
+++ b/packages/nene2-standards/src/migrations/hooks-to-model/move.test.ts
@@ -1,0 +1,151 @@
+/**
+ * A1 codemod の e2e 実証（fleet#66・pilot=vault 構造）。
+ * 一時ディレクトリに vault 相当の hooks/ 構造を作り、applyA1 で実 move + import rewrite させて検証する。
+ * 施主裁定①（07-17・DOM hook も (A) move）と 3リナ特異ケースを実ファイルで固定。
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { applyA1, planMoves } from './move.js';
+
+let tmp: string;
+let src: string;
+
+function write(rel: string, content: string): void {
+  const abs = path.join(src, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+}
+function read(rel: string): string {
+  return readFileSync(path.join(src, rel), 'utf8');
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(path.join(os.tmpdir(), 'a1-pilot-'));
+  src = path.join(tmp, 'frontend', 'src');
+  // vault 相当: login(単純)・document-detail(型 re-export + 複数 hooks + ui 直 import)・kanban(DOM hook)
+  write('features/login/hooks/use-login.ts', `export function useLogin() { return null; }\n`);
+  write(
+    'features/login/hooks/use-login.test.tsx',
+    `import { useLogin } from './use-login';\ntest('x', () => useLogin());\n`,
+  );
+  write('features/login/index.ts', `export { useLogin } from './hooks/use-login';\n`);
+
+  write(
+    'features/document-detail/hooks/use-metadata-edit.ts',
+    `export type OcrPrefill = { v: string };\nexport function useMetadataEdit() { return null; }\n`,
+  );
+  write(
+    'features/document-detail/hooks/use-void-document.ts',
+    `export function useVoidDocument() { return null; }\n`,
+  );
+  write(
+    'features/document-detail/index.ts',
+    `export type { OcrPrefill } from './hooks/use-metadata-edit';\nexport { useVoidDocument } from './hooks/use-void-document';\n`,
+  );
+  write(
+    'features/document-detail/ui/DocumentDetailView.tsx',
+    `import type { OcrPrefill } from '../hooks/use-metadata-edit';\nexport const V = (_: OcrPrefill) => null;\n`,
+  );
+
+  // DOM hook（施主裁定①で move 対象・barrel 非 re-export・ui 直 import）
+  write(
+    'features/kanban/hooks/use-kanban-dnd.ts',
+    `export function useKanbanDnd() { return null; }\n`,
+  );
+  write(
+    'features/kanban/ui/KanbanView.tsx',
+    `import { useKanbanDnd } from '../hooks/use-kanban-dnd';\nexport const K = () => useKanbanDnd();\n`,
+  );
+
+  // スライス跨ぎ @/ 絶対 import（対象外）
+  write('shared/auth/use-auth-token.ts', `export function useAuthToken() { return null; }\n`);
+  write(
+    'features/login/ui/LoginView.tsx',
+    `import { useAuthToken } from '@/shared/auth/use-auth-token';\nexport const L = () => useAuthToken();\n`,
+  );
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('A1 applyA1 — e2e（vault 構造 pilot）', () => {
+  it('planMoves は全 hooks/use-*（実装＋test・DOM hook 含む）を拾う', () => {
+    const moves = planMoves(path.join(src, 'features'));
+    const files = moves.map((m) => `${m.slice}/${m.file}`).sort();
+    expect(files).toEqual([
+      'document-detail/use-metadata-edit.ts',
+      'document-detail/use-void-document.ts',
+      'kanban/use-kanban-dnd.ts', // DOM hook も対象（施主裁定①）
+      'login/use-login.test.tsx',
+      'login/use-login.ts',
+    ]);
+  });
+
+  it('fs move: hooks/ → model/・空 hooks/ は削除', () => {
+    applyA1(src);
+    expect(existsSync(path.join(src, 'features/login/model/use-login.ts'))).toBe(true);
+    expect(existsSync(path.join(src, 'features/login/model/use-login.test.tsx'))).toBe(true);
+    expect(existsSync(path.join(src, 'features/login/hooks'))).toBe(false);
+    expect(existsSync(path.join(src, 'features/kanban/model/use-kanban-dnd.ts'))).toBe(true);
+  });
+
+  it('barrel index.ts: export（型・値とも）が model/ へ追随', () => {
+    applyA1(src);
+    expect(read('features/login/index.ts')).toContain(`from './model/use-login'`);
+    const dd = read('features/document-detail/index.ts');
+    expect(dd).toContain(`export type { OcrPrefill } from './model/use-metadata-edit'`);
+    expect(dd).toContain(`export { useVoidDocument } from './model/use-void-document'`);
+  });
+
+  it('🔴 ui の相対 import（型のみ・barrel 非経由）も model/ へ（deal 特異ケース）', () => {
+    applyA1(src);
+    const view = read('features/document-detail/ui/DocumentDetailView.tsx');
+    expect(view).toContain('import type');
+    expect(view).toContain(`from '../model/use-metadata-edit'`);
+    expect(view).not.toContain('hooks/');
+  });
+
+  it('🔴 DOM hook の ui 直 import も追随（施主裁定①で move 対象）', () => {
+    applyA1(src);
+    expect(read('features/kanban/ui/KanbanView.tsx')).toContain(`from '../model/use-kanban-dnd'`);
+  });
+
+  it('test 内の相対 import（同一ディレクトリ ./use-*）は move でパス保存（書換不要）', () => {
+    applyA1(src);
+    // 実装と test が一緒に model/ へ動くので `./use-login` は相対のまま有効
+    expect(read('features/login/model/use-login.test.tsx')).toContain(`from './use-login'`);
+  });
+
+  it('🔴 負例: @/ 絶対 import は書き換えない（shared は対象外）', () => {
+    applyA1(src);
+    expect(read('features/login/ui/LoginView.tsx')).toContain(
+      `from '@/shared/auth/use-auth-token'`,
+    );
+    expect(existsSync(path.join(src, 'shared/auth/use-auth-token.ts'))).toBe(true);
+  });
+
+  it('dryRun: fs を触らず plan だけ返す', () => {
+    const r = applyA1(src, { dryRun: true });
+    expect(r.dryRun).toBe(true);
+    expect(r.moves.length).toBe(5);
+    expect(existsSync(path.join(src, 'features/login/hooks/use-login.ts'))).toBe(true); // 動いていない
+  });
+
+  it('🔴 変異で赤: movedHooks を落とす経路（planMoves が空）だと ui import が hooks/ のまま残る', () => {
+    // features ディレクトリを誤って空にした想定（＝move 対象 0）で import が追随しないことを実証
+    const emptyRoot = path.join(tmp, 'empty', 'src');
+    mkdirSync(path.join(emptyRoot, 'features'), { recursive: true });
+    writeFileSync(
+      path.join(emptyRoot, 'stray.tsx'),
+      `import { useLogin } from '../features/login/hooks/use-login';\n`,
+    );
+    const r = applyA1(emptyRoot);
+    expect(r.moves).toHaveLength(0);
+    // move 対象が無いので import は書き換わらない＝「codemod が走ったのに壊れたまま」を検出できる形
+    expect(readFileSync(path.join(emptyRoot, 'stray.tsx'), 'utf8')).toContain('hooks/use-login');
+  });
+});

--- a/packages/nene2-standards/src/migrations/hooks-to-model/move.ts
+++ b/packages/nene2-standards/src/migrations/hooks-to-model/move.ts
@@ -1,0 +1,132 @@
+/**
+ * A1 codemod — move ランナー＋オーケストレーション（fleet#66・施主裁定 07-17）。
+ *
+ * 施主裁定①（07-17）で **DOM/interaction hook も (A) model/ 一律**へ確定したため、
+ * move 対象は「barrel が re-export する page hook」に限らず **全 `features/<slice>/hooks/use-*.{ts,tsx}`**
+ * （併置 test 含む・use-kanban-dnd 等の DOM hook 含む）。分類判定は不要になった。
+ *
+ * 手順（migration-only・ロジック不変）:
+ *   1. `features/<slice>/hooks/use-*.{ts,tsx}` を列挙（実装＋併置 test）
+ *   2. `hooks/` → `model/` へ fs move（model/ を作成・空になった hooks/ を削除）
+ *   3. src 配下の全 `.ts/.tsx` に import rewrite transform を適用（barrel index.ts の re-export も追随）
+ *
+ * `dryRun` で move/書換を行わず plan だけ返す（各リナが自リポで確認してから適用するため）。
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import jscodeshift from 'jscodeshift';
+
+import transform from './transform.js';
+
+const tsx = jscodeshift.withParser('tsx');
+
+export interface MoveEntry {
+  slice: string;
+  /** 拡張子つきファイル名（例 `use-login.ts` / `use-login.test.tsx`）。 */
+  file: string;
+  from: string;
+  to: string;
+}
+
+export interface A1Result {
+  moves: MoveEntry[];
+  /** transform に渡す `"<slice>/<basename>"`（実装・test を basename で正規化した集合）。 */
+  movedHooks: string[];
+  /** import rewrite で実際に書き換わったファイル（相対パス）。 */
+  rewritten: string[];
+  dryRun: boolean;
+}
+
+const HOOK_FILE_RE = /^use-.+\.tsx?$/;
+
+/** `use-login.ts` / `use-login.test.tsx` → `use-login`（実装と test を同一キーへ）。 */
+function baseKey(file: string): string {
+  return file.replace(/\.(test\.)?tsx?$/, '');
+}
+
+/** features 配下の `hooks/use-*.{ts,tsx}`（実装＋test）を列挙。 */
+export function planMoves(featuresDir: string): MoveEntry[] {
+  const entries: MoveEntry[] = [];
+  if (!existsSync(featuresDir)) return entries;
+  for (const slice of readdirSync(featuresDir, { withFileTypes: true })) {
+    if (!slice.isDirectory()) continue;
+    const hooksDir = path.join(featuresDir, slice.name, 'hooks');
+    if (!existsSync(hooksDir)) continue;
+    for (const f of readdirSync(hooksDir)) {
+      if (!HOOK_FILE_RE.test(f)) continue;
+      entries.push({
+        slice: slice.name,
+        file: f,
+        from: path.join(hooksDir, f),
+        to: path.join(featuresDir, slice.name, 'model', f),
+      });
+    }
+  }
+  return entries;
+}
+
+/** src 配下の全 `.ts/.tsx` を列挙（node_modules/dist は除外）。 */
+function allSourceFiles(srcRoot: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (e.name === 'node_modules' || e.name === 'dist') continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (/\.tsx?$/.test(e.name)) out.push(full);
+    }
+  };
+  walk(srcRoot);
+  return out;
+}
+
+function rewriteFile(absPath: string, movedHooks: string[]): boolean {
+  const source = readFileSync(absPath, 'utf8');
+  const api = { jscodeshift: tsx, j: tsx, stats: () => {}, report: () => {} };
+  const next = transform({ source, path: absPath }, api as never, { movedHooks });
+  if (typeof next === 'string' && next !== source) {
+    writeFileSync(absPath, next);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * srcRoot（`…/frontend/src`）に A1 を適用する。
+ * dryRun=true なら fs を触らず plan（moves / movedHooks）だけ返す。
+ */
+export function applyA1(srcRoot: string, opts: { dryRun?: boolean } = {}): A1Result {
+  const dryRun = opts.dryRun ?? false;
+  const featuresDir = path.join(srcRoot, 'features');
+  const moves = planMoves(featuresDir);
+  const movedHooks = [...new Set(moves.map((m) => `${m.slice}/${baseKey(m.file)}`))];
+
+  if (dryRun) return { moves, movedHooks, rewritten: [], dryRun: true };
+
+  // 1. fs move（model/ 作成 → rename → 空 hooks/ 削除）
+  const touchedHooksDirs = new Set<string>();
+  for (const m of moves) {
+    mkdirSync(path.dirname(m.to), { recursive: true });
+    renameSync(m.from, m.to);
+    touchedHooksDirs.add(path.dirname(m.from));
+  }
+  for (const d of touchedHooksDirs) {
+    if (existsSync(d) && readdirSync(d).length === 0) rmdirSync(d);
+  }
+
+  // 2. import rewrite（全 .ts/.tsx・move 後のパスに対して）
+  const rewritten: string[] = [];
+  for (const f of allSourceFiles(srcRoot)) {
+    if (rewriteFile(f, movedHooks)) rewritten.push(path.relative(srcRoot, f));
+  }
+
+  return { moves, movedHooks, rewritten, dryRun: false };
+}

--- a/packages/nene2-standards/src/migrations/hooks-to-model/transform.test.ts
+++ b/packages/nene2-standards/src/migrations/hooks-to-model/transform.test.ts
@@ -1,0 +1,109 @@
+/**
+ * A1 codemod import rewrite の検出プローブ（AM-16 MUST — 正例・負例）。
+ * 3リナ pre-stage（invoice/vault/deal）の特異ケースを負例として固定する。
+ */
+import { describe, expect, it } from 'vitest';
+import jscodeshift from 'jscodeshift';
+
+import transform, { moveKeyOf, rewriteHooksSegment } from './transform.js';
+
+const tsx = jscodeshift.withParser('tsx');
+function apply(source: string, movedHooks: string[]): string {
+  const api = { jscodeshift: tsx, j: tsx, stats: () => {}, report: () => {} };
+  return transform({ source, path: 'x.tsx' }, api as never, { movedHooks });
+}
+
+describe('A1 transform — 正例（move 対象への参照を書き換える）', () => {
+  it('ui からの相対 import（別スライス）: ../<slice>/hooks/ → ../<slice>/model/', () => {
+    const out = apply(
+      `import { useDealDetailPage } from '../deal-detail/hooks/use-deal-detail-page';\n`,
+      ['deal-detail/use-deal-detail-page'],
+    );
+    expect(out).toContain(`from '../deal-detail/model/use-deal-detail-page'`);
+    expect(out).not.toContain('hooks/');
+  });
+
+  it('同一スライス内の相対 import: ./hooks/ → ./model/', () => {
+    const out = apply(`import { useLogin } from './hooks/use-login';\n`, ['login/use-login']);
+    expect(out).toContain(`from './model/use-login'`);
+  });
+
+  it('barrel re-export（export { … } from ./hooks/…）も書き換わる', () => {
+    const out = apply(`export { useDocumentSearch } from './hooks/use-document-search';\n`, [
+      'document-search/use-document-search',
+    ]);
+    expect(out).toContain(`from './model/use-document-search'`);
+  });
+
+  it('named export/import 識別子は不変（(a) move-only・リネームしない）', () => {
+    const out = apply(`import { useLogin, type LoginPage } from './hooks/use-login';\n`, [
+      'login/use-login',
+    ]);
+    expect(out).toContain('useLogin');
+    expect(out).toContain('LoginPage');
+  });
+});
+
+describe('A1 transform — 🔴 負例（保存すべきものを書き換えない）', () => {
+  it('move 対象でない hook（deal use-kanban-dnd = DOM/interaction・fail-closed 保留）は保存', () => {
+    const src = `import { useKanbanDnd } from '../hooks/use-kanban-dnd';\n`;
+    // movedHooks に use-kanban-dnd を含めない（move 対象は use-kanban-board-page のみ）
+    const out = apply(src, ['kanban-board/use-kanban-board-page']);
+    expect(out).toBe(src); // 一切書き換えない
+  });
+
+  it('型のみ相対 import（deal DealDetailView）: import type を型のまま hooks→model', () => {
+    const out = apply(
+      `import type { DealDetailStatus } from '../deal-detail/hooks/use-deal-detail-page';\n`,
+      ['deal-detail/use-deal-detail-page'],
+    );
+    expect(out).toContain('import type');
+    expect(out).toContain(`from '../deal-detail/model/use-deal-detail-page'`);
+  });
+
+  it('export type（barrel の型 re-export・invoice template-bar）も型のまま書き換わる', () => {
+    const out = apply(`export type { TemplateSnapshot } from './hooks/use-template-bar';\n`, [
+      'template-bar/use-template-bar',
+    ]);
+    expect(out).toContain('export type');
+    expect(out).toContain(`from './model/use-template-bar'`);
+  });
+
+  it('スライス跨ぎ @/ 絶対 import は対象外（相対のみ書き換える）', () => {
+    const src = `import { useAuthToken } from '@/shared/auth/use-auth-token';\n`;
+    const out = apply(src, ['auth/use-auth-token']);
+    expect(out).toBe(src);
+  });
+
+  it('hooks/ でない相対 import（./model/ 既済・./lib/ 等）は触らない', () => {
+    const src = `import { formatDate } from './lib/format-date';\n`;
+    const out = apply(src, ['x/use-x']);
+    expect(out).toBe(src);
+  });
+
+  it('movedHooks が空なら何も書き換えない（fail-safe）', () => {
+    const src = `import { useLogin } from './hooks/use-login';\n`;
+    expect(apply(src, [])).toBe(src);
+  });
+});
+
+describe('A1 transform — ヘルパ単体', () => {
+  it('moveKeyOf: 別スライス相対', () => {
+    expect(moveKeyOf('../deal-detail/hooks/use-deal-detail-page')).toBe(
+      'deal-detail/use-deal-detail-page',
+    );
+  });
+  it('moveKeyOf: 同一スライス相対はワイルドカード', () => {
+    expect(moveKeyOf('./hooks/use-login')).toBe('*/use-login');
+  });
+  it('moveKeyOf: @/ 絶対・hooks 以外は null', () => {
+    expect(moveKeyOf('@/shared/auth/use-auth-token')).toBeNull();
+    expect(moveKeyOf('./lib/format')).toBeNull();
+  });
+  it('rewriteHooksSegment: hooks/use- → model/use-（basename 不変）', () => {
+    expect(rewriteHooksSegment('../deal-detail/hooks/use-deal-detail-page')).toBe(
+      '../deal-detail/model/use-deal-detail-page',
+    );
+    expect(rewriteHooksSegment('./hooks/use-login')).toBe('./model/use-login');
+  });
+});

--- a/packages/nene2-standards/src/migrations/hooks-to-model/transform.ts
+++ b/packages/nene2-standards/src/migrations/hooks-to-model/transform.ts
@@ -1,0 +1,97 @@
+/**
+ * A1 codemod — hooks→model 移行の import rewrite（jscodeshift transform・fleet#66）。
+ *
+ * 規約 01:99「hook は model/ に置く」・01:266「hook ファイルは `use-<kebab>.ts(x)`・model/ 配下」。
+ * この transform は **move されるフックへの相対 import を書き換える**だけ（ロジック不変・migration-only）:
+ *
+ *   import { useDealDetailPage } from '../hooks/use-deal-detail-page'
+ *   → import { useDealDetailPage } from '../model/use-deal-detail-page'
+ *
+ * 設計上の要点（3リナ pre-stage の特異ケースを反映）:
+ * - **move 対象だけ書き換える**: `options.movedHooks`（`"<slice>/<basename>"` の集合）に含まれる
+ *   フックへの参照のみ。move されない hook（deal use-kanban-dnd = DOM/interaction・fail-closed 保留）は保存する。
+ * - **命名は (a) ディレクトリ移動のみ**（`hooks/`→`model/` の1セグメント置換・`use-` は落とさない・
+ *   basename 不変）。リネームしないので **named export / import 識別子は不変**（jscodeshift は識別子を触らない）。
+ * - **`import type` を温存**: `ImportDeclaration.importKind` と specifier の importKind は書き換えないので、
+ *   deal DealDetailView の `import type { DealDetailStatus } from '../hooks/…'`（型のみ相対 import）も型のまま。
+ * - **barrel（index.ts）の re-export も同一規則**: `export { … } from './hooks/…'` /
+ *   `export type { … } from './hooks/…'` は ExportNamedDeclaration の source として同じ置換を受ける。
+ *
+ * 標準の jscodeshift transform 署名。ファイルの move（fs）は姉妹モジュール `move.ts` の責務で、
+ * この transform は move 後（または move と同時）に全 `.ts/.tsx` へ適用して参照を追随させる。
+ */
+import type { API, FileInfo, Options, Transform } from 'jscodeshift';
+
+export interface HooksToModelOptions extends Options {
+  /**
+   * move されるフックの識別集合。各要素は `"<slice>/<basename>"`
+   * （例 `"deal-detail/use-deal-detail-page"`・拡張子なし）。
+   * import path をこの集合と突き合わせ、該当するものだけ `hooks/`→`model/` に書き換える。
+   */
+  movedHooks?: ReadonlyArray<string>;
+}
+
+/** `./hooks/use-x` `../<slice>/hooks/use-x` から `<slice>/<basename>` を取り出す（相対 import のみ）。 */
+export function moveKeyOf(importPath: string): string | null {
+  if (!importPath.startsWith('.')) return null; // スライス跨ぎは @/ 絶対 → 対象外
+  // 同一スライス内の hooks/ 参照（slice 名を持たない）を先に判定（`.` を slice と誤認しないため）:
+  // `./hooks/use-x`（hooks 隣接ファイルから）と `../hooks/use-x`（ui/ 等の子セグメントから）。
+  // FSD ではスライス跨ぎは @/ 絶対（01:128）なので `../hooks/` は必ず同一スライス。
+  const same = importPath.match(/^\.\.?\/hooks\/(use-[^/]+?)(?:\.tsx?)?$/);
+  if (same) return `*/${same[1]}`; // ワイルドカードスライス（basename で緩く照合）
+  // 別スライス `../<slice>/hooks/use-x`（slice 名は `.`/`..` で始まらない）
+  const m = importPath.match(/\/([^/.][^/]*)\/hooks\/(use-[^/]+?)(?:\.tsx?)?$/);
+  if (m) return `${m[1]}/${m[2]}`;
+  return null;
+}
+
+/** import path の `hooks/` セグメントを `model/` に置換（basename・拡張子・use- は不変）。 */
+export function rewriteHooksSegment(importPath: string): string {
+  return importPath.replace(/(^|\/)hooks\/(use-)/, '$1model/$2');
+}
+
+/**
+ * movedHooks に該当するか。`<slice>/<basename>` の完全一致、または同一スライス相対
+ * （moveKeyOf がワイルドカードスライスを返した場合）は basename 一致で許可
+ * （同一スライス内の `./hooks/use-x` は import 元がその slice 内なので安全）。
+ */
+function isMoved(moveKey: string, movedHooks: ReadonlyArray<string>): boolean {
+  if (movedHooks.includes(moveKey)) return true;
+  if (moveKey.startsWith('*/')) {
+    const base = moveKey.slice(2);
+    return movedHooks.some((k) => k.endsWith('/' + base));
+  }
+  return false;
+}
+
+const transform: Transform = (file: FileInfo, api: API, options: HooksToModelOptions) => {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  const movedHooks = options.movedHooks ?? [];
+  let changed = false;
+
+  // import ... from '…/hooks/use-x' と export ... from '…/hooks/use-x'（barrel re-export）の両方。
+  const sources = [
+    ...root.find(j.ImportDeclaration).paths(),
+    ...root.find(j.ExportNamedDeclaration).paths(),
+    ...root.find(j.ExportAllDeclaration).paths(),
+  ];
+
+  for (const p of sources) {
+    const src = p.node.source;
+    if (!src || typeof src.value !== 'string') continue;
+    const importPath = src.value;
+    const key = moveKeyOf(importPath);
+    if (key === null) continue;
+    if (!isMoved(key, movedHooks)) continue; // move されない hook（DOM 等）は保存
+    const next = rewriteHooksSegment(importPath);
+    if (next !== importPath) {
+      src.value = next;
+      changed = true;
+    }
+  }
+
+  return changed ? root.toSource({ quote: 'single' }) : file.source;
+};
+
+export default transform;


### PR DESCRIPTION
Closes #66

フロントリファクタ phase の本丸 A1（hooks→model 横断移行）の versioned codemod。**migration-only**（ロジック不変・move + import rewrite だけ）。

## 何を配るか
各リナが自リポで叩く codemod（`nene2-a1-hooks-to-model <frontend/src> [--dry-run]`）。手作業移設 MUST NOT（#15/W1）。

- **move**: `features/<slice>/hooks/use-*.{ts,tsx}`（併置 test 含む）→ 同 slice `model/`
- **import rewrite**: 相対 import の `hooks/`→`model/` を全サイト書換（AST-aware・jscodeshift）
- **命名 (a) 移動のみ**: `use-` 維持・リネームなし（規約 01:266 命名表 MUST）
- **施主裁定①（07-17）**: DOM/interaction hook も (A) `model/` 一律 → 分類判定なし・全 hooks/use-* を move

## 構成
| ファイル | 役割 |
|---|---|
| `transform.ts` | jscodeshift import rewrite（movedHooks に該当する相対 import のみ・`import type` 温存・@/ 絶対対象外・識別子不変） |
| `move.ts` | fs move + オーケストレーション（planMoves→move→transform・`dryRun` 対応） |
| `cli.ts` | `nene2-a1-hooks-to-model <src> [--dry-run]` |

## AM-16 プローブ 23件緑（正例・負例）
- **import rewrite 14件**: 別/同一スライス相対・**ui からの `../hooks/`**・barrel re-export・movedHooks 外は保存・`import type`/`export type` 温存・@/ 絶対対象外・movedHooks 空で fail-safe
- **e2e move pilot 9件**（vault 構造・一時ディレクトリで実 move）: fs move・空 hooks/ 削除・barrel 追随・**ui 相対直 import 追随**・**DOM hook も move**・dryRun・🔴 **変異で赤**（move 対象0なら壊れたまま検出）

3リナ pre-stage（invoice/vault/deal）の特異ケースを e2e で固定: 型 re-export 保持・複数 hooks/slice・ui 相対直 import（barrel 非経由）・併置 test 非対称・.ts/.tsx 混在。

## 🔴 開発中にテスト/esbuild が捕捉した自作バグ2件（正直な記録）
1. JSDoc 内の `*/basename` が**コメントを早期終了**（esbuild が即捕捉）
2. `moveKeyOf` が `./hooks/` の `.` を slice 名と誤認・`../hooks/`（ui→同一スライス）を取りこぼし（プローブが捕捉）

どちらも「道具が正直に失敗を報告した」例で、AM-16 プローブの価値そのものです。

## 検査
- build ✅ / 全体テスト **359 passed（24ファイル・回帰なし）** / format ✅ / lint（実コード）✅
- `nene2-standards` **1.0.1→1.1.0**（新 export `./migrations/hooks-to-model`・新 bin・`jscodeshift` dependency 追加）

## スコープ外（別レーン）
- **extract**（View 直書き→model hook 新設・deal audit-export/settings）= 別 Issue（ロジック境界の AST 判定は危険・自動化しない）
- **DOM hook の家の 01/05 注記** = standards patch（hub・施主裁定①の是正注記）

**pilot=vault 構造で緑実証済み。実適用は各リナ per-product PR。マージは施主承認後。**
