### PR TITLE
feat(standards): registries に components-allowlist kind を新設（DEBT・#65 第1弾）

### DIFF
--- a/packages/nene2-standards/src/registries/registries.test.ts
+++ b/packages/nene2-standards/src/registries/registries.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   ALL_KINDS,
+  DEBT_KINDS,
   parseRegistries,
   REGISTRIES_SCHEMA_ID,
   stripJsonc,
@@ -172,7 +173,39 @@ describe('stripJsonc', () => {
     expect(JSON.parse(stripJsonc(src))).toEqual({ a: 'http://example.com', b: [1, 2] });
   });
 
-  it('kind 列挙は 9種＋scoped-theme＋transition＋waiver', () => {
-    expect(ALL_KINDS).toHaveLength(11);
+  it('kind 列挙は 9種＋scoped-theme＋transition＋waiver＋components-allowlist', () => {
+    expect(ALL_KINDS).toHaveLength(12);
+    expect(ALL_KINDS).toContain('components-allowlist');
+  });
+});
+
+describe('components-allowlist kind（#65 — DEBT・縮小単調）', () => {
+  it('有効な components-allowlist エントリは green', () => {
+    const ok = validateRegistries(
+      doc([
+        {
+          kind: 'components-allowlist',
+          id: 'vault-components',
+          repo: 'nene-vault',
+          classes: ['tbl', 'audit-row', 'rail-link'],
+        },
+      ]),
+      NOW,
+    );
+    expect(ok).toEqual([]);
+  });
+
+  it('classes 欠落・空配列・非文字列要素は FAIL（fail-closed）', () => {
+    for (const bad of [{}, { classes: [] }, { classes: ['ok', 3] }]) {
+      const diags = validateRegistries(
+        doc([{ kind: 'components-allowlist', id: 'x', repo: 'nene-x', ...bad }]),
+        NOW,
+      );
+      expect(diags.some((d) => d.message.includes('classes'))).toBe(true);
+    }
+  });
+
+  it('DEBT_KIND に含まれる（縮小単調の対象 — REG-3）', () => {
+    expect(DEBT_KINDS).toContain('components-allowlist');
   });
 });

--- a/packages/nene2-standards/src/registries/schema.ts
+++ b/packages/nene2-standards/src/registries/schema.ts
@@ -15,7 +15,7 @@
 export const REGISTRIES_SCHEMA_ID = 'nene2-registries/1';
 
 /** 負債台帳 kind（縮小単調 — 追加・変更 FAIL・削除のみ可。green にはエントリ 0 が必要） */
-export const DEBT_KINDS = ['legacy-manifest', 'lint-baseline'] as const;
+export const DEBT_KINDS = ['legacy-manifest', 'lint-baseline', 'components-allowlist'] as const;
 
 /** 構造レジストリ kind（恒久・中央 PR＋reason-ref で追加可・蒸し返し禁止） */
 export const STRUCTURAL_KINDS = [
@@ -72,6 +72,18 @@ export interface LegacyManifestEntry extends EntryBase {
   /** pinned prettier 整形後の行数（AM-25': 初期値は init --scan 実測値・0 プレースホルダ MUST NOT） */
   maxLines: number;
   maxBytes: number;
+}
+
+export interface ComponentsAllowlistEntry extends EntryBase {
+  kind: 'components-allowlist';
+  /**
+   * `@layer components` の grandfather 済みクラス（完全一致列挙 — 会議R4 AM-10決定）。
+   * 初期値は `init --scan` 実測（手書き列挙 MUST NOT — G-7/AM-13(ii)）。縮小単調（REG-3 DEBT）＝
+   * 新規クラスの追加 FAIL・削除のみ可（green は 0＝legacy 債務の完済）。repo 単位で1エントリ。
+   * リポごとに統べる機構が違う: components-allowlist（vault/invoice）と legacy-manifest（deal）は
+   * 兄弟 registry（deal は @layer legacy 包込のため本 kind のエントリを持たない・hub 裁定 2026-07-17）。
+   */
+  classes: string[];
 }
 
 export interface LintBaselineEntry extends EntryBase {
@@ -134,6 +146,7 @@ export type RegistryEntry =
   | AuthorizedDivergenceEntry
   | WaiverEntry
   | LegacyManifestEntry
+  | ComponentsAllowlistEntry
   | LintBaselineEntry
   | InjectorEntry
   | ScopedThemeEntry
@@ -323,6 +336,11 @@ export function validateRegistries(source: string, now = new Date()): RegistryDi
         }
         break;
       }
+      case 'components-allowlist':
+        // grandfather 済みクラスの完全一致列挙（init --scan 実測）。空エントリは無意味＝FAIL
+        // （0 クラスなら entry を持たない＝payout/deal 型。green は entry 0）。
+        requireStringArray(raw, 'classes', id, diags);
+        break;
       case 'lint-baseline': {
         requireString(raw, 'rule', id, diags);
         requireString(raw, 'initializedBy', id, diags);


### PR DESCRIPTION
#65 の第1弾（foundation）。⚠️ **施主裁定案件**（registries スキーマ＝配布物変更）につき merge は施主承認後。

## 論点
legacy components-allowlist（@layer components の grandfather 済みクラス）の正本モデル。第3案（#65）: **components-allowlist を DEBT_KIND として新設**し、per-repo エントリ・中央 PR（REG-2）＋縮小単調（REG-3）で管理＝「中央 vs per-repo」の二択を既存枠組みで解く（G-7 に規約 patch 不要）。

## 変更
- `ComponentsAllowlistEntry { kind, id, repo, classes: string[] }`（`legacy-manifest` と同型・DEBT）。`classes` は init --scan 実測の完全一致列挙・非空 MUST（手書き列挙 MUST NOT — AM-10/G-7）。
- `DEBT_KINDS` に追加（縮小単調＝新規クラス追加 FAIL・削除のみ・green は entry 0）。`ALL_KINDS` 11→12。

## 3リポ ground truth（設計前提・出典 _work/reports の seed 3本）
- vault=**156** / invoice=**381** → components-allowlist 統治。
- deal=**0**（@layer legacy 包込）→ legacy-manifest 統治（hub 裁定 2026-07-17 = (A) 確定・本 kind の entry 持たない）。
- payout=0-green。
- ⇒ 「リポごとに統べる機構が違う」を前提に、components-allowlist と legacy-manifest は兄弟 registry。

## スコープ（1PR=1論点）
本 PR は **kind 定義のみ**。後続:
- Piece 2: registries→stylelint override 生成器（供給欠落の根治・allowedClasses/legacy files を repo 別に合成）。
- Piece 3: init --scan が本 kind を emit。

## 検証
- プローブ3本: 有効 green・classes 欠落/空/非文字列 FAIL（fail-closed）・DEBT 所属。
- `npm run check` 全緑（test 370・AM-2 gate PASS）。exhaustiveness 回帰なし（tsc 緑）。

出所: #65（invoice/vault/deal seed 実測・hub 裁定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)