### PR TITLE
feat(standards): stylelint 合成が (rule,file) lint-baseline を消費（P2-A2・#101）

### DIFF
--- a/packages/nene2-standards/src/stylelint/index.ts
+++ b/packages/nene2-standards/src/stylelint/index.ts
@@ -17,6 +17,7 @@ import {
   parseRegistries,
   type ComponentsAllowlistEntry,
   type LegacyManifestEntry,
+  type LintBaselineEntry,
   type RegistriesDocument,
 } from '../registries/schema.js';
 
@@ -81,6 +82,16 @@ export default config;
  * **供給元は中央 registries のみ**（被検査者=product が書けるファイルは読まない）。これにより
  * 「合成そのものを被検査者の手から取り上げる」＝G-7 を API で強制する（手書き列挙 MUST NOT）。
  */
+/**
+ * base config が configure する stylelint rule の語彙（core＋nene2/*）。
+ * lint-baseline の rule がこの語彙内なら「合成が意味を理解できる rule」＝(rule,file) grandfather の対象。
+ * 語彙外（eslint 系 noHardcodedJapanese 等）は stylelint config には無関係＝素通し。
+ */
+const KNOWN_STYLELINT_RULES: ReadonlySet<string> = new Set<string>([
+  ...Object.keys(config.rules ?? {}),
+  ...(config.overrides ?? []).flatMap((o) => Object.keys(o.rules ?? {})),
+]);
+
 export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: string): Config {
   const forRepo = doc.entries.filter((e) => e.repo === repo);
   const classes = forRepo
@@ -96,7 +107,24 @@ export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: str
   if (files.length > 0) {
     rules['nene2/layer-legacy-manifest-only'] = [true, { files: [...files].sort() }];
   }
-  return { ...config, rules };
+
+  // (rule,file) lint-baseline を per-file grandfather の override として焼く（P2 §2・#101）。
+  // 語彙内の rule が file 無しで来たら loud error（黙って未消費の座席にしない — invoice 座席事件 /
+  // #92「表に無いものを黙って処理しない」と同族。file 有無 × 語彙内外の4象限を全て明示挙動に）。
+  const overrides = config.overrides ? [...config.overrides] : [];
+  const baselines = forRepo.filter((e): e is LintBaselineEntry => e.kind === 'lint-baseline');
+  for (const b of baselines) {
+    if (!KNOWN_STYLELINT_RULES.has(b.rule)) continue; // 語彙外（eslint 系）は stylelint 合成に無関係＝素通し
+    if (!b.file) {
+      throw new Error(
+        `lint-baseline "${b.id}": rule "${b.rule}" は stylelint 語彙内だが file が無い — ` +
+          `(rule,file) 粒度が必要（黙ってスキップしない・loud error — #101/A2）`,
+      );
+    }
+    overrides.push({ files: [b.file], rules: { [b.rule]: null } });
+  }
+
+  return { ...config, rules, overrides };
 }
 
 /**

--- a/packages/nene2-standards/src/stylelint/registry-config.test.ts
+++ b/packages/nene2-standards/src/stylelint/registry-config.test.ts
@@ -125,3 +125,67 @@ describe('stylelintConfigFor — 同梱中央 registries を読む', () => {
     expect(r.plugins).toEqual(config.plugins);
   });
 });
+
+describe('lint-baseline (rule,file) grandfather の合成（P2-A2・#101）', () => {
+  it('invoice 型（file 在り・語彙内 rule）: 当該 file の当該 rule を null 化する override を足す', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'lint-baseline',
+          id: 'invoice-spec-index',
+          repo: 'nene-invoice',
+          rule: 'selector-max-specificity',
+          file: 'src/shared/ui/theme/index.css',
+          frozenCount: 149,
+          initializedBy: 'init --scan',
+        },
+      ]),
+      'nene-invoice',
+    );
+    const added = (r.overrides ?? []).filter((o) =>
+      (o.files as string[])?.includes('src/shared/ui/theme/index.css'),
+    );
+    expect(added).toHaveLength(1);
+    expect(added[0]?.rules?.['selector-max-specificity']).toBeNull();
+    // base の rule 本体は不変（当該 file 以外では効く）
+    expect(r.rules?.['selector-max-specificity']).toBe(config.rules?.['selector-max-specificity']);
+    // base の overrides（themes/base.css）は保たれる
+    expect((r.overrides ?? []).length).toBe((config.overrides ?? []).length + 1);
+  });
+
+  it('語彙内 rule なのに file 無し → loud error（黙ってスキップしない・hub 追加受入条件）', () => {
+    expect(() =>
+      stylelintConfigFromRegistries(
+        docOf([
+          {
+            kind: 'lint-baseline',
+            id: 'invoice-spec-nofile',
+            repo: 'nene-invoice',
+            rule: 'selector-max-specificity',
+            frozenCount: 149,
+            initializedBy: 'init --scan',
+          },
+        ]),
+        'nene-invoice',
+      ),
+    ).toThrow(/file が無い/);
+  });
+
+  it('語彙外 rule（eslint JP-lint）は file 無しでも素通し（stylelint 合成に無関係・throw しない）', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'lint-baseline',
+          id: 'concierge-jp',
+          repo: 'nene-concierge',
+          rule: 'no-restricted-syntax (noHardcodedJapanese)',
+          frozenCount: null,
+          initializedBy: 'init --scan',
+        },
+      ]),
+      'nene-concierge',
+    );
+    // override は増えない（base のまま）
+    expect((r.overrides ?? []).length).toBe((config.overrides ?? []).length);
+  });
+});


### PR DESCRIPTION
## P2 実装レーンA 第2弾（#101・#100 にスタック）

(rule,file) lint-baseline を **stylelint config 合成が消費**する本体。invoice 169 / deal 12 の構造 red を per-file で grandfather する。**base=feat/99（PR #100）にスタック**＝この PR の diff は A2 分のみ。#100 merge 後に base は main へ retarget。

## 変更
- `stylelintConfigFromRegistries` が repo の lint-baseline を overrides へ焼く:
  - file 在り＋語彙内 rule → `{files:[file], rules:{[rule]:null}}`（per-file grandfather）
  - 語彙内 rule ＋ file 無し → **loud error**（hub 追加受入条件・黙ってスキップ禁止）
  - 語彙外 rule（eslint JP-lint）→ 素通し
- 語彙 `KNOWN_STYLELINT_RULES` は base config の rule キーから実計算。

## 実測
- `npm run check` → 388 tests 全緑（+3: invoice grandfather / 語彙内 file 無し loud error / 語彙外素通し）・AM-2 PASS。
- 4象限（file 有無 × 語彙内外）が全て明示挙動＝器を密閉。

## 次
A4（init --scan が (rule,file) frozenCount 生成）→ B1（per-repo read）→ D-invoice で 169 が実際に green になる受入。merge は施主 seam。

Closes #101