### PR TITLE
feat(standards): init --check に lint-baseline count-ratchet を配線（判例20 の穴を閉じる・#119）

### DIFF
--- a/packages/nene2-standards/src/checks/cli.ts
+++ b/packages/nene2-standards/src/checks/cli.ts
@@ -139,9 +139,24 @@ async function main(): Promise<number> {
       if (flags.has('check')) {
         const report = await initCheck(cwd, repo, registries);
         console.log(JSON.stringify(report, null, 2));
-        const count = report.unregisteredClasses.length + report.unregisteredLegacyFiles.length;
-        console.error(`init --check: 未分類 ${count} 件（styling green 条件は 0 件 — AM-10）`);
-        return count > 0 ? 1 : 0;
+        const unclassified =
+          report.unregisteredClasses.length + report.unregisteredLegacyFiles.length;
+        const regressions = report.lintBaselineRegressions.length;
+        console.error(
+          `init --check: 未分類 ${unclassified} 件（styling green 条件は 0 件 — AM-10）／` +
+            `lint-baseline 回帰 ${regressions} 件（count-ratchet FAIL 条件 — AM-14 縮小単調・#119）`,
+        );
+        for (const r of report.lintBaselineRegressions) {
+          console.error(
+            `  回帰: ${r.rule} @ ${r.file} — frozenCount ${r.frozenCount} → 実測 ${r.liveCount}（超過）`,
+          );
+        }
+        for (const s of report.lintBaselineShrinkable) {
+          console.error(
+            `  advisory（縮小可）: ${s.rule} @ ${s.file} — frozenCount ${s.frozenCount} → 実測 ${s.liveCount}（registry を下げられる）`,
+          );
+        }
+        return unclassified + regressions > 0 ? 1 : 0;
       }
       if (!flags.has('scan')) {
         console.error('init は --scan（生成）か --check（読み取り専用再走査）を指定する');

--- a/packages/nene2-standards/src/checks/init-scan.test.ts
+++ b/packages/nene2-standards/src/checks/init-scan.test.ts
@@ -8,8 +8,9 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import type { RegistriesDocument } from '../registries/schema.js';
 import { validateRegistries, REGISTRIES_SCHEMA_ID } from '../registries/schema.js';
-import { initScan, initScanEntries, scanLintBaselines } from './init-scan.js';
+import { initCheck, initScan, initScanEntries, scanLintBaselines } from './init-scan.js';
 
 const dirs: string[] = [];
 afterEach(() => {
@@ -88,5 +89,50 @@ describe('initScanEntries — lint-baseline emit（P2-A4）', () => {
     // validateRegistries を通る（id 付き・貼れる正本形）
     const diags = validateRegistries(JSON.stringify({ schema: REGISTRIES_SCHEMA_ID, entries }));
     expect(diags).toEqual([]);
+  });
+});
+
+describe('initCheck — lint-baseline count-ratchet（#119・AM-14）', () => {
+  const REPO = 'nene-test';
+  const CLEAN = `@layer components {\n  .ok { opacity: 1; }\n}\n`;
+
+  /** 指定 CSS の scan を凍結値として登録した registries doc を作る。 */
+  async function registriesFrozenAt(css: string): Promise<RegistriesDocument> {
+    const scan = await initScan(makeRepo(css));
+    return { entries: initScanEntries(scan, REPO) } as RegistriesDocument;
+  }
+
+  it('回帰: live > frozenCount は regression（FAIL 対象）・shrinkable でない', async () => {
+    const registries = await registriesFrozenAt(TWO_HEX); // color-no-hex frozen 2
+    const report = await initCheck(makeRepo(THREE_HEX), REPO, registries); // live 3
+    expect(report.lintBaselineRegressions.find((r) => r.rule === 'color-no-hex')).toMatchObject({
+      frozenCount: 2,
+      liveCount: 3,
+    });
+    expect(report.lintBaselineShrinkable.find((s) => s.rule === 'color-no-hex')).toBeUndefined();
+  });
+
+  it('不変: live == frozenCount なら regression も shrinkable も無し', async () => {
+    const registries = await registriesFrozenAt(TWO_HEX);
+    const report = await initCheck(makeRepo(TWO_HEX), REPO, registries);
+    expect(report.lintBaselineRegressions).toEqual([]);
+    expect(report.lintBaselineShrinkable).toEqual([]);
+  });
+
+  it('縮小: live < frozenCount は shrinkable advisory（FAIL でない）', async () => {
+    const registries = await registriesFrozenAt(THREE_HEX); // color-no-hex frozen 3
+    const report = await initCheck(makeRepo(TWO_HEX), REPO, registries); // live 2
+    expect(report.lintBaselineShrinkable.find((s) => s.rule === 'color-no-hex')).toMatchObject({
+      frozenCount: 3,
+      liveCount: 2,
+    });
+    expect(report.lintBaselineRegressions).toEqual([]);
+  });
+
+  it('完全解消: 登録ありで live 0（clean）は shrinkable（liveCount 0・scan 不在を 0 と扱う）', async () => {
+    const registries = await registriesFrozenAt(TWO_HEX);
+    const report = await initCheck(makeRepo(CLEAN), REPO, registries);
+    expect(report.lintBaselineShrinkable.find((s) => s.rule === 'color-no-hex')?.liveCount).toBe(0);
+    expect(report.lintBaselineRegressions).toEqual([]);
   });
 });

--- a/packages/nene2-standards/src/checks/init-scan.ts
+++ b/packages/nene2-standards/src/checks/init-scan.ts
@@ -17,6 +17,7 @@ import stylelintPlugins from '../stylelint/plugin.js';
 import { classTokens, layerParamsInclude } from '../stylelint/helpers.js';
 import type {
   ComponentsAllowlistEntry,
+  LintBaselineEntry,
   RegistriesDocument,
   RegistryEntry,
 } from '../registries/schema.js';
@@ -192,9 +193,25 @@ export function ledgersAlreadyInitialized(
   };
 }
 
+/** (rule,file) count-ratchet の1件（#119・AM-14）。frozenCount = 登録凍結値・liveCount = 実測。 */
+export interface LintBaselineDelta {
+  rule: string;
+  file: string;
+  frozenCount: number;
+  liveCount: number;
+}
+
 export interface InitCheckReport {
   unregisteredClasses: string[];
   unregisteredLegacyFiles: string[];
+  /**
+   * baselined (rule,file) で実測 live > frozenCount（**回帰＝FAIL**・AM-14 縮小単調違反）。
+   * stylelint 合成は当該 file で rule を null 化（grandfather）するため、baselined (rule,file) 内の
+   * count 超過は stylelint gate では機械検出できない（判例20 の穴）。この count-ratchet がその一辺を閉じる。
+   */
+  lintBaselineRegressions: LintBaselineDelta[];
+  /** baselined (rule,file) で live < frozenCount（縮小＝歓迎・frozenCount を下げられる advisory・非 FAIL）。 */
+  lintBaselineShrinkable: LintBaselineDelta[];
 }
 
 /** `--check`（読み取り専用再走査）: 台帳との差分を報告する。 */
@@ -218,10 +235,41 @@ export async function initCheck(
       )
       .flatMap((e) => e.classes),
   );
+  // (rule,file) count-ratchet（#119・AM-14 縮小単調検査器の実装本体）:
+  // 登録 lint-baseline の frozenCount と、いま実測した live count を突き合わせる。
+  // 登録キーを起点に回す（scan.lintBaselines は frozenCount>0 のみ返す＝完全解消は不在＝live 0）。
+  // file 無し（リポ全体 baseline）や未走査座席（frozenCount null）は (rule,file) ratchet の対象外。
+  const frozenByKey = new Map<string, number>();
+  for (const e of registries.entries) {
+    if (e.kind !== 'lint-baseline' || e.repo !== repo) continue;
+    const b = e as LintBaselineEntry;
+    if (b.file === undefined || b.frozenCount === null) continue;
+    frozenByKey.set(`${b.rule}\t${b.file}`, b.frozenCount);
+  }
+  const liveByKey = new Map(scan.lintBaselines.map((l) => [`${l.rule}\t${l.file}`, l.frozenCount]));
+  const lintBaselineRegressions: LintBaselineDelta[] = [];
+  const lintBaselineShrinkable: LintBaselineDelta[] = [];
+  for (const [key, frozen] of frozenByKey) {
+    const [rule = '', file = ''] = key.split('\t');
+    const live = liveByKey.get(key) ?? 0; // 不在 = 完全解消（live 0）
+    if (live > frozen)
+      lintBaselineRegressions.push({ rule, file, frozenCount: frozen, liveCount: live });
+    else if (live < frozen)
+      lintBaselineShrinkable.push({ rule, file, frozenCount: frozen, liveCount: live });
+  }
+  lintBaselineRegressions.sort(
+    (a, b) => a.rule.localeCompare(b.rule) || a.file.localeCompare(b.file),
+  );
+  lintBaselineShrinkable.sort(
+    (a, b) => a.rule.localeCompare(b.rule) || a.file.localeCompare(b.file),
+  );
+
   return {
     unregisteredClasses: scan.allowedClasses.filter((c) => !registeredClasses.has(c)),
     unregisteredLegacyFiles: scan.legacyManifest
       .map((e) => e.path)
       .filter((p) => !manifestPaths.has(p)),
+    lintBaselineRegressions,
+    lintBaselineShrinkable,
   };
 }


### PR DESCRIPTION
Closes #119

## これは何

baselined な `(rule,file)` の `frozenCount` ceiling を、**`init --check` の count-ratchet として強制**する（AM-14 縮小単調検査器の実装本体）。D-invoice/D-deal pilot で判例20 として周知した穴——**同一 baselined (rule,file) 内の count 回帰が機械検出されない一辺**——を閉じる。

## なぜ必要（Q-D4 実測）

frozenCount はこれまで測って registries に載るだけで、**どこでも ceiling 強制されていなかった**:
- stylelint 合成: baselined (rule,file) を `{ [rule]: null }` で当該 file 丸ごと無効化（count 非依存）。
- `initCheck`: unregisteredClasses/LegacyFiles のみ。lint-baseline count 未検査。
- conformance / gate-integrity: lint-baseline 未参照。

## 変更

- `InitCheckReport` に `lintBaselineRegressions`（live > frozen＝**FAIL**）＋`lintBaselineShrinkable`（live < frozen＝縮小歓迎の **advisory・非 FAIL**）。
- `initCheck`: 登録 frozenCount と実測 live count を突き合わせ。**登録キー起点**で回す（`scan.lintBaselines` は frozenCount>0 のみ返す＝不在を live 0＝完全解消と扱う）。file 無し（リポ全体 baseline）・frozenCount null（未走査座席）は対象外。
- CLI `init --check`: exit を「未分類 + 回帰 > 0 で FAIL」へ拡張・回帰/縮小を stderr に明示。
- 回帰テスト4本。

## 実測

| 検証 | 結果 |
|---|---|
| `npm run check` | 🟢 27 files / **405 tests**（+4 count-ratchet）・AM-2 gate PASS |
| 回帰（live>frozen）| regressions に載る・FAIL |
| 不変（live==frozen）| regression/shrinkable とも空 |
| 縮小（live<frozen）| shrinkable advisory・非 FAIL |
| 完全解消（live 0）| shrinkable liveCount 0 |

## enforcement 位置（hub 確認事項）

本 PR は**機構**（init --check の count 検査）を standards に実装。**実際の強制には arm 各リポの CI が `nene2-check init --check` を回す配線が要る**（stylelint gate の flip と同型の arm-side ステップ）。この arm-side 配線を stylelint gate 側に合流させるか別ステップにするかは hub 確認事項（PR 本文にも明記）。新規 (rule,file) は stylelint gate が捕捉するので、ここは baselined pair 内 count の一辺に専念。

landed で判例20 の穴が閉じ、field/origin/vault/残艦への横展開ガード（#119 due 超過で停止）を解除できます。