### PR TITLE
feat(tokens): FIELD_TABLE 正本化＋1.2.0 — C part-2 束の合流（#127）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -8,13 +8,13 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 
 | パッケージ                      | 版                                 | 状態                                                                                                                                                                                                                                                                                                                                                                 |
 | ------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@hideyukimori/nene2-tokens`    | ローカル **1.1.0** / npm **1.1.0** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1・1.1.0 は publish 済み**（1.1.0 = 2026-07-18・#85 束・写像表 v1 payout 分＋codemod ランナー同梱の minor〔npm view 実測〕）＝**未 publish の差分なし**。旧ローカル表記 1.0.2（`21ce902`）は束に feat #32 を含むため minor へ改番（semver 判断は fleet 委任 — 2026-07-18 pickup）                                 |
+| `@hideyukimori/nene2-tokens`    | ローカル **1.2.0** / npm **1.1.0** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1・1.1.0 は publish 済み**（1.1.0 = 2026-07-18・#85 束〔npm view 実測〕）。**1.2.0 は未 publish**（#127 準備・下記「1.2.0 節」・minor = C part-2 束: LEGACY_PREFIX_HINTS＋FIELD_TABLE＋§4-4 版乖離吸収） |
 | `@hideyukimori/nene2-standards` | ローカル **2.1.0** / npm **2.0.1** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1・1.1.0・1.2.0・2.0.0・2.0.1 は publish 済み**（2.0.1 = 2026-07-21・patch #116 keyframe 偽陽性修正〔npm view 実測 latest=2.0.1〕）。**2.1.0 は未 publish**（#123 準備・下記「2.1.0 節」・minor = #119 lint-baseline count-ratchet を arm へ届ける） |
 | `@hideyukimori/nene2-i18n`      | ローカル **0.1.0** / npm **0.1.0** | `private` 解除済み（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。**0.1.0 は publish 済み**（2026-07-16T05:46:12Z・`dist-tags latest=0.1.0`・`shasum 36d06bcd65854543c8af1ef971b36eccc1dcb3db`）＝ **未 publish の差分なし**。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記）                            |
 
 ## publish 束の履歴と現在の待ち
 
-> **現在の未 publish = `nene2-standards` 2.1.0 のみ**（#123・下記「2.1.0 節」・minor）。
+> **現在の未 publish = `nene2-standards` 2.1.0（#123）＋ `nene2-tokens` 1.2.0（#127）**（各 minor・下記各節）。
 > standards **2.0.1** は **2026-07-21 publish 済み**（patch #116 keyframe 修正／npm view 実測 latest=2.0.1・shasum e6ce6b0e）。
 > standards **2.0.0** は **2026-07-21 publish 済み**（BREAKING・per-repo registries／npm view 実測 latest=2.0.0・shasum 20e4f3e0）。
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
@@ -66,6 +66,17 @@ release note 明記2点（hub 依頼・正直表記）:
 
 1. **適用済みリポ re-run の idempotence（no-op）保証範囲**〔#90 で実測訂正〕: 保証されるのは (a) themegen `fill` の不動点（**テストで保証** — `themegen.test.ts`「fill is idempotent」）と (b) **契約 namespace の x-送り済みトークン**（`--spacing-x-*`・`--font-weight-x-*` 等 — contract 扱いで不変〔dist 実測〕）。**一般には no-op ではない**: (i) **未知 namespace の x-送り済みトークンは再走で silent 二重送り**（`--line-x-height-body → --line-x-x-height-body`・`--z-x-modal → --z-x-x-modal`〔dist 実測 2026-07-18〕— fallback が namespace を再発明するため。plan に通常 rename として載り誤りとは示されない） (ii) 字面衝突の再入 pair（`gap-x-*` 等）は `reentrantRenames` が plan で**開示**する（既知・#17）。**運用条項: re-run 時は plan を必ず確認し、reentrant または `-x-x-` を含む rename があれば撃たない**。(i) の根治は C part-1（fallback 除去＝loud reject 化・本 publish 後にマージ）。
 2. **dead/unknown-namespace token（`--line-x-height-body` 等）の挙動**: 写像側は未知名を **reject（fail-closed・null → 呼び出し側 error・写像を発明しない）**が実装・テスト済み。**生成側の loud reject（(i)reject＝`tailwindNamespaceOf` regex fallback 除去）は C part-1 で未実装** — 本束に入っているのは #50 の導出までで、(i)reject は C 完了後（原理: loud reject・実装状況を誇称しない）。
+
+### `@hideyukimori/nene2-tokens` 1.2.0（**minor — C part-2 束**・#127 準備）
+
+未 publish コミット（C part-1 #93〔`6c6cc36`〕/ C part-2 impl #126 / FIELD_TABLE＋版 #127）:
+
+- **feat: C part-1（#92/#93）＝未知 namespace の x-送り fallback 除去→loud reject**（1.1.0 publish 後にマージ済み・本 1.2.0 で初めて npm に載る）。
+- **feat: C part-2 impl（#125/#126）＝`LEGACY_PREFIX_HINTS`（hint 付き reject 表・step 5.5）**。fallback 非経由の silent 受理（`--font-size-*` が font-family に食われる #17 型）を止める。font-size は activeFrom W3（既定 W1 は現行 x-送り維持）・z/border-width は plain var 誘導。
+- **feat: FIELD_TABLE 正本化（#127）**＝nene-field W1 語彙表（(B) x-送り 20 行）。安全弁1 で origin#24 型衝突を排除（(A) 8 件は field 側 (C)-style 5＋本表 (B) 3 へ再分類）。
+- **🔴 §4-4 版乖離吸収**: published 1.1.0 は「未知 namespace を silent x-送り＝`gap-x-stack` 衝突あり」で、main の 1.1.0（C part-1 で reject）と**同一版番号で別挙動**だった（C part-1 が 1.1.0 publish 後マージのため）。**1.2.0 が正本**——published=silent x-送り／1.2.0=reject の別を版で確定する（origin W1 #300 の栓を抜く合流点）。
+- 検証: 統合 main で `npm run check` 緑（415 tests・AM-2 PASS）〔実測〕。CODEMOD_MAP_VERSION 1.2.0＝package version と一致。
+- 後続: 本 publish 後に origin/field 同時解禁（origin=#300 の栓解除・field=FIELD_TABLE pin＋(C)-style 手前処理→W1 再開）。
 
 publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run → 本番とも**施主実行**。成功後に fleet-baseline.json の null → 実版数の**別 PR**（下記「publish 成功後にやること」）。
 

--- a/packages/nene2-tokens/package.json
+++ b/packages/nene2-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-tokens",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "NeNe Core Token Contract v1 — contract types, CONTRACT_TOKENS, validate:themes CLI, themegen, codemod mapping table v1 + jscodeshift codemod runner, reference theme",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-tokens/src/codemod-map.test.ts
+++ b/packages/nene2-tokens/src/codemod-map.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   CODEMOD_MAP_V1,
+  FIELD_TABLE,
   ORIGIN_TABLE,
   REMEDIATION_V1,
   SUITE_TABLE,
@@ -14,7 +15,7 @@ import {
 
 describe('codemod mapping table v1 (versioned)', () => {
   it('is versioned (M-1: 使い捨てスクリプト化 MUST NOT)', () => {
-    expect(CODEMOD_MAP_V1.version).toBe('1.1.0');
+    expect(CODEMOD_MAP_V1.version).toBe('1.2.0');
     expect(CODEMOD_MAP_V1.contract).toBe('1.0');
   });
 
@@ -351,5 +352,43 @@ describe('remediation list v1 (同梱 — R2⑩)', () => {
     const unconfirmed = REMEDIATION_V1.filter((r) => !r.confirmed);
     expect(unconfirmed.length).toBeGreaterThan(0);
     for (const r of unconfirmed) expect(r.source).toContain('起草判断');
+  });
+});
+
+describe('FIELD_TABLE — field 語彙表正本化（C part-2・#127）', () => {
+  it('20 行の (B) x-送りエントリ（全て x- 名＝x- 座席へ改名）', () => {
+    const entries = Object.entries(FIELD_TABLE);
+    expect(entries).toHaveLength(20);
+    for (const [key, val] of entries) {
+      expect(val, `${key} は x- 送り`).toMatch(/^x-/);
+    }
+  });
+
+  it('field token は --color-x-* へ rename（業務状態色・機能色）', () => {
+    expect(mapTokenName('--color-submitted', 'field')).toBe('--color-x-submitted');
+    expect(mapTokenName('--color-approved', 'field')).toBe('--color-x-approved');
+    expect(mapTokenName('--color-rejected', 'field')).toBe('--color-x-rejected');
+    expect(mapTokenName('--color-ai', 'field')).toBe('--color-x-ai');
+    expect(mapTokenName('--color-fg-muted-2', 'field')).toBe('--color-x-fg-muted-2');
+    expect(mapTokenName('--color-border-input', 'field')).toBe('--color-x-border-input');
+  });
+
+  it('🔴 (A) を排した効果: field ネイティブ契約トークンと (B) 改名は conflict しない', () => {
+    // 契約 border/surface-overlay を native 保持しつつ FIELD_TABLE の (B) 改名 = 別ターゲット（x-）
+    // なので 2ソース→1ターゲット衝突は起きない（G-6・(A) rename を排した設計の実証）。
+    const names = [
+      '--color-border', // native contract
+      '--color-surface-overlay', // native contract
+      '--color-submitted', // (B) → x-submitted
+      '--color-fg-muted-2', // (A)由来 (B) → x-fg-muted-2
+    ];
+    const r = mapTokenSet(names, 'field');
+    expect(r.conflicts).toEqual([]);
+    expect(r.rejected).toEqual([]);
+  });
+
+  it('draft は fg-muted-2 と hex 同値でも別ターゲット（意味が別＝統合しない）', () => {
+    expect(mapTokenName('--color-draft', 'field')).toBe('--color-x-draft');
+    expect(mapTokenName('--color-fg-muted-2', 'field')).toBe('--color-x-fg-muted-2');
   });
 });

--- a/packages/nene2-tokens/src/codemod-map.ts
+++ b/packages/nene2-tokens/src/codemod-map.ts
@@ -26,7 +26,10 @@ import {
 export { TAILWIND_V4_NAMESPACES, tailwindNamespaceOf };
 
 // 1.1.0: C part-1（#92）— 未知 namespace の x-送り（fallback 発明）を廃し reject へ。
-export const CODEMOD_MAP_VERSION = '1.1.0';
+// 1.2.0: C part-2 束 — LEGACY_PREFIX_HINTS（#125）＋FIELD_TABLE 正本化（#127）。
+//   ＋published 1.1.0（silent x-送り＝gap-x-stack 衝突）と main 1.1.0（reject）の挙動乖離を
+//   版で区別する是正を兼ねる（§4-4・origin W1 #300 実測 2026-07-21）。正本は 1.2.0。
+export const CODEMOD_MAP_VERSION = '1.2.0';
 
 /**
  * Tailwind v4 の theme variable namespace（**長い namespace が短い prefix より先**）。
@@ -50,7 +53,7 @@ export const CODEMOD_MAP_VERSION = '1.1.0';
  * 未知 namespace（`--z-*` 等）は C part-1（#92）で reject へ落ちる — namespace を発明しない。
  */
 
-export type MappingTableId = 'common' | 'origin' | 'vault' | 'suite';
+export type MappingTableId = 'common' | 'origin' | 'vault' | 'suite' | 'field';
 
 /**
  * 写像の結果類型（#24 point5 — 「fatal null」と「pass-through」を型で区別する）。
@@ -276,14 +279,57 @@ export const SUITE_TABLE: Readonly<Record<string, string>> = {
   'r-pill': '--r-x-pill',
 };
 
+/**
+ * field 個別表（#127 — nene-field W1 語彙表正本化・候補案 handoff-field-w1-token-map-proposal を
+ * fleet 正本化レビュー通過＝安全弁1 で origin#24 型衝突を排除して確定）。
+ *
+ * ここに載るのは **(B) x-送り 20 行のみ**（改名のみ＝視覚変化ゼロ・x- 座席は空＝conflict なし）。
+ * 元候補の (A) 8 件は、field ネイティブ契約トークン（surface-overlay/border 等）への rename が
+ * codemod の 2ソース→1ターゲット conflict を起こすため（G-6 silent 上書き禁止・実測確認）、正本化前に
+ * hub 裁定で再分類済み: 5 件は field 側 **(C)-style**（源削除＋参照書換＝視覚 merge を意図どおり
+ * 実現）・3 件は本表の **(B) x-送り**（fg-muted-2/fg-faint-2/border-input・使用多&中Δ で退行回避）。
+ * (C) 総数 = 8（btn-danger 統合＋btn-disabled/pulse 削除＋(A)由来 (C)-style 5）— FIELD_TABLE 外。
+ *
+ * **Δ中スモーク条項（安全弁2）**: (C)-style で契約段へ寄せる行のうち fg-muted-2/fg-faint-2 型は Δ中。
+ * field 統合時の目視スモーク（Dashboard/MobileShell/フォーム系/Table）で退行が出たら (B) x-送りへ
+ * 切替可（本表へ追加＝視覚変化ゼロへ退避）。
+ */
+export const FIELD_TABLE: Readonly<Record<string, string>> = {
+  // 分類1 (B): 面・線の1色化(#24 型)回避＋ドメイン深段
+  'accent-soft-border': 'x-accent-soft-border',
+  'accent-deep': 'x-accent-deep',
+  'accent-deep-2': 'x-accent-deep-2',
+  // 分類1 (A由来→B): 使用多&中Δ＝退行回避で x-送り（安全弁2 の事前適用）
+  'fg-muted-2': 'x-fg-muted-2',
+  'fg-faint-2': 'x-fg-faint-2',
+  'border-input': 'x-border-input',
+  // 分類2 (B): 業務状態色（report status のドメイン語彙 — 汎用へ潰さず独立保持）
+  submitted: 'x-submitted',
+  'submitted-soft': 'x-submitted-soft',
+  approved: 'x-approved',
+  'approved-soft': 'x-approved-soft',
+  rejected: 'x-rejected',
+  'rejected-soft': 'x-rejected-soft',
+  draft: 'x-draft', // hex=fg-muted-2 と同値だが意味が別＝統合しない
+  'draft-soft': 'x-draft-soft',
+  // 分類3 (B): 機能色（近い契約段なし／別トーン塗り）
+  ai: 'x-ai',
+  'ai-soft': 'x-ai-soft',
+  'btn-success': 'x-btn-success',
+  'toast-check': 'x-toast-check',
+  'row-hover': 'x-row-hover',
+  'row-active': 'x-row-active',
+};
+
 /** `--color-` 接尾辞で引く個別表（common 共通ベース付き）。 */
 const COLOR_SUFFIX_TABLES: Record<
-  'common' | 'origin' | 'vault',
+  'common' | 'origin' | 'vault' | 'field',
   Readonly<Record<string, string>>
 > = {
   common: COMMON_TABLE,
   origin: ORIGIN_TABLE,
   vault: VAULT_TABLE,
+  field: FIELD_TABLE,
 };
 
 /** prefix-less 全名で引く個別表（suite — キーは裸名・値は完全なターゲット名）。 */


### PR DESCRIPTION
Closes #127

## これは何

**C part-2 束の合流 PR**（hub「FIELD_TABLE 正本化込み1本」）。field 語彙表（(B) x-送り 20 行）を FIELD_TABLE 正本化し、CODEMOD_MAP_VERSION と package version を **1.2.0** へ bump（§4-4 の published/main 挙動乖離ごと吸収）。tokens 1.2.0 束が publish 待ちに到達する。publish は施主 seam（standards 2.1.0 とまとめて施主タイミング）。

## 変更

- `FIELD_TABLE` 新設（20 (B) 行・`--color-` suffix 表）＋`MappingTableId` 'field'＋`COLOR_SUFFIX_TABLES` 配線＋**Δ中スモーク注記**（安全弁2）。
- `CODEMOD_MAP_VERSION` 1.1.0→**1.2.0**・`package.json` version 1.1.0→**1.2.0**（一致）。
- `publish.md`: tokens 1.2.0 節新設（C part-1/impl #126/FIELD_TABLE ＋ §4-4 乖離吸収明記）・未 publish を standards 2.1.0＋tokens 1.2.0 の2つへ。

## 正本化レビューの結論（安全弁1）

元候補の **(A) 8 件は as-is で FIELD_TABLE 化すると codemod を停止**させる（field ネイティブ契約トークンへの rename ＝2ソース→1ターゲット conflict・実測確認 `mapTokenSet(vault line→border)`）。hub 裁定で再分類:
- **field 側 (C)-style 5**（surface-soft/surface-faint/fg-strong/border-2/border-hairline＝源削除＋参照書換）。
- **本表 (B) 3**（fg-muted-2/fg-faint-2/border-input＝使用多&中Δ で退行回避・安全弁2 事前適用）。
- **(C) 総数 = 8**（機械カウントで field 提案 §3 の off-by-one＝B20/C8 を確定・hub 中継「4→12」も訂正）。

## 実測

| 検証 | 結果 |
|---|---|
| `npm run check` | 🟢 27 files / **415 tests**（+4 FIELD）・AM-2 gate PASS |
| `npm pack --dry-run` version | tokens **1.2.0**（CODEMOD_MAP_VERSION と一致） |
| FIELD_TABLE 20 行 | 全て `--color-x-*` へ rename・field ネイティブ契約と **conflict なし**（(A) 排除の実証） |

## 後続

merge → 施主が tokens 1.2.0 publish（standards 2.1.0 とまとめて）→ **origin/field 同時解禁**（origin=#300 の栓解除／field=FIELD_TABLE pin＋(C)-style 手前処理→W1 再開）。

マージは施主 seam。hub レビュー依頼。