### PR TITLE
feat(standards): init --scan は registries 不在=空で bootstrap 続行（P2 #107）

### DIFF
--- a/packages/nene2-standards/src/checks/cli.ts
+++ b/packages/nene2-standards/src/checks/cli.ts
@@ -25,7 +25,7 @@ import { checkExemplars, renderExemplarsMarkdown, type DocFile } from './exempla
 import { checkGateIntegrity } from './gate-integrity.js';
 import { initCheck, initScan, initScanEntries, ledgersAlreadyInitialized } from './init-scan.js';
 import { REGISTRIES_SCHEMA_ID } from '../registries/schema.js';
-import { loadRegistries, runConformance } from './run.js';
+import { resolveInitRegistries, runConformance } from './run.js';
 import {
   auditStandardsDoc,
   enforcedEslintRuleIds,
@@ -129,7 +129,9 @@ async function main(): Promise<number> {
     }
 
     case 'init': {
-      const { registries, error } = loadRegistries(registriesPath, cwd);
+      // --scan（生成）は registries 不在=空で bootstrap 続行・--check（検証）は不在=中止（#107）。
+      const initMode = flags.has('check') ? 'check' : 'scan';
+      const { registries, error } = resolveInitRegistries(registriesPath, cwd, initMode);
       if (registries === null) {
         console.error(`registries が読めない（fail-closed で中止）: ${error ?? 'unknown'}`);
         return 2;

--- a/packages/nene2-standards/src/checks/run.ts
+++ b/packages/nene2-standards/src/checks/run.ts
@@ -13,7 +13,11 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
-import { parseRegistries, type RegistriesDocument } from '../registries/schema.js';
+import {
+  parseRegistries,
+  REGISTRIES_SCHEMA_ID,
+  type RegistriesDocument,
+} from '../registries/schema.js';
 import {
   CONFORMANCE_KEYS,
   CONFORMANCE_SCHEMA_ID,
@@ -96,6 +100,25 @@ export function loadRegistries(
   } catch (e) {
     return { registries: null, manifestSha: null, error: (e as Error).message };
   }
+}
+
+/**
+ * init の registries 解決（P2 follow-up・#107）。意味論を mode で分離する:
+ * - `scan`（生成）: registries.jsonc **不在＝空とみなして生成へ進む**（fresh repo の初回 bootstrap。
+ *   --scan は空の初回台帳を作る道具＝不在中止は目的と逆）。ただし**在るが形式不正なら null**（fail-closed）。
+ * - `check`（読み取り専用再走査・検証）: 不在＝null（呼び出し側が exit 2）。検証は不在中止が美徳。
+ */
+export function resolveInitRegistries(
+  registriesPath: string | undefined,
+  cwd: string,
+  mode: 'scan' | 'check',
+): { registries: RegistriesDocument | null; error?: string } {
+  const effectivePath = registriesPath ?? path.join(cwd, 'registries.jsonc');
+  if (mode === 'scan' && !existsSync(effectivePath)) {
+    return { registries: { schema: REGISTRIES_SCHEMA_ID, entries: [] } };
+  }
+  const { registries, error } = loadRegistries(registriesPath, cwd);
+  return error !== undefined ? { registries, error } : { registries };
 }
 
 export async function runConformance(options: RunOptions): Promise<ConformanceVector> {

--- a/packages/nene2-standards/tests/nene2-check.test.ts
+++ b/packages/nene2-standards/tests/nene2-check.test.ts
@@ -2,7 +2,8 @@
  * nene2-check（conformance skeleton）— fail-closed（G-6）・5状態ユニオン・gate-integrity・
  * scan-coverage・init --scan の両方向（green＋故意 fail）検査。
  */
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -22,7 +23,7 @@ import {
   initScanEntries,
   ledgersAlreadyInitialized,
 } from '../src/checks/init-scan.js';
-import { runConformance } from '../src/checks/run.js';
+import { resolveInitRegistries, runConformance } from '../src/checks/run.js';
 import {
   parseRegistries,
   REGISTRIES_SCHEMA_ID,
@@ -324,5 +325,34 @@ describe('runConformance（skeleton 全体 — CF-1〜4）', () => {
     // meta（CF-4）: contractVersion = テーマプラグマ最小値
     expect(vector.meta.contractVersion).toBe('1.0');
     expect(vector.meta.manifestSha).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('resolveInitRegistries — scan は不在=空で bootstrap 続行・check は不在=中止（#107）', () => {
+  const tmp: string[] = [];
+  afterAll(() => {
+    for (const d of tmp) rmSync(d, { recursive: true, force: true });
+  });
+  const freshRepo = (): string => {
+    const d = mkdtempSync(path.join(tmpdir(), 'nene2-boot-'));
+    tmp.push(d);
+    return d; // registries.jsonc 無し
+  };
+
+  it('scan: registries 不在 → 空 doc で生成へ進む（fresh repo bootstrap）', () => {
+    const { registries } = resolveInitRegistries(undefined, freshRepo(), 'scan');
+    expect(registries).toEqual({ schema: REGISTRIES_SCHEMA_ID, entries: [] });
+  });
+
+  it('check: registries 不在 → null（呼び出し側が exit 2・fail-closed 維持）', () => {
+    const { registries } = resolveInitRegistries(undefined, freshRepo(), 'check');
+    expect(registries).toBeNull();
+  });
+
+  it('scan: 在るが形式不正 → null（不在だけが空・fail-closed）', () => {
+    const d = freshRepo();
+    writeFileSync(path.join(d, 'registries.jsonc'), '{ not valid registries');
+    const { registries } = resolveInitRegistries(undefined, d, 'scan');
+    expect(registries).toBeNull();
   });
 });


### PR DESCRIPTION
## P2 follow-up（#107・#106 にスタック）— bootstrap 鶏卵の解

B1 の per-repo 既定化の副作用で、`init --scan` が registries 不在の fresh repo で中止し**初回台帳を bootstrap できない**問題（invoice/deal/field 全 arm が踏む）を解く。hub 裁定どおり意味論分離。

## 変更
- `resolveInitRegistries(path, cwd, mode)`:
  - **scan**（生成）: 不在=空 doc で**生成へ進む**（bootstrap）。在るが形式不正なら null（fail-closed）。
  - **check**（検証）: 不在=null（exit 2 維持）。
- cli.ts init が mode で解決を切替。空 seed --registries の暗黙回避策は採らない（手順に一手増やさない）。

## 実測（hub 指定2面＋）
- fresh repo で scan → 空 doc で生成へ進む。
- fresh repo で check → null（exit 2 維持）。
- 在るが不正 → scan でも中止（不在だけが空）。
- `npm run check` → 398 tests 全緑・AM-2 PASS。

merge は施主 seam。Closes #107