### PR TITLE
feat(standards): LintBaselineEntry を (rule,file) 粒度へ拡張（P2-A1・#99）

### DIFF
--- a/packages/nene2-standards/src/registries/registries.test.ts
+++ b/packages/nene2-standards/src/registries/registries.test.ts
@@ -209,3 +209,58 @@ describe('components-allowlist kind（#65 — DEBT・縮小単調）', () => {
     expect(DEBT_KINDS).toContain('components-allowlist');
   });
 });
+
+describe('lint-baseline kind の (rule,file) 粒度（#99 — P2 §2 構造負債 grandfather 器）', () => {
+  it('file 在り（CSS 構造 grandfather）は green', () => {
+    const ok = validateRegistries(
+      doc([
+        {
+          kind: 'lint-baseline',
+          id: 'invoice-specificity-index',
+          repo: 'nene-invoice',
+          rule: 'selector-max-specificity',
+          file: 'src/shared/ui/theme/index.css',
+          frozenCount: 149,
+          initializedBy: 'init --scan (P2 ゲート導入)',
+        },
+      ]),
+      NOW,
+    );
+    expect(ok).toEqual([]);
+  });
+
+  it('file 無し（リポ全体 rule baseline・JP-lint 型）も green（optional）', () => {
+    const ok = validateRegistries(
+      doc([
+        {
+          kind: 'lint-baseline',
+          id: 'concierge-jp-baseline',
+          repo: 'nene-concierge',
+          rule: 'no-restricted-syntax (noHardcodedJapanese)',
+          frozenCount: null,
+          initializedBy: 'init --scan (W0b)',
+        },
+      ]),
+      NOW,
+    );
+    expect(ok).toEqual([]);
+  });
+
+  it('file が空文字列は FAIL（在れば非空 MUST・fail-closed）', () => {
+    const diags = validateRegistries(
+      doc([
+        {
+          kind: 'lint-baseline',
+          id: 'x',
+          repo: 'nene-x',
+          rule: 'selector-max-specificity',
+          file: '   ',
+          frozenCount: 0,
+          initializedBy: 'init --scan',
+        },
+      ]),
+      NOW,
+    );
+    expect(diags.some((d) => d.message.includes('file'))).toBe(true);
+  });
+});

--- a/packages/nene2-standards/src/registries/schema.ts
+++ b/packages/nene2-standards/src/registries/schema.ts
@@ -89,6 +89,14 @@ export interface ComponentsAllowlistEntry extends EntryBase {
 export interface LintBaselineEntry extends EntryBase {
   kind: 'lint-baseline';
   rule: string;
+  /**
+   * (rule,file) 粒度の grandfather 対象ファイル（P2 §2・#99）。
+   * - **在り** = CSS 構造ルールの per-file grandfather（stylelint 消費側=config 合成が file 単位で
+   *   当該 rule を null 化する override を焼く。invoice 169 / deal 12 の緑化器）。
+   * - **無し** = リポ全体の rule baseline（eslint noHardcodedJapanese 等・単一 file を持たない負債）。
+   * ※ optional の理由: リポ全体 baseline（JP-lint）は単一 file を持たず、file 必須化は虚偽 file の強要になる。
+   */
+  file?: string;
   /** 凍結違反の件数（init --scan / ゲート導入 PR で実測生成。green には 0 が必要 — AM-14） */
   frozenCount: number | null;
   /** null = ゲート導入時に init --scan で生成（T-3）。生成前の座席登録を明示する */
@@ -344,6 +352,13 @@ export function validateRegistries(source: string, now = new Date()): RegistryDi
       case 'lint-baseline': {
         requireString(raw, 'rule', id, diags);
         requireString(raw, 'initializedBy', id, diags);
+        // file は optional（(rule,file) 粒度・#99）。在るなら非空文字列 MUST・無しはリポ全体 baseline。
+        if ('file' in raw && (typeof raw['file'] !== 'string' || raw['file'].trim() === '')) {
+          diags.push({
+            entryId: id,
+            message: 'file は在れば非空文字列 MUST（(rule,file) 粒度・#99）',
+          });
+        }
         const fc = raw['frozenCount'];
         if (fc !== null && (typeof fc !== 'number' || !Number.isInteger(fc) || fc < 0)) {
           diags.push({ entryId: id, message: 'frozenCount は null（未走査）か非負整数 MUST' });


### PR DESCRIPTION
## P2 registry 再設計 実装レーンA 第1弾（施主 GO 済み・work-order 準拠）

`LintBaselineEntry` を **(rule,file) 粒度**へ拡張し、CSS 構造ルール（selector-max-specificity 等）を per-file で grandfather できる schema を用意する。消費配線（config 合成・overrides null 化）は後続 **PR-A2**。

## 変更
- `file?: string`（optional）を追加。validate は「在れば非空文字列 MUST」。
- test +3: file 在り green / file 無し green / 空 file FAIL。

## 🔎 hub review ポイント: `file` を optional にした設計判断
既存 lint-baseline 2件（concierge/corpus の `noHardcodedJapanese`）は**リポ全体の eslint baseline で単一 file を持たない**。file 必須化はこの2件を壊すか虚偽 file を強要する。
- **file 在り** = CSS 構造 grandfather（stylelint・PR-A2 は file 必須で per-file override を焼く）
- **file 無し** = リポ全体 rule baseline（JP-lint 等・従来どおり）
work-order の「(rule,file) 粒度」は満たしつつ、リポ全体 baseline も壊さない両立形。**この optional 判断に異論あれば A2 着手前に差し戻しを。**

## 実測
- `npm run check` → 385 tests 全緑（+3）・AM-2 gate PASS。既存 fleet.jsonc green 維持。
- standards 2.0.0 予定の一部（破壊的だが未配線 kind の拡張＝実消費者ゼロ）。merge は施主 seam。

Closes #99