### PR TITLE
docs(daily): 2026-07-18 の日報にセッション2 を追記（一本道 Step1〜4・#86）

### DIFF
--- a/docs/daily/2026-07-18.md
+++ b/docs/daily/2026-07-18.md
@@ -81,3 +81,36 @@
 
 - **明日の出発点の数字（vault156/invoice381/deal 0-2）は seed 実測に基づく想定＝実走で確かめてから施主に出す**（憶測を実測扱いしない）。
 - マージは施主 seam（本リポ規約＋hide 運用）。hub の中継承認だけでは merge しない・都度直接確認（今日は #77/#78/#79 とも個別委任を取れた。恒常化するなら規約改訂を fleet から提案する筋）。
+
+---
+
+## セッション2（深夜・新セッション pickup の一本道を消化）
+
+> 施主指示で統合リナ（hub）指揮下の新セッションとして起動。#80 の pickup「一本道」を Step1〜4 まで走り切った。publish 2手（Actions dry_run → 本番）は施主 seam で明朝想定。
+
+### 成果（時系列・PR/Issue つき）
+
+- **起動時の裏取りで pickup の前提誤りを1件検出**: 「npm@最新を scratch 配線」とあるが、npm 最新 1.1.0 は 2026-07-16T16:16Z publish で #77/#78/#79 未収載〔npm view time 実測〕＝ components-allowlist が emit されない。hub へ relay → 裁定 (a)「ローカル build の dist で実走」を取得。
+- **Step2 — init --scan 実走3本（read-only）**: 生成器 main 3c19c98 のローカル build を各 frontend cwd で実行（対象 SHA: vault 3692641 / deal c33f34a / invoice c6a1a17・全てクリーンツリー〔実測〕）。実走値 vault **156** classes / invoice **381** classes / deal allowlist 0＋legacy-manifest **2**（designs.css 1128行/27,890B・styles.css 1696行/38,766B）〔実測〕。**seed 期待値と全件一致・差分なし**（一致の確認も実走で）。
+- **Step3 — REG-2 登録 PR #82**: 実走出力を fleet.jsonc へ機械転記（手写しなし）。validateRegistries GREEN・check 全緑（380→**381** tests・陳腐化テスト1本を登録後の現実へ更新）〔実測〕。**マージ済み**（施主個別委任・squash `3d1a5e7`〔gh で実測確認〕）。
+- **Step4 — release 準備 Issue #84 → PR #85**: standards **1.2.0**・tokens **1.1.0** へ bump＋publish.md「publish 待ち束」監査節。dry-run 実測で standards に registries/fleet.jsonc（17.5kB）同梱・tokens にランナー実体（dist/codemod.js ほか）同梱を確認〔実測〕。**マージ済み**（施主個別委任・squash `b013013`〔実測確認〕）。**publish は未実施**（npm は standards 1.1.0 / tokens 1.0.1 のまま〔実測〕・施主 seam）。
+- **tokens semver を hub 表記 1.0.2 から 1.1.0 へ改番**: tag 実測（`nene2-tokens-v1.0.1`=`4438e6a`..main）で束に feat #32（codemod ランナー同梱）を確認 → patch は semver 違反。判断は pickup で fleet 委任済みの範囲・hub APPROVE で追認。
+- pickup の確認2点に実測回答: (a) 写像表 v1 payout 分（ランナー実行物）は tokens 1.1.0 の束で初 npm 収載 (b) known-utility lint は entryPoint seam が standards 1.0.1 から出荷済み＝1.1.0 のまま発射可・bump 不要。
+- 記事ネタ2本を articles リナへ relay（standing 任務・「merged ≠ released の罠」「semver は tag..HEAD で数える」）。
+
+### 🔴 自分の誤り・迷いと、どう捕まえたか
+
+- **validateRegistries に parsed オブジェクトを渡して空振り**（引数は raw ソース文字列）。「jsonc パース不能」の診断で即気づき、シグネチャを実読して是正 — 機械証拠は正しい呼び方で取り直した。
+- **scan 出力の集計スクリプトで legacy-manifest の field 名を想定で書いて TypeError**。集計をやめて出力現物を直接読む方に切り替えた（想定より現物）。
+- publish.md 初稿で「payout fixtures 込み」と書いたが、tarball 実測で fixtures は**非同梱**（テスト専用）と判明 → 誇称になる前に表現を是正。
+
+### 📊 セッション2の数字
+
+- PR **2本 landed**（#82・#85・いずれも施主個別委任 squash〔gh 実測〕）・Issue 3起票（#84・#86・うち #86 は本日報）
+- test **381**（+1・25 files 全緑・AM-2 gate PASS〔npm run check 実測〕）
+- npm publish は **0回**（未実施が正 — 施主 seam 待ち。standards 1.1.0 / tokens 1.0.1 のまま〔npm view 実測〕）
+
+### 申し送り（明朝）
+
+1. 施主 publish 2手（dry_run → 本番・2パッケージ）→ landed は hub が中継。
+2. publish 後: **fleet-baseline null → 実版数の別 PR**（fleet-tooling リナ＝私）→ hub の arm 一斉中継（vault/deal/invoice の stylelint.config 1行化＋bump）→ payout PR-A → vault W1。


### PR DESCRIPTION
日報規約正本 §1 の同日複数セッション追記。daily 慣行（routine 自走 self-merge 可・#80 本文）に乗り、CI 緑で self-merge する。数字は実測/伝聞を書き分け済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)