### PR TITLE
feat(standards): stylelintConfigFor — 台帳由来 secondary の合成（#65 第2弾・arm 実効部）

### DIFF
--- a/packages/nene2-standards/src/stylelint/index.ts
+++ b/packages/nene2-standards/src/stylelint/index.ts
@@ -8,7 +8,17 @@
  * ここでは**未指定＝fail-closed（空集合）**。実効値は registries から機械生成した override を
  * ゲート導入 PR（W1）で合成する — 手書き列挙 MUST NOT（会議R4 AM-10/AM-13(ii)決定・G-7）。
  */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
 import type { Config } from 'stylelint';
+
+import {
+  parseRegistries,
+  type ComponentsAllowlistEntry,
+  type LegacyManifestEntry,
+  type RegistriesDocument,
+} from '../registries/schema.js';
 
 const config: Config = {
   plugins: ['@hideyukimori/nene2-standards/stylelint-plugin'],
@@ -58,3 +68,53 @@ const config: Config = {
 };
 
 export default config;
+
+/**
+ * 台帳由来 secondary を焼いた stylelint config を合成する（#65 — 供給経路の欠落の根治）。
+ *
+ * base config は `layer-components-allowlist` / `layer-legacy-manifest-only` を fail-closed（空集合）
+ * で持つ。本関数は**中央 registries の当該 repo エントリ**から実効値を焼く:
+ * - components-allowlist（vault/invoice 型）→ `allowedClasses`
+ * - legacy-manifest（deal 型）→ `files`
+ * どちらのエントリも持たない repo（payout 型・未登録）は base のまま＝fail-closed（G-6）。
+ *
+ * **供給元は中央 registries のみ**（被検査者=product が書けるファイルは読まない）。これにより
+ * 「合成そのものを被検査者の手から取り上げる」＝G-7 を API で強制する（手書き列挙 MUST NOT）。
+ */
+export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: string): Config {
+  const forRepo = doc.entries.filter((e) => e.repo === repo);
+  const classes = forRepo
+    .filter((e): e is ComponentsAllowlistEntry => e.kind === 'components-allowlist')
+    .flatMap((e) => e.classes);
+  const files = forRepo
+    .filter((e): e is LegacyManifestEntry => e.kind === 'legacy-manifest')
+    .map((e) => e.path);
+  const rules: NonNullable<Config['rules']> = { ...config.rules };
+  if (classes.length > 0) {
+    rules['nene2/layer-components-allowlist'] = [true, { allowedClasses: [...classes].sort() }];
+  }
+  if (files.length > 0) {
+    rules['nene2/layer-legacy-manifest-only'] = [true, { files: [...files].sort() }];
+  }
+  return { ...config, rules };
+}
+
+/**
+ * 製品側 stylelint.config.js のコピペ正本（#65 arm の実効部）:
+ * `import { stylelintConfigFor } from '@hideyukimori/nene2-standards/stylelint';`
+ * `export default stylelintConfigFor('nene-vault');`
+ *
+ * 同梱の中央 registries（fleet.jsonc）を読み、`repo` の台帳を焼いて返す。
+ *
+ * ⚠️ `repo` は**自己申告**である。理論上、別リポ名を渡して他リポの allowlist を借用する迂回が
+ * ありうる（例: invoice が 'nene-vault' を渡すと vault の許可クラスを借りる）。現実には config 1行の
+ * diff レビューで可視＋故意でしか起きないが、**将来の gate-integrity 拡張で「引数 repo ↔ 実リポの
+ * 同一性」を照合する**（それまでは中央 PR レビューが担保）。
+ */
+export function stylelintConfigFor(repo: string): Config {
+  const source = readFileSync(
+    fileURLToPath(new URL('../../registries/fleet.jsonc', import.meta.url)),
+    'utf8',
+  );
+  return stylelintConfigFromRegistries(parseRegistries(source), repo);
+}

--- a/packages/nene2-standards/src/stylelint/registry-config.test.ts
+++ b/packages/nene2-standards/src/stylelint/registry-config.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #65 Piece 2 — stylelintConfigFor / stylelintConfigFromRegistries（台帳由来 secondary の合成）。
+ * 4型（vault=allowlist / deal=legacy-manifest / payout=0 / 未登録=fail-closed）＋ G-7 隔離を固定。
+ */
+import { describe, expect, it } from 'vitest';
+
+import { REGISTRIES_SCHEMA_ID, type RegistriesDocument } from '../registries/schema.js';
+import config, { stylelintConfigFor, stylelintConfigFromRegistries } from './index.js';
+
+function docOf(entries: RegistriesDocument['entries']): RegistriesDocument {
+  return { schema: REGISTRIES_SCHEMA_ID, entries };
+}
+
+describe('stylelintConfigFromRegistries — 台帳由来 secondary の合成', () => {
+  it('vault 型（components-allowlist）: allowedClasses を焼く（ソート済み）', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'components-allowlist',
+          id: 'vault-c',
+          repo: 'nene-vault',
+          classes: ['tbl', 'audit-row', 'rail-link'],
+        },
+      ]),
+      'nene-vault',
+    );
+    expect(r.rules?.['nene2/layer-components-allowlist']).toEqual([
+      true,
+      { allowedClasses: ['audit-row', 'rail-link', 'tbl'] },
+    ]);
+    // legacy-manifest は base のまま（fail-closed）
+    expect(r.rules?.['nene2/layer-legacy-manifest-only']).toBe(true);
+  });
+
+  it('deal 型（legacy-manifest）: files を焼く・allowlist は base のまま', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'legacy-manifest',
+          id: 'deal-s',
+          repo: 'nene-deal',
+          path: 'src/shared/ui/styles.css',
+          maxLines: 100,
+          maxBytes: 2000,
+        },
+        {
+          kind: 'legacy-manifest',
+          id: 'deal-d',
+          repo: 'nene-deal',
+          path: 'src/shared/ui/designs.css',
+          maxLines: 200,
+          maxBytes: 4000,
+        },
+      ]),
+      'nene-deal',
+    );
+    expect(r.rules?.['nene2/layer-legacy-manifest-only']).toEqual([
+      true,
+      { files: ['src/shared/ui/designs.css', 'src/shared/ui/styles.css'] },
+    ]);
+    expect(r.rules?.['nene2/layer-components-allowlist']).toBe(true);
+  });
+
+  it('payout 型（エントリ0）・未登録 repo: base のまま＝fail-closed（G-6）', () => {
+    for (const repo of ['nene-payout', 'nene-does-not-exist']) {
+      const r = stylelintConfigFromRegistries(docOf([]), repo);
+      expect(r.rules?.['nene2/layer-components-allowlist']).toBe(true);
+      expect(r.rules?.['nene2/layer-legacy-manifest-only']).toBe(true);
+    }
+  });
+
+  it('🔴 G-7 隔離: 他リポのエントリは焼かれない（repo で厳密フィルタ）', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'components-allowlist',
+          id: 'vault-c',
+          repo: 'nene-vault',
+          classes: ['tbl'],
+        },
+      ]),
+      'nene-invoice', // invoice には自分のエントリが無い
+    );
+    // invoice は vault の allowlist を借用しない＝base のまま
+    expect(r.rules?.['nene2/layer-components-allowlist']).toBe(true);
+  });
+
+  it('base config の他ルール・overrides は保持する（rules を破壊しない）', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([{ kind: 'components-allowlist', id: 'x', repo: 'nene-vault', classes: ['a'] }]),
+      'nene-vault',
+    );
+    expect(r.rules?.['color-no-hex']).toBe(true);
+    expect(r.overrides).toEqual(config.overrides);
+  });
+});
+
+describe('stylelintConfigFor — 同梱中央 registries を読む', () => {
+  it('現行 fleet.jsonc は components-allowlist 未登録＝どの repo も base（fail-closed）で返る・throw しない', () => {
+    const r = stylelintConfigFor('nene-vault');
+    expect(r.rules?.['nene2/layer-components-allowlist']).toBe(true);
+    expect(r.plugins).toEqual(config.plugins);
+  });
+});


### PR DESCRIPTION
#65 の第2弾（arm の実効部）。⚠️ **施主裁定案件**（配布物）につき merge は施主承認後。API 形は統合リナ裁定済み（`stylelintConfigFor(repo)`・2026-07-18）。

## 論点
#65 が特定した「供給経路の欠落」の根治。base config（`stylelint/index.ts`）は `layer-components-allowlist` / `layer-legacy-manifest-only` を **fail-closed（空集合）**で持つが、実効値を registries から焼く生成器が存在しなかった（Piece 1 の kind は inert）。

## 変更
- `stylelintConfigFromRegistries(doc, repo)`（pure・テスト可能）: components-allowlist→`allowedClasses`・legacy-manifest→`files`。どちらも無い repo は base のまま＝fail-closed（G-6）。
- `stylelintConfigFor(repo)`（公開 API）: 同梱の中央 registries（fleet.jsonc）を読んで焼く。product は `export default stylelintConfigFor('nene-vault')` の1行。
- **供給元は中央 registries のみ**＝合成を被検査者の手から取り上げ **G-7 を API で強制**。repo 引数の自己申告リスクは docblock 明記＋将来 gate-integrity で「引数 repo ↔ 実リポ同一性」照合（それまで中央 PR レビュー担保）。

## これで 3型 arm 可能に
vault(156)/invoice(381)=allowlist・**deal=legacy-manifest**（(A)裁定）・payout=0-green。

## 検証
- プローブ6本: vault型（allowedClasses ソート）/deal型（files）/payout+未登録（fail-closed）/🔴G-7隔離（他リポの allowlist を借用しない）/base の他ルール・overrides 保持/同梱 fleet.jsonc 読取（throw しない）。
- `npm run check` 全緑（test 376・AM-2 gate PASS）。

## 後続
Piece 3: init --scan が components-allowlist を emit。arm 手順（product の stylelint.config.js を1行化＋中央 registries に repo エントリ登録）は各リポ Wave G。

出所: #65（第3案）・統合リナ API 裁定 2026-07-18。

🤖 Generated with [Claude Code](https://claude.com/claude-code)