### PR TITLE
fix(baseline): fleet-baseline standards ^1.2.0→^2.0.0 追随（2.0.0 publish landed・#114）

### DIFF
--- a/docs/fleet-baseline.test.ts
+++ b/docs/fleet-baseline.test.ts
@@ -41,15 +41,16 @@ describe('fleet-baseline.json', () => {
     }
   });
 
-  it('発効済み: client ^1.1.0・tokens ^1.1.0・standards ^1.2.0（2026-07-18 publish landed で実在版追随・npm 公開実測 shasum standards 6b8fd027 / tokens e18befd5）・i18n ^0.1.0', () => {
+  it('発効済み: client ^1.1.0・tokens ^1.1.0・standards ^2.0.0（2026-07-21 publish landed で実在版追随・npm 公開実測 shasum standards 20e4f3e0 / tokens e18befd5）・i18n ^0.1.0', () => {
     expect(baseline.packages['@hideyukimori/nene2-client']).toBe('^1.1.0');
     // tokens ^1.1.0: 2026-07-18 publish landed（写像表 v1 payout 分＋codemod ランナー同梱の最低版）。
     // npm latest=1.1.0・dist.shasum e18befd55354be6002b236859746ebcf89399b91（fleet-tooling 実測）。
     expect(baseline.packages['@hideyukimori/nene2-tokens']).toBe('^1.1.0');
-    // standards ^1.2.0: 2026-07-18 publish landed（registries/fleet.jsonc 同梱・components-allowlist kind）。
-    // npm latest=1.2.0・dist.shasum 6b8fd02714cdc9f52fc469c07bc71327a3d4071a（fleet-tooling 実測）。
+    // standards ^2.0.0: 2026-07-21 publish landed（BREAKING・per-repo registries.jsonc read＋tarball 同梱撤去）。
+    // npm latest=2.0.0・dist.shasum 20e4f3e0c4cbfb508f788fb2053af4d27d9eae04（fleet-tooling 実測）。
+    // BREAKING なので caret でも 1.x は拾わない（意図どおり）。
     // #57 順序規範（publish→座席充填）どおり、publish 実在確認後にフロアを実在版へ追随。
-    expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^1.2.0');
+    expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^2.0.0');
     // null（座席のみ）→ ^0.1.0。rc で出すと範囲が ^0.1.0-rc.1 になり、それは 0.1.0 も 0.1.1 も
     // 拾う（semver 実測）ため、版が進んでも全消費リポに prerelease 範囲が残り続ける（#44）
     expect(baseline.packages['@hideyukimori/nene2-i18n']).toBe('^0.1.0');

--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -4,7 +4,7 @@
   "packages": {
     "@hideyukimori/nene2-client": "^1.1.0",
     "@hideyukimori/nene2-tokens": "^1.1.0",
-    "@hideyukimori/nene2-standards": "^1.2.0",
+    "@hideyukimori/nene2-standards": "^2.0.0",
     "@hideyukimori/nene2-i18n": "^0.1.0"
   }
 }


### PR DESCRIPTION
Closes #114

## これは何

standards **2.0.0 publish landed**（2026-07-21）を受け、`docs/publish.md`「publish 成功後にやること」L99 の正順で `fleet-baseline.json` のフロアを実在版へ追随する PR。hub 発令①・payout B-1 の前提。

## 変更（1PR=1論点）

- `fleet-baseline.json`: `@hideyukimori/nene2-standards` `^1.2.0` → `^2.0.0`（BREAKING・caret でも 1.x は拾わない）
- `docs/fleet-baseline.test.ts`: 期待値 `^1.2.0`→`^2.0.0`・shasum 注記 `6b8fd027…`→`20e4f3e0…`（未公開版を書かない誠実性ガードの解除・AM-12 の結合）

## 実測（独立裏取り）

| 項目 | 値 |
|---|---|
| npm latest | `2.0.0` |
| dist.shasum | `20e4f3e0c4cbfb508f788fb2053af4d27d9eae04` |
| git tag | `nene2-standards-v2.0.0`（origin 実在・`fab0bfe`） |
| publish run | `29801100666` success |
| `npm run check` | 緑（26 files / **398 tests** passed・AM-2 gate PASS・conformance は unknown=非 blocker） |

## スコープ外

- レーンD（arm 各リポの `registries.jsonc` 配備＋standards devDep pin `^2.0.0`・D-invoice 実証1例目）は本 PR の後の別レーン。
- #58（非 null 座席の npm 実在を機械検査）は既知の別 Issue。

マージは施主 seam。hub レビュー依頼。