### PR TITLE
fix(stylelint): layer-components-allowlist が @keyframes フレームを class 誤検知するのを修正（#116）

### DIFF
--- a/packages/nene2-standards/src/stylelint/keyframes-allowlist.test.ts
+++ b/packages/nene2-standards/src/stylelint/keyframes-allowlist.test.ts
@@ -1,0 +1,60 @@
+/**
+ * #116 回帰: layer-components-allowlist は @layer components 内にネストした
+ * @keyframes のフレーム行（from / to / percentage）を class として reject しない。
+ * 兄弟ルール（noUnlayeredCss 等）と一貫。init-scan も keyframe を class 収集しないので、
+ * 罰する側だけが keyframe を見る非対称＝生成 baseline で緑到達不能を潰す（D-invoice pilot 実測）。
+ * 本リポの programmatic stylelint 実行テスト（init-scan.test.ts と同型）。
+ */
+import stylelint from 'stylelint';
+import { describe, expect, it } from 'vitest';
+
+import plugins from './plugin.js';
+
+const allowlistOnly = (allowedClasses: string[]) => ({
+  plugins,
+  rules: { 'nene2/layer-components-allowlist': [true, { allowedClasses }] },
+});
+
+async function allowlistWarnings(css: string, allowedClasses: string[]): Promise<string[]> {
+  const { results } = await stylelint.lint({ code: css, config: allowlistOnly(allowedClasses) });
+  return results[0].warnings
+    .filter((w) => w.rule === 'nene2/layer-components-allowlist')
+    .map((w) => w.text);
+}
+
+describe('layer-components-allowlist — @keyframes フレームのスキップ（#116）', () => {
+  it('@layer components 内の @keyframes フレーム（from/to）は reject しない', async () => {
+    const css = `@layer components {
+  .spinner { animation: spin 1s linear infinite; }
+  @keyframes spin {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+}
+`;
+    expect(await allowlistWarnings(css, ['.spinner'])).toEqual([]);
+  });
+
+  it('percentage フレーム（0% / 100%）も reject しない', async () => {
+    const css = `@layer components {
+  .bar { animation: grow 1s; }
+  @keyframes grow {
+    0% { width: 0; }
+    100% { width: 100%; }
+  }
+}
+`;
+    expect(await allowlistWarnings(css, ['.bar'])).toEqual([]);
+  });
+
+  it('未登録の実 class は依然 reject する（keyframe スキップが穴を開けていない）', async () => {
+    const css = `@layer components {
+  .known { color: red; }
+  .unknown { color: blue; }
+}
+`;
+    const warnings = await allowlistWarnings(css, ['.known']);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('.unknown');
+  });
+});

--- a/packages/nene2-standards/src/stylelint/plugin.ts
+++ b/packages/nene2-standards/src/stylelint/plugin.ts
@@ -136,6 +136,15 @@ const layerComponentsAllowlist: Rule<true, { allowedClasses?: string[] }> =
     root.walkAtRules('layer', (atRule) => {
       if (!layerParamsInclude(atRule.params, 'components')) return;
       atRule.walkRules((rule) => {
+        // @keyframes のフレーム行（from/to/percentage）は class ではない — 兄弟ルール
+        // （noUnlayeredCss :39-46 等）と一貫してスキップする（#116 — init-scan も keyframe を
+        // class 収集しないので、罰する側だけが keyframe を見る非対称＝生成 baseline で緑到達不能を潰す）。
+        if (
+          rule.parent?.type === 'atrule' &&
+          /keyframes$/i.test((rule.parent as { name?: string }).name ?? '')
+        ) {
+          return;
+        }
         const tokens = classTokens(rule.selector);
         if (tokens.length === 0) {
           report({


### PR DESCRIPTION
Closes #116

## これは何

**D-invoice pilot（実証1例目）が炙り出した standards の実バグ**の修正。`@layer components` 内にネストした `@keyframes` のフレーム行（from/to/percentage）を `layer-components-allowlist` ルールが「class トークン0の rule」として reject していた。

## 原因

`layerComponentsAllowlist`（src/stylelint/plugin.ts）は @layer components 配下の全 rule を `atRule.walkRules` で走査し、`classTokens` が空なら reject する。keyframe フレーム `to {}` は class トークンを持たない → 偽陽性。同 plugin.ts の兄弟ルール（noUnlayeredCss :39-46・他 :611-614）は keyframe スキップガードを持つのに**このルールだけ欠落**。init-scan も keyframe を class 収集しないため、**罰する側だけが keyframe を見る非対称**＝生成 baseline で緑到達不能。

## 変更（1PR=1論点）

- `plugin.ts`: `walkRules` 冒頭に兄弟ルールと同一の keyframe フレームスキップを追加。
- `keyframes-allowlist.test.ts`（新規・programmatic stylelint 3ケース）: from/to・percentage は reject しない／未登録の実 class は依然 reject（穴を開けない）。

## 実証（エンドツーエンド）

| 検証 | 結果 |
|---|---|
| `npm run check` | 🟢 27 files / **401 tests**（+3 keyframe）・AM-2 gate PASS |
| 修正版 standards を pack→nene-invoice clone に install→`stylelint 'src/**/*.css'` | **rc=0（緑）**: 168 構造違反は registries.jsonc で grandfather・keyframe 偽陽性消滅 |
| 同上で新規未登録クラスを注入 | **rc=2（赤）**: `.rina-brand-new-999` を捕捉＝空虚合格でない |

## 影響・後続

@keyframes を @layer components に置く全 repo に効く systemic 欠陥。**D-invoice の緑化前提**。standards 2.0.x patch → publish（施主 seam）後に invoice が registries.jsonc＋config を配備（レーンD 本体）。publish 版数・seam 順序は hub 裁定。

マージは施主 seam。hub レビュー依頼。