### PR TITLE
docs(daily): 2026-07-18 の日報＋新セッション pickup（#80）

### DIFF
--- a/docs/daily/2026-07-18.md
+++ b/docs/daily/2026-07-18.md
@@ -1,0 +1,83 @@
+# 日報 — 2026-07-18（nene2-fleet-tooling）
+
+> 期間注記: 本セッションは 2026-07-17 日中に着手し 07-18 未明にかけて走った1本。07-17.md（PR #71・別セッション＝A1 codemod 深夜バースト）とは別物なので 07-18 として起こす。
+
+## ヘッドライン
+
+完全準拠キャンペーン初日。**批准前提 (a)（`check:standards-doc` green）を red→green で1日でクローズ**し、続けて施主 GO の Phase 1 本線で **#65 components-allowlist kind の実装本体3枚（#77/#78/#79）を landed** まで通した。統合リナ（hub）指揮下で、古いキューと裁定の前提の穴を実測で差し戻しつつ、出した全 PR を machine-verify（scratch 適用→checker/test 再実行）で裏取りした。マージは施主 seam を守り、都度 hide の個別委任を取ってから hub が実行した。
+
+## 本日の成果（時系列）
+
+### 批准前提 (a) — 残 61/15 → green 0/0
+
+- **A 列（tag 列）作成**: `check:standards-doc` の未処理76件（未タグ MUST 61＋rule-id 失敗15）を G-1 基準で全件分類（未分類0・重複0）。〔自分で実測: reports HEAD・6文書 SHA ピン〕。成果物 `_work/handoff-fleet-tooling-to-hub-2026-07-17-ratification-a-column.md`。
+  - 機械検証: 22編集を scratch reports に適用→checker 再実行で **未タグ 61→48・rule-id 15→6・新規0**（fail-open 無し）を実証してから hub へ渡した。〔自分で実測〕
+- **hub 手番の適用**: §1 の17編集＋1c（SHOULD格下げ5・施主承認）＋§2 の tags/格下げを hub が適用。hub 独立再計測 = 私の予告と完全一致。最終 pin = **MUST 248・タグ欠落0・非規範マーカー除外43・rule-id 0**（checker 版 fleet main f713e69）。〔hub 提示 pin。私も scratch で43→0 を確認済み〕
+- **fleet checker 2枚**:
+  - **#72 / PR #73 — 未配布注記 rule-id を `deferred` 化（マージ済）**: rule-id 失敗 6→0。missing と分離・注記無しは従来どおり missing（fail-open にしない）。
+  - **#74 / PR #75 — `<!-- nonnormative -->` 構造マーカー対応（マージ済）**: 述べる/言及の分離（施主確定＝doc 側マーキング）。43行付与で未タグ 43→0。行単位・非伝染（fail-open 負例プローブ2本）。
+- hub が43行にマーカー付与→再計測 **exit 0（green）**。付与スクリプトの MUST 存在チェック警告 **0件**＝§3分類43行の座標が全数正確だった裏取り。〔hub 実測・座標一致は機械確認〕
+
+### #65 components-allowlist kind — 実装本体3枚 landed
+
+- **#77 — kind 新設（マージ済）**: `components-allowlist` を DEBT_KIND（`{repo, classes[]}`・legacy-manifest と同型・REG-3 縮小単調・中央 PR REG-2 で G-7 担保）。ALL_KINDS 11→12。
+- **#78 — 生成器 `stylelintConfigFor(repo)`（マージ済・arm 実効部）**: #65 が指した「供給経路の欠落」の根治。中央 registries の当該 repo エントリから secondary（allowedClasses / legacy files）を焼く。供給元は中央のみ＝合成を被検査者の手から取り上げ G-7 を API で強制。API 形は hub 裁定。
+- **#79 — init --scan の emit（マージ済・施主委任で hub 実行）**: 走査→id 付き registries エントリ（`validateRegistries` 往復緑＝貼れる正本形）。T-3 ガード/initCheck を新 kind に追随。CLI 出力を registries-paste-ready 形に。
+- 3リポ ground truth（出典 `_work/reports` の seed 3本）: vault **156** / invoice **381** = allowlist 統治・deal = legacy-manifest 統治（allowlist **0**・manifest 2）・payout = 0-green。**deal は hub 裁定 (A)** で legacy-manifest 型確定（universe223 先積みは T-3「実測から生成・記憶で列挙しない」に反する）。
+- #65 本文の ⚠️「供給経路 未精査」を実測解消（生成器が存在しないことを grep 確認）。
+
+### 実測駆動の差し戻し・反証（hub の像を正した）
+
+- 朝のキュー2件が古い像と判明→証拠つき差し戻し→**hub 全面採用**: ①A1 codemod は 1.1.0 に **publish 済み**（「codemod 待ち」は誤り・bin/PR#67/publish.md で確認） ②firm 数は **26**（「28」は旧称）。
+- **C（namespace (i)reject）の裁定前提を実測反証**: 「silent は非対称1つの症状・fallback 除去で根治」は不成立（`--font-size-body` は 'font' が表の実在 prefix ゆえ fallback を通らず silent 受理が残る）。→ hub が board 台帳を訂正。C=part-1 のみ／part-2 は別 issue＋設計ノート先行（hub 推し B1）。
+- **Issue #76 起票**: 批准前提 (b) の enabler = nene2-i18n に `./testing` export が無い（npm 0.1.0・source とも exports は `.` のみ＝実測確認）→ payout の [X] アンカー3本が植えられない。0.2.0 系で ./testing を積む道。
+
+## 📊 本日の数字（すべて自分で実測。渡された数字は明示）
+
+- **PR: #73 / #75 / #77 / #78 / #79 — 全マージ済**（#77–79 は施主個別委任→hub 実行・#79 は hub squash）。〔gh で確認〕
+- **Issue 起票: #72 / #74 / #76 / #80**（#72・#74 は PR で close）。
+- **(a): 未タグ MUST 61→0・rule-id 15→0**（自分で scratch 機械検証 61→48→〔hub 適用〕43→0／hub pin 248 タグ付き・marker43）。
+- **test: 359 → 380（+21）**（#73 +4・#75 +4・#77 +3・#78 +6・#79 +4）。〔`npm run check` で確認・全緑・AM-2 gate PASS〕
+- main = **42ed264**（#79 landed）。
+
+## 🔴 自分の誤り・迷いと、どう捕まえたか
+
+- **A 列の 1c（I18N-22/24 core の SHOULD 格下げ）を自分で決め打ちしかけた**が、core 条文の弱体化＝施主案件と判断し「要 施主確認」で分離して出した→施主承認で正しく通った。単独裁定していたら踏み外していた。
+- **#75 を #73 にスタックした**ため details 行の衝突が出たが、#73 merge 後に rebase してクリーン単一コミットで解消（手順を踏めば無事故）。
+- 大きな踏み外しは無し。理由は毎 PR の **machine-verify ループ**（build→test→全 check→scratch 実証）が疲労非依存で効いたから。数字は一度も概算で出さず、scratch/checker/gh で裏取りしてから relay した。
+
+## 明日への引き継ぎ（＝新セッション pickup）
+
+> 施主が今夜このあと新セッションを起動して続きを走らせる（「実走は新鮮セッションが正」の条件を朝を待たず満たす形）。#79 は landed 済み（main 42ed264）。
+
+### 一本道（機械的・上から順に）
+
+1. **#79 landed 確認**: `git fetch && git checkout main && git merge --ff-only origin/main`。main に #77/#78/#79（42ed264）。
+2. **init --scan を実リポで実走（read-only）**: vault / deal / invoice の各 frontend で `@hideyukimori/nene2-standards@最新` を scratch 配線（`--no-save`・vault #238 / payout PR#189 と同形）→ `node <nene2-standards>/dist/checks/cli.js init --scan --repo nene-xxx --registries <中央 fleet.jsonc>`。
+3. **REG-2 登録 PR**: 実走出力 `entries`（`{schema, entries}` の paste-ready 形）を中央 `packages/nene2-standards/registries/fleet.jsonc` の entries に貼る（REG-2 中央 PR・**施主 merge**）。
+4. **hub へ relay** → **arm 一斉中継は hub**（vault/deal/invoice）。
+5. その後 **tokens release 準備**（task 化済み・Phase 1 発射条件）→ i18n 0.2.0（#76）。
+
+### ハマりどころ（1行ずつ）
+
+- CLI 出力は **id 付き registries-valid**（`validateRegistries` を通る）＝そのまま fleet.jsonc へ貼れる。**手写し MUST NOT**（AM-10/G-7）＝必ず実走生成を貼る。
+- **deal は components-allowlist 0・legacy-manifest 2（styles/designs）想定**（(A)裁定・seed と一致するはず・実走で確認）。vault=156・invoice=381 想定。
+- **T-3 ガード**: 対象 repo の台帳が既存だと `init --scan` は実行拒否（再走査は `--check` 読み取り専用のみ）。初回は空台帳（該当 repo エントリ無し）で撃つ。
+- arm 手順（product 側）: `stylelint.config.js` を `export default stylelintConfigFor('nene-xxx')` の1行化＋中央 registries に repo エントリ登録（＝上の REG-2 PR）。
+
+### tokens release 準備（Phase 1 発射条件・#65 の後）
+
+- W1 blocker 修正（#35 x-送り namespace 保存・#50 拡張トークン導出・#34/#43）が **未 publish**＝npm tokens 1.0.1 のまま。W1 は npm 実在版でしか撃てない（M-1）ので **tokens publish が Phase 1 発射条件**。
+- semver 判断（1.0.2 か束ねて 1.1.0）は fleet に委任。publish.md 監査は standards 1.1.0 と同型。**publish は施主 seam**（準備完了を hub へ relay→施主上程）。
+- release note 明記2点（hub 依頼）: (1) 適用済みリポ re-run の idempotence（no-op）保証範囲 (2) dead/unknown-namespace token（`--line-x-height-body` 等）の挙動＝**C part-1 の (i)reject と整合**（loud reject が原理・実装済みは #50 導出・(i)reject は C 完了後、を正直に）。
+- 確認2点（1行回答）: (a) 写像表 v1 payout 分は現行 npm 束に入るか (b) known-utility lint（AM-13）は standards 1.1.0 で発射可か・standards bump 要るか。
+
+### 未着手キュー（順序 hub 確定）
+
+- **C part-1**（`tailwindNamespaceOf` の regex fallback 除去＝ns=null で生成側 reject・起票 GO・関連 #17）＋ part-2 設計ノート（hub 推し B1 hint-reject 表・longest-match 網羅の確認込み）。
+- **D**（`_work/issues.md` #59 の NENE2 lock-drift 横断監査・read-only）: hub の adoption-audit（`_work/reports/2026-07-18-fleet-tooling-adoption-audit.md`）が答え合わせの起点（symlink drift・deal/origin vendor lock 違反・payout dangling ref）。
+
+### 注意
+
+- **明日の出発点の数字（vault156/invoice381/deal 0-2）は seed 実測に基づく想定＝実走で確かめてから施主に出す**（憶測を実測扱いしない）。
+- マージは施主 seam（本リポ規約＋hide 運用）。hub の中継承認だけでは merge しない・都度直接確認（今日は #77/#78/#79 とも個別委任を取れた。恒常化するなら規約改訂を fleet から提案する筋）。


### PR DESCRIPTION
Closes #80

キャンペーン初日の日報。批准前提 (a) を red→green で1日クローズ（#73/#75）＋#65 実装本体3枚 landed（#77/#78/#79）。実測プロベナンス付き・マージ有無/実測vs渡された数字を書き分け・成果を大きく書かない（書式=2026-07-16.md 準拠）。

施主指示で **今夜起動する新セッション用の pickup 節**を同梱（一本道: #79 landed 確認→init --scan 実走→REG-2 登録 PR→hub relay/arm→tokens release 準備。ハマりどころ: CLI paste-ready 形・deal は allowlist 0/manifest 2・T-3 ガード）。

daily 慣行の routine ドキュメント（配布物変更なし）。CI 緑で self-merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)