### PR TITLE
chore(baseline): nene2-standards ^1.1.0 座席充填（A1 codemod 同梱・publish 実在確認済み・#57 順序）

### DIFF
--- a/docs/fleet-baseline.test.ts
+++ b/docs/fleet-baseline.test.ts
@@ -41,10 +41,13 @@ describe('fleet-baseline.json', () => {
     }
   });
 
-  it('発効済み: client ^1.1.0・tokens/standards ^1.0.0（2026-07-14 npm 公開実測: 39/79 files）・i18n ^0.1.0（2026-07-16 施主裁定・publish 待ち）', () => {
+  it('発効済み: client ^1.1.0・tokens ^1.0.0・standards ^1.1.0（2026-07-17 A1 codemod 同梱で minor bump・npm 公開実測 shasum 080230a1）・i18n ^0.1.0', () => {
     expect(baseline.packages['@hideyukimori/nene2-client']).toBe('^1.1.0');
     expect(baseline.packages['@hideyukimori/nene2-tokens']).toBe('^1.0.0');
-    expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^1.0.0');
+    // standards ^1.1.0: A1 hooks→model codemod（新 bin nene2-a1-hooks-to-model）を含む最低版を要求
+    // （^1.0.0 でも 1.1.0 は install されるが、A1 を持つ最低版を fleet-baseline に記録する — AM-12 の結合）。
+    // 2026-07-17 publish 実在確認後に座席充填（#57 順序規範: publish→座席充填）。
+    expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^1.1.0');
     // null（座席のみ）→ ^0.1.0。rc で出すと範囲が ^0.1.0-rc.1 になり、それは 0.1.0 も 0.1.1 も
     // 拾う（semver 実測）ため、版が進んでも全消費リポに prerelease 範囲が残り続ける（#44）
     expect(baseline.packages['@hideyukimori/nene2-i18n']).toBe('^0.1.0');

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -9,7 +9,7 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 | パッケージ | 版 | 状態 |
 | --- | --- | --- |
 | `@hideyukimori/nene2-tokens` | ローカル **1.0.2** / npm **1.0.1** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:27Z / 18:51:15Z）。**1.0.2 は未 publish**（`21ce902` #17/#18 の是正）＝ 2回目以降の手順（下記）で出す |
-| `@hideyukimori/nene2-standards` | ローカル **1.0.1** / npm **1.0.1** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:56Z / 18:51:18Z）＝ **未 publish の差分なし** |
+| `@hideyukimori/nene2-standards` | ローカル **1.1.0** / npm **1.1.0** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1・1.1.0 は publish 済み**（1.1.0 = 2026-07-17・A1 hooks→model codemod 同梱で minor bump・`shasum 080230a1a7db87e74d5e6619117b79d4574baa1d`・新 bin `nene2-a1-hooks-to-model`）＝ **未 publish の差分なし** |
 | `@hideyukimori/nene2-i18n` | ローカル **0.1.0** / npm **0.1.0** | `private` 解除済み（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。**0.1.0 は publish 済み**（2026-07-16T05:46:12Z・`dist-tags latest=0.1.0`・`shasum 36d06bcd65854543c8af1ef971b36eccc1dcb3db`）＝ **未 publish の差分なし**。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記） |
 
 ## 初回 publish（パッケージごとに1回・hide のローカル操作）

--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -4,7 +4,7 @@
   "packages": {
     "@hideyukimori/nene2-client": "^1.1.0",
     "@hideyukimori/nene2-tokens": "^1.0.0",
-    "@hideyukimori/nene2-standards": "^1.0.0",
+    "@hideyukimori/nene2-standards": "^1.1.0",
     "@hideyukimori/nene2-i18n": "^0.1.0"
   }
 }


### PR DESCRIPTION
publish 実在後に座席充填（#57 順序規範）。**1.1.0 実測確認済み**（shasum `080230a1a7db87e74d5e6619117b79d4574baa1d` = hub 提示値と一致・新 bin `nene2-a1-hooks-to-model` 実在）。standards ^1.0.0 → ^1.1.0（A1 codemod を含む最低版を fleet-baseline に記録・AM-12 結合）。fleet-baseline.test.ts 3 passed。**マージは施主承認後。**