### PR TITLE
docs(daily): 2026-07-17 の日報＋docs/daily/README.md 新設 (#70)

### DIFF
--- a/docs/daily/2026-07-17.md
+++ b/docs/daily/2026-07-17.md
@@ -1,0 +1,43 @@
+# 2026-07-17
+
+A1 codemod（hooks→model 移行）を実装・publish し、批准前提 (a) の全119件仕分けを完了して 07-21 green の道を確定させた日。統合リナ（hub）の報告も自分の見立ても実測してから使う姿勢を通し、自分の概算ミス・行番号 typo・codemod の自作バグを、実測とテストと hub の機械検証が繰り返し捕まえて訂正した。フロントリファクタ phase の本丸（A1）と W0a 批准の詰めが同日に進んだ。
+
+## A1 codemod（hooks→model 横断移行）
+
+- **PR #67（マージ済み — 施主実行〔実測: gh で MERGED 確認〕）**。`nene2-standards` に migration-only codemod を同梱（`features/<slice>/hooks/use-*.{ts,tsx}` → 同 slice `model/`・AST-aware import rewrite・命名は (a) 移動のみ＝規約 01:266）。施主裁定①で DOM hook も (A) model/ 一律。
+- **AM-16 プローブ 23件緑〔実測〕**（import rewrite 14 + e2e move pilot 9・pilot=vault 構造・変異で赤）。全体テスト **359 passed〔実測〕**。
+- **nene2-standards 1.1.0 publish（施主実行）**・`shasum 080230a1a7db87e74d5e6619117b79d4574baa1d`〔hub 提示値を自分で `npm view` 照合〕。**fleet-baseline ^1.1.0 bump PR #68（マージ済み・施主実行〔実測〕）**（#57 順序=publish 実在後に座席充填）。
+- 3リナ pre-stage（invoice/vault/deal）を裏取りして受入基準を固めた。deal の use-kanban-dnd（DOM hook）で **規約穴を発見**（DOM interaction hook の家が語彙に無い＝01:99 一律 vs 05:916 限定）→ 施主裁定 (A) で解決。
+- 開発中に自作バグ2件（JSDoc の `*/` 早期終了・moveKeyOf の `.` 誤認）を esbuild とプローブが捕捉。
+- 4リナ適用 **2/4 完走（deal/payout）〔hub 伝聞〕**・invoice/vault 進行中。
+
+## 批准前提 (a) の仕分け完了 — 07-21 green 確定
+
+- **全119件 = firm 51 + needs-impl 35 + D 15 + [P] 7 + B 11〔実測: 全件目視 + subagent fan-out〕**（勘定がぴったり合う）。
+- 成果物（すべて hub の追記ベルトで適用・機械検証 PASS）: firm-26 正座標リスト（Issue #63）・(2b) 格下げワークリスト56件・**needs-impl 検査器実装レーン台帳 Issue #69**。
+- **untaggedMusts 162 → 64**（#62 較正 + firm 51 タグ追記 + 格下げ）。firm-26 反映で **-26 ちょうど・malformed 增0＝空虚タグゼロ〔hub 機械検証・-26 は自分で照合〕**。
+- 施主裁定: needs-impl 27件（後に **35 に訂正**）は (X) SHOULD 格下げ（G-1「タグの書けない MUST は SHOULD＋issue化」）→ W1 で検査器実装後に必須へ復帰。
+- 73仕分けは **subagent fan-out（Sonnet 一次分類 → Opus 確定）**。subagent が私の hint の誤り（DF-2 を [P] と渡したが本文表では [E] 確定）を捕捉。
+- ★教訓: **概算を実測扱いしない**。firm 28→25、needs-impl 27→35、行番号 -1 typo（287→288）、格下げ注記の「MUST」を checker が数える罠（hub 発見・#69 記録）——どれも自分のサマリ/概算を実測・表と再照合せず出したミスで、実測・機械検証が訂正した。
+
+## concierge C1 eslint sanction（G-7 レーン）
+
+- ESLint native bulk-suppressions（`--suppress-all`/`--prune-suppressions`）が **shrink-only を実測**〔fleet eslint v9.39.5: 既存違反を凍結→新規違反は exit 非0（error）〕。REG-3 縮小単調と一致・#64 stylelint 版と概念統一 → 「既存負債リポの公式凍結パターン」として sanction。CI では `--suppress-all` を使わない（既存 suppressions を読むだけ）で G-7 担保。
+
+## その他
+
+- Issue #63（(a) 分母・仕分け）・#64（core stylelint baseline）・#65（components-allowlist kind）・#66（A1）・#69（needs-impl 台帳）起票。
+- **#65 設計固め**（kind = DEBT components-allowlist・seed 2本 vault156/invoice381 揃い・testid 雛形）。hub 承認で #65 を #64 より先（vault の 1-blocker）。
+
+## 残タスク・申し送り
+
+- **#65 components-allowlist kind 実装（最優先・vault Lane1 緑化・seed 2本入力）** — 実装本体は A1 規模なので新鮮な状態で（長文脈の精度低下を避ける）。
+- 導入文5件の checker 較正（#61 拡張・実 doc 座標 288/435/530/126/714 で照合）・#64 core baseline・AM-1 fill 見積り（07-18）・A1 dry-run 表示バグ（#13）・CLAUDE.md 日報正本差し替え（付録B・#15）。
+
+## 📊 本日の数字
+
+- PR: **#67（A1・マージ済み）/ #68（baseline・マージ済み）**〔自分で gh 確認〕。
+- Issue: #63/#64/#65/#66/#69 起票。
+- untaggedMusts **162 → 64**〔hub 機械検証・firm-26 の -26 は自分で照合〕。
+- A1 プローブ **23件緑**・全体テスト **359 passed**〔実測〕。
+- nene2-standards **1.1.0 publish**・shasum 080230a1〔施主実行・自分で照合〕。

--- a/docs/daily/README.md
+++ b/docs/daily/README.md
@@ -1,0 +1,11 @@
+# docs/daily — nene2-fleet-tooling の日報
+
+このリポ**内**の作業の記録（作業日は可能な限り 1日1ファイル `YYYY-MM-DD.md`）。
+
+- **`_work/` との線引き**: 横断・戦略・複数リポにまたがる話・事業議論は `_work/daily/`・`_work/discussion-log/` が正（`/home/xi/docker/CLAUDE.md`）。ここには書かない。
+- **置き場・命名・書式・運用の正本**: `_work/daily-report-convention.md`（# YYYY-MM-DD・リード段落・## トピック＋PR/Issue 番号・**数字は実測/伝聞を書き分ける**・📊 は任意）。
+
+## 索引（新しい順）
+
+- [2026-07-17](2026-07-17.md) — A1 codemod 実装・publish（PR #67/#68 マージ）／批准前提(a) 全119件仕分け完了で 07-21 green 確定／concierge C1 sanction
+- [2026-07-16](2026-07-16.md) — `check:exemplars` が規約 A-10 に違反していた日（PR 6本マージ・Issue 7本起票）


### PR DESCRIPTION
Closes #70

本日の日報。**書式はフリート正本** `_work/daily-report-convention.md`（# YYYY-MM-DD・**実測/伝聞の書き分け**・成果を大きく書かない・frontmatter なし）。docs/daily/README.md も正本§4で新設（役割・_work 線引き・索引）。

本日の実測: A1 codemod（PR #67 マージ済み）・fleet-baseline ^1.1.0（PR #68 マージ済み）・nene2-standards 1.1.0 publish（shasum 080230a1 自分で照合）・批准前提(a) 全119件仕分け完了（07-21 green 確定）・untaggedMusts 162→64。doc のみ・マージは施主承認後。