### PR TITLE
chore(release): standards 1.2.0＋tokens 1.1.0 の publish 準備（2パッケージ1束・#84）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -8,9 +8,35 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 
 | パッケージ | 版 | 状態 |
 | --- | --- | --- |
-| `@hideyukimori/nene2-tokens` | ローカル **1.0.2** / npm **1.0.1** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:27Z / 18:51:15Z）。**1.0.2 は未 publish**（`21ce902` #17/#18 の是正）＝ 2回目以降の手順（下記）で出す |
-| `@hideyukimori/nene2-standards` | ローカル **1.1.0** / npm **1.1.0** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1・1.1.0 は publish 済み**（1.1.0 = 2026-07-17・A1 hooks→model codemod 同梱で minor bump・`shasum 080230a1a7db87e74d5e6619117b79d4574baa1d`・新 bin `nene2-a1-hooks-to-model`）＝ **未 publish の差分なし** |
+| `@hideyukimori/nene2-tokens` | ローカル **1.1.0** / npm **1.0.1** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1 は publish 済み**（2026-07-14T14:24:27Z / 18:51:15Z・1.0.1 = tag `nene2-tokens-v1.0.1` = `4438e6a` #27）。**1.1.0 は未 publish**（#84 準備・下記「publish 待ち束」）。旧ローカル表記 1.0.2（`21ce902`）は束に feat #32 を含むため minor へ改番（semver 判断は fleet 委任 — 2026-07-18 pickup） |
+| `@hideyukimori/nene2-standards` | ローカル **1.2.0** / npm **1.1.0** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1・1.1.0 は publish 済み**（1.1.0 = 2026-07-17・`ddce2e2` #67・A1 hooks→model codemod 同梱で minor bump・`shasum 080230a1a7db87e74d5e6619117b79d4574baa1d`・新 bin `nene2-a1-hooks-to-model`）。**1.2.0 は未 publish**（#84 準備・下記「publish 待ち束」） |
 | `@hideyukimori/nene2-i18n` | ローカル **0.1.0** / npm **0.1.0** | `private` 解除済み（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。**0.1.0 は publish 済み**（2026-07-16T05:46:12Z・`dist-tags latest=0.1.0`・`shasum 36d06bcd65854543c8af1ef971b36eccc1dcb3db`）＝ **未 publish の差分なし**。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記） |
+
+## publish 待ち束（2026-07-18 準備・#84 — 施主上程は2パッケージ1回）
+
+> 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ（tokens: `nene2-tokens-v1.0.1`=`4438e6a` → main・standards: npm 1.1.0=`ddce2e2` → main）。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
+
+### `@hideyukimori/nene2-standards` 1.2.0（minor — feat を含む）
+
+未 publish コミット（`ddce2e2`..main・6件）:
+
+- feat: registries に **components-allowlist kind** 新設（#77）・**stylelintConfigFor** — 台帳由来 secondary の合成（#78・arm 実効部）・**init --scan が components-allowlist を emit**＋T-3/initCheck 追随（#79）
+- REG-2 実走台帳の同梱（#82）: vault 156 classes / invoice 381 classes / deal legacy-manifest 2 を `registries/fleet.jsonc` に登録済み。**`files` に `registries` を含むため npm 同梱される**（= arm の前提。stylelintConfigFor は同梱中央 registries しか読まない）
+- fix: check:standards-doc の deferred 扱い分離（#73）・`<!-- nonnormative -->` 構造マーカー対応（#75）
+
+### `@hideyukimori/nene2-tokens` 1.1.0（minor — feat を含むため 1.0.2 から改番）
+
+未 publish コミット（`4438e6a`..main・5件）:
+
+- **feat: 語彙 codemod ランナー同梱**（jscodeshift・T-4 の実行物・#32）— tarball 実測で `dist/codemod.js`・`dist/codemod-transform.js`・CLI サブコマンド `codemod`/`codemod-plan` を確認。payout 実弾は fixture テストで固定（fixtures 自体は tarball 非同梱）。**写像表 v1 の payout 分（ランナー実行物）はこの束で初めて npm に載る**（v1.0.0/1.0.1 は写像表のみで実行物なし）
+- fix（W1 ブロッカー束）: validate:themes の fill 誇称是正（#34）・**x- 送りの Tailwind v4 namespace 保存**（#35）・@import layer() 二重指定封じ（#43）・**拡張トークン検査の namespace 表導出**（#50 — 道具が自分の生成物を拒否していた W1 ブロッカーの解消）
+
+release note 明記2点（hub 依頼・正直表記）:
+
+1. **適用済みリポ re-run の idempotence（no-op）保証範囲**: themegen `fill` は不動点（fixed point）を**テストで保証**（`themegen.test.ts`「fill is idempotent」）。codemod は写像キーが旧名のみ＝適用済みコードに再走しても書き換え対象が残らない設計（衝突検出 #27）。**フリート実リポでの re-run 実測はまだ無い** — 保証はテスト・設計由来の範囲。
+2. **dead/unknown-namespace token（`--line-x-height-body` 等）の挙動**: 写像側は未知名を **reject（fail-closed・null → 呼び出し側 error・写像を発明しない）**が実装・テスト済み。**生成側の loud reject（(i)reject＝`tailwindNamespaceOf` regex fallback 除去）は C part-1 で未実装** — 本束に入っているのは #50 の導出までで、(i)reject は C 完了後（原理: loud reject・実装状況を誇称しない）。
+
+publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run → 本番とも**施主実行**。成功後に fleet-baseline.json の null → 実版数の**別 PR**（下記「publish 成功後にやること」）。
 
 ## 初回 publish（パッケージごとに1回・hide のローカル操作）
 

--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-standards",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules, A1 hooks→model migration codemod",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-tokens/package.json
+++ b/packages/nene2-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-tokens",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "NeNe Core Token Contract v1 — contract types, CONTRACT_TOKENS, validate:themes CLI, themegen, codemod mapping table v1 + jscodeshift codemod runner, reference theme",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
#84（Step4・hub GO 2026-07-18）。standards＋tokens の2パッケージ publish 上程（施主・2つ1束）のための release 準備 PR。

## 変更3点

1. **version bump**: standards 1.1.0 → **1.2.0** / tokens 1.0.2（未 publish のローカル表記）→ **1.1.0**
2. **docs/publish.md 対象表の監査更新**（実測 provenance: tag/npm view 突き合わせ）
3. **「publish 待ち束」節を新設**: 両束の未 publish コミット列挙＋release note 明記2点（idempotence 保証範囲・dead/unknown-namespace 挙動を正直表記）

## semver 判断（fleet 委任分・hub 表記 1.0.2 からの変更）

tokens 束は fix のみではなく **feat #32（語彙 codemod ランナー同梱・T-4 実行物）を含む** — tag 実測 `nene2-tokens-v1.0.1`=`4438e6a` 以降の未 publish は #32/#34/#35/#43/#50。後方互換の機能追加を含む束は semver 上 minor＝**1.1.0**（patch 1.0.2 は不適切）。standards は feat #77/#78/#79/#82 を含み **1.2.0**（hub 表記どおり）。

## 機械証拠（実測）

- `npm run check` 全緑: 25 files / **381 tests**・conformance red 0・**AM-2 release gate PASS**（契約凍結一致）
- `npm publish --dry-run` 両パッケージ:
  - standards **1.2.0**: 97 files / 366.7 kB unpacked・**`registries/fleet.jsonc`（17.5 kB）同梱確認**＝arm の前提（stylelintConfigFor は同梱中央 registries しか読まない）
  - tokens **1.1.0**: 45 files / 268.3 kB unpacked・**ランナー実体同梱確認**（`dist/codemod.js`・`dist/codemod-transform.js`・CLI `codemod`/`codemod-plan`）。payout fixtures はテスト専用で非同梱（誇称しない）

## publish 手順（この PR の下流・すべて施主実行）

merge 後: Actions → Publish npm → 各パッケージ dry_run: true → 本番。成功後に fleet-baseline.json null → 実版数の**別 PR**（publish.md 記載の既存手順）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
