### PR TITLE
fix(baseline): fleet-baseline を実在版へ追随 — standards ^1.2.0 / tokens ^1.1.0（#96）

### DIFF
--- a/docs/fleet-baseline.test.ts
+++ b/docs/fleet-baseline.test.ts
@@ -41,13 +41,15 @@ describe('fleet-baseline.json', () => {
     }
   });
 
-  it('発効済み: client ^1.1.0・tokens ^1.0.0・standards ^1.1.0（2026-07-17 A1 codemod 同梱で minor bump・npm 公開実測 shasum 080230a1）・i18n ^0.1.0', () => {
+  it('発効済み: client ^1.1.0・tokens ^1.1.0・standards ^1.2.0（2026-07-18 publish landed で実在版追随・npm 公開実測 shasum standards 6b8fd027 / tokens e18befd5）・i18n ^0.1.0', () => {
     expect(baseline.packages['@hideyukimori/nene2-client']).toBe('^1.1.0');
-    expect(baseline.packages['@hideyukimori/nene2-tokens']).toBe('^1.0.0');
-    // standards ^1.1.0: A1 hooks→model codemod（新 bin nene2-a1-hooks-to-model）を含む最低版を要求
-    // （^1.0.0 でも 1.1.0 は install されるが、A1 を持つ最低版を fleet-baseline に記録する — AM-12 の結合）。
-    // 2026-07-17 publish 実在確認後に座席充填（#57 順序規範: publish→座席充填）。
-    expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^1.1.0');
+    // tokens ^1.1.0: 2026-07-18 publish landed（写像表 v1 payout 分＋codemod ランナー同梱の最低版）。
+    // npm latest=1.1.0・dist.shasum e18befd55354be6002b236859746ebcf89399b91（fleet-tooling 実測）。
+    expect(baseline.packages['@hideyukimori/nene2-tokens']).toBe('^1.1.0');
+    // standards ^1.2.0: 2026-07-18 publish landed（registries/fleet.jsonc 同梱・components-allowlist kind）。
+    // npm latest=1.2.0・dist.shasum 6b8fd02714cdc9f52fc469c07bc71327a3d4071a（fleet-tooling 実測）。
+    // #57 順序規範（publish→座席充填）どおり、publish 実在確認後にフロアを実在版へ追随。
+    expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^1.2.0');
     // null（座席のみ）→ ^0.1.0。rc で出すと範囲が ^0.1.0-rc.1 になり、それは 0.1.0 も 0.1.1 も
     // 拾う（semver 実測）ため、版が進んでも全消費リポに prerelease 範囲が残り続ける（#44）
     expect(baseline.packages['@hideyukimori/nene2-i18n']).toBe('^0.1.0');

--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -3,8 +3,8 @@
   "schemaVersion": 1,
   "packages": {
     "@hideyukimori/nene2-client": "^1.1.0",
-    "@hideyukimori/nene2-tokens": "^1.0.0",
-    "@hideyukimori/nene2-standards": "^1.1.0",
+    "@hideyukimori/nene2-tokens": "^1.1.0",
+    "@hideyukimori/nene2-standards": "^1.2.0",
     "@hideyukimori/nene2-i18n": "^0.1.0"
   }
 }


### PR DESCRIPTION
## 変更
`fleet-baseline.json` のフロアを publish landed の実在版へ追随：
- `@hideyukimori/nene2-standards`: `^1.1.0` → `^1.2.0`
- `@hideyukimori/nene2-tokens`: `^1.0.0` → `^1.1.0`
- 据え置き: client `^1.1.0` / i18n `^0.1.0`（今回 publish 対象外）

腐敗防止テスト `docs/fleet-baseline.test.ts` の固定値も新現実へ更新。

## 裏取り（実測）
- `npm view @hideyukimori/nene2-standards version` → **1.2.0**（latest）/ dist.shasum `6b8fd027...`
- `npm view @hideyukimori/nene2-tokens version` → **1.1.0**（latest）/ dist.shasum `e18befd5...`
- `npm run check` → **382 tests 全緑**・AM-2 gate PASS。

## 位置づけ
publish 手順 step4 の一部（hub 号令）。#57 順序規範（publish→座席充填）どおり publish 実在確認後に実施。merge は施主 seam。

Closes #96