### PR TITLE
fix(standards): check:standards-doc の未配布注記つき rule-id を deferred 扱いに（#72）

### DIFF
--- a/packages/nene2-standards/src/checks/standards-doc.ts
+++ b/packages/nene2-standards/src/checks/standards-doc.ts
@@ -35,6 +35,15 @@ const MACHINE_TAG_KINDS: readonly TagKind[] = ['E', 'S', 'T', 'G', 'C', 'X'];
 /** タグ文法説明のプレースホルダ綴り（rule-id 照合をスキップ）。 */
 const RULE_ID_PLACEHOLDERS: ReadonlySet<string> = new Set(['rule-id', 'rule', '…', '...']);
 
+/**
+ * 未配布注記（`[E:<rule>（未配布——…）]`）。配布 config に未有効化のルールを著者が
+ * **明示注記**したもの＝意図的な W0b 送りであり、綴り誤り（missing）とは意味が違う。
+ * placeholder と同種の「照合対象外」として deferred 扱いにし件数を報告する（skip は green の
+ * 根拠にしない）。注記の無い不存在 rule-id は従来どおり missing（fail-open にしない）。
+ * 綴りは正規化前の raw id に対して照合する（normalizeRuleId が `（…）` を落とすため）。
+ */
+const RULE_ID_DEFERRED_MARKER = '未配布';
+
 const TAG_RE = /\[([ESTGCXP])(?::([^\]]*))?\]/g;
 const MUST_RE = /\bMUST(?:\s+NOT)?\b/;
 const FENCE_RE = /^\s*(```|~~~)/;
@@ -113,7 +122,7 @@ export interface UntaggedMust {
   text: string;
 }
 
-export type RuleIdStatus = 'ok' | 'missing' | 'placeholder' | 'malformed';
+export type RuleIdStatus = 'ok' | 'missing' | 'placeholder' | 'malformed' | 'deferred';
 
 export interface RuleIdFinding {
   file: string;
@@ -292,7 +301,10 @@ export function auditStandardsDoc(
           const kind = tag.kind;
           const candidate = normalizeRuleId(tag.id);
           const base = { file: tag.file, line: tag.line, raw: tag.raw, kind, candidate };
-          if (RULE_ID_PLACEHOLDERS.has(candidate)) {
+          if (tag.id.includes(RULE_ID_DEFERRED_MARKER)) {
+            // 著者が「未配布」と明示注記＝意図的な W0b 送り（missing ではない）。raw id で照合。
+            ruleIdFindings.push({ ...base, status: 'deferred' });
+          } else if (RULE_ID_PLACEHOLDERS.has(candidate)) {
             ruleIdFindings.push({ ...base, status: 'placeholder' });
           } else if (candidate === '') {
             ruleIdFindings.push({ ...base, status: 'malformed' });
@@ -332,7 +344,8 @@ export function auditStandardsDoc(
     `MUST 総数 ${mustTotal}（タグ付き ${mustTagged}・機械強制タグ付き ${mustMachineTagged}・タグ欠落 ${untaggedMusts.length}）`,
     `見出しの MUST ${headingMustsSkipped} 件は監査対象外（規範の名前であって本体ではない — skip は green の根拠にしない）`,
     `rule-id 照合: ok ${ruleIdFindings.filter((f) => f.status === 'ok').length} / ` +
-      `missing+malformed ${ruleIdFailures.length} / placeholder スキップ ${ruleIdFindings.filter((f) => f.status === 'placeholder').length}`,
+      `missing+malformed ${ruleIdFailures.length} / placeholder スキップ ${ruleIdFindings.filter((f) => f.status === 'placeholder').length}` +
+      ` / 未配布 deferred ${ruleIdFindings.filter((f) => f.status === 'deferred').length}`,
     `[P] 列挙外 ${pEnumerationFailures.length}・[X] 委譲 ${refs.length} 参照（解決は check:exemplars）`,
   );
 
@@ -428,7 +441,8 @@ export function renderStandardsDocMarkdown(report: StandardsDocReport): string {
   out.push(
     `補足: rule-id 照合 ok ${report.ruleIdFindings.filter((f) => f.status === 'ok').length} 件` +
       `（うち prefix 補完解決 ${report.ruleIdFindings.filter((f) => f.resolvedTo !== undefined).length} 件）・` +
-      `構文プレースホルダのスキップ ${report.ruleIdFindings.filter((f) => f.status === 'placeholder').length} 件。` +
+      `構文プレースホルダのスキップ ${report.ruleIdFindings.filter((f) => f.status === 'placeholder').length} 件・` +
+      `未配布注記の deferred ${report.ruleIdFindings.filter((f) => f.status === 'deferred').length} 件。` +
       `[X:file#anchor] は ${report.exemplarRefsDelegated} 参照を check:exemplars へ委譲（G-2）。`,
   );
   out.push('');

--- a/packages/nene2-standards/tests/standards-doc.test.ts
+++ b/packages/nene2-standards/tests/standards-doc.test.ts
@@ -201,6 +201,39 @@ describe('auditStandardsDoc — (ii) rule-id 実在照合（RAT-2）', () => {
   });
 });
 
+describe('auditStandardsDoc — (ii) 未配布注記つき rule-id は deferred（#72）', () => {
+  it('現物: 未配布注記つき [E:rule] は deferred＝red にしない・件数を報告する', () => {
+    // 04-i18n.md:348 / 02-data-flow.md:739 等の現物形（配布 config 未有効化を著者が明示）
+    const r = audit(
+      'View は網羅 switch MUST `[E:@typescript-eslint/switch-exhaustiveness-check（未配布——配布 config 未設定の空隙）]` [T]\n',
+    );
+    expect(r.ruleIdFailures).toHaveLength(0);
+    expect(r.ruleIdFindings.filter((f) => f.status === 'deferred')).toHaveLength(1);
+    expect(r.state).toBe('green');
+  });
+
+  it('未配布でも [T] 等の裏付けタグがあれば MUST 自体はタグ済み（untagged にしない）', () => {
+    const r = audit(
+      'export は named のみ MUST `[E:import-x/no-default-export（未配布——W0b）]` [T]\n',
+    );
+    expect(r.untaggedMusts).toHaveLength(0);
+  });
+
+  it('🔴 fail-open の負例: 未配布注記の無い不存在 rule-id は従来どおり missing（deferred が漏れない）', () => {
+    const r = audit('境界は zones で強制 MUST `[E:zones]`\n');
+    expect(r.ruleIdFailures).toHaveLength(1);
+    expect(r.ruleIdFailures[0]?.status).toBe('missing');
+    expect(r.ruleIdFindings.filter((f) => f.status === 'deferred')).toHaveLength(0);
+  });
+
+  it('未配布は raw id で判定する（normalize が注記を落としても deferred を取りこぼさない）', () => {
+    // 実在ルール + 未配布注記 → 著者が「未配布」と言う以上 deferred（missing でも ok でもない）
+    const r = audit('MUST `[E:no-restricted-imports（未配布——W0b 追加候補）]`\n');
+    expect(r.ruleIdFindings[0]?.status).toBe('deferred');
+    expect(r.ruleIdFailures).toHaveLength(0);
+  });
+});
+
 describe('auditStandardsDoc — [P] 列挙制（G-3）と (iv) カバレッジ', () => {
   it('故意 fail: [P:process] 以外の id 付き [P] は red', () => {
     const r = audit('MUST [P:review]\n');


### PR DESCRIPTION
Closes #72

## 論点
`check:standards-doc` の RAT-2 実在照合で、`[E:<rule>（未配布——…）]`（配布 config に未有効化のルールを著者が**明示注記**した形）が **missing** に計上され、批准前提 (a) の red を作っていた。これは placeholder と同種の「照合対象外」であって綴り誤りではない（著者が「未配布」と明示＝意図的な W0b 送り）。

## 変更
- `RuleIdStatus` に `deferred` を追加。**raw id** に「未配布」注記を含む `[E]/[S]` は `deferred` とし、`ruleIdFailures`（red の根拠）から除外。件数を details / red-list 補足に報告（skip は green の根拠にしない）。
- 注記の無い不存在 rule-id は従来どおり `missing`＝**fail-open にしない**。

## 検証（実測）
- 単体プローブ4本同梱: 現物形が deferred・untagged 非該当・🔴 fail-open 負例（注記無し missing が漏れない）・raw id 判定（normalize が注記を落としても取りこぼさない）。**test 363 passed**（+4）。
- reports HEAD（統合リナの 1a/1b 17編集適用後）で `npm run build && standards-doc` 実行: **rule-id missing+malformed 6 → 0 / deferred 6**。tag欠落 61→53 は本 PR のスコープ外（別レーン: 構造マーカー §3・SHOULD格下げ §1c）。
- `npm run check` 全緑（type-check / lint / format / test / check:cli / conformance 非blocker / AM-2 gate PASS）。

## 出所
統合リナ裁定 2026-07-17（§3b 未配布6件 skip 化 = 先行実装 GO）。#63 の誤検知仕分けの残。#61 較正の続き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)