### PR TITLE
feat(i18n): ./testing subpath export（expectCatalogParity）＝0.2.0 ティア1（批准前提(b) 最小解除・#129）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -10,11 +10,12 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 | ------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@hideyukimori/nene2-tokens`    | ローカル **1.2.0** / npm **1.1.0** | 契約凍結済み（2026-07-14 hide 承認）。**1.0.0・1.0.1・1.1.0 は publish 済み**（1.1.0 = 2026-07-18・#85 束〔npm view 実測〕）。**1.2.0 は未 publish**（#127 準備・下記「1.2.0 節」・minor = C part-2 束: LEGACY_PREFIX_HINTS＋FIELD_TABLE＋§4-4 版乖離吸収） |
 | `@hideyukimori/nene2-standards` | ローカル **2.1.0** / npm **2.0.1** | known-utility warn プレースホルダ等の暫定は README 明記のまま（規約の設計 — O-5/O-6）。**1.0.0・1.0.1・1.1.0・1.2.0・2.0.0・2.0.1 は publish 済み**（2.0.1 = 2026-07-21・patch #116 keyframe 偽陽性修正〔npm view 実測 latest=2.0.1〕）。**2.1.0 は未 publish**（#123 準備・下記「2.1.0 節」・minor = #119 lint-baseline count-ratchet を arm へ届ける） |
-| `@hideyukimori/nene2-i18n`      | ローカル **0.1.0** / npm **0.1.0** | `private` 解除済み（#44 — 施主 hide 2026-07-16 裁定: 0.1.0 で publish）。**0.1.0 は publish 済み**（2026-07-16T05:46:12Z・`dist-tags latest=0.1.0`・`shasum 36d06bcd65854543c8af1ef971b36eccc1dcb3db`）＝ **未 publish の差分なし**。W0a 実体は catalog+parity（`/format` `/react` `/testing` は W0b — 規約 04 §0 の API 表が状態を明記）                            |
+| `@hideyukimori/nene2-i18n`      | ローカル **0.2.0** / npm **0.1.0** | `private` 解除済み（#44 — 施主 hide 2026-07-16 裁定）。**0.1.0 は publish 済み**（2026-07-16・latest=0.1.0）。**0.2.0 は未 publish**（#129 準備・下記「0.2.0 節」・minor = `./testing` subpath ＝批准前提(b) の最小解除）。W0a 実体は catalog+parity（`/format` `/react` は W0b・`renderWithI18n` は 0.3.0 — 規約 04 §0 の API 表） |
 
 ## publish 束の履歴と現在の待ち
 
-> **現在の未 publish = `nene2-standards` 2.1.0（#123）＋ `nene2-tokens` 1.2.0（#127）**（各 minor・下記各節）。
+> **現在の未 publish = `nene2-i18n` 0.2.0（#129・minor・下記「0.2.0 節」）**。
+> standards **2.1.0**（#123・count-ratchet）＋ tokens **1.2.0**（#127・C part-2＋FIELD_TABLE）は **2026-07-21 publish 済み**（npm view 実測 latest=2.1.0 shasum 4921c61d / latest=1.2.0 shasum 8ba2e691）。※各 table 行・版節の「publish 済み」訂正は各パッケージの次 bump PR で（established パターン）。
 > standards **2.0.1** は **2026-07-21 publish 済み**（patch #116 keyframe 修正／npm view 実測 latest=2.0.1・shasum e6ce6b0e）。
 > standards **2.0.0** は **2026-07-21 publish 済み**（BREAKING・per-repo registries／npm view 実測 latest=2.0.0・shasum 20e4f3e0）。
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
@@ -77,6 +78,15 @@ release note 明記2点（hub 依頼・正直表記）:
 - **🔴 §4-4 版乖離吸収**: published 1.1.0 は「未知 namespace を silent x-送り＝`gap-x-stack` 衝突あり」で、main の 1.1.0（C part-1 で reject）と**同一版番号で別挙動**だった（C part-1 が 1.1.0 publish 後マージのため）。**1.2.0 が正本**——published=silent x-送り／1.2.0=reject の別を版で確定する（origin W1 #300 の栓を抜く合流点）。
 - 検証: 統合 main で `npm run check` 緑（415 tests・AM-2 PASS）〔実測〕。CODEMOD_MAP_VERSION 1.2.0＝package version と一致。
 - 後続: 本 publish 後に origin/field 同時解禁（origin=#300 の栓解除・field=FIELD_TABLE pin＋(C)-style 手前処理→W1 再開）。
+
+### `@hideyukimori/nene2-i18n` 0.2.0（**minor — `./testing` subpath**・#129 準備）
+
+未 publish コミット（#129・ティア1）:
+
+- **feat: `./testing` subpath export（`expectCatalogParity`）**（#76 の批准前提(b) 最小解除）。規約 04 §0 API 表の正本 import 経路 `@hideyukimori/nene2-i18n/testing` の実体。payout の [X] exemplar アンカー3本（I18N-6/20/22）が要る `expectCatalogParity` を、この subpath から解決可能にする。`.`（ルート）からの export はそのまま維持（非破壊）。
+- スコープ外（分離）: `renderWithI18n` は `/react`（I18nProvider）依存＝**0.3.0 W0b レーン**（「無いものを配らない」— I18N-22 の沈黙 fallback を再生産しないため react は設計してから）。payout B-2 は B-2a（本 0.2.0）/ B-2b（format 0.3.0）分割。
+- 検証: 統合 main で `npm run check` 緑（28 files / 418 tests・AM-2 PASS）〔実測〕。`npm pack --dry-run` で version 0.2.0・`dist/testing.{js,d.ts}` 同梱。`import { expectCatalogParity } from '@hideyukimori/nene2-i18n/testing'` が実解決（node exports 解決 OK）〔実測〕。
+- 後続: 本 publish 後、payout 側で [X] アンカー3本植栽＋`check:exemplars --ref origin/main`（fetch あり・A-10 正）で green を取り直す（payout レーン同時）。
 
 publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run → 本番とも**施主実行**。成功後に fleet-baseline.json の null → 実版数の**別 PR**（下記「publish 成功後にやること」）。
 

--- a/packages/nene2-i18n/package.json
+++ b/packages/nene2-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-i18n",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "NeNe fleet typed i18n — typed catalog + parity (AM-17 final form). W0a skeleton: translate/plural/format/react are W0b.",
   "type": "module",
   "license": "MIT",
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
     }
   },
   "files": [

--- a/packages/nene2-i18n/src/testing.test.ts
+++ b/packages/nene2-i18n/src/testing.test.ts
@@ -1,0 +1,37 @@
+/**
+ * ./testing subpath バレル（#129/#76）— 規約 04 §0 API 表の import 経路
+ * `@hideyukimori/nene2-i18n/testing` の実体が expectCatalogParity を解決すること、
+ * および `.` と同一実装であること（再export であってコピーでない）を固定する。
+ */
+import { describe, expect, it } from 'vitest';
+
+import { expectCatalogParity as fromRoot } from './index.js';
+import { expectCatalogParity as fromTesting } from './testing.js';
+
+/** n キーの健全カタログ対（parity.test.ts と同型）。 */
+function catalogs(n: number): { ja: Record<string, string>; en: Record<string, string> } {
+  const ja: Record<string, string> = {};
+  const en: Record<string, string> = {};
+  for (let i = 0; i < n; i++) {
+    ja[`common.key${i}`] = `日本語${i}`;
+    en[`common.key${i}`] = `English ${i}`;
+  }
+  return { ja, en };
+}
+
+describe('./testing subpath — expectCatalogParity 再export（#129/#76）', () => {
+  it('expectCatalogParity を export する（規約 I18N-20 の import 経路が解決）', () => {
+    expect(typeof fromTesting).toBe('function');
+  });
+
+  it('`.` と同一関数（再export であってコピーでない）', () => {
+    expect(fromTesting).toBe(fromRoot);
+  });
+
+  it('キー集合一致は green・欠落は throw（parity の挙動が subpath 経由でも同じ）', () => {
+    expect(() => fromTesting(catalogs(10))).not.toThrow();
+    const { ja, en } = catalogs(10);
+    delete en['common.key0'];
+    expect(() => fromTesting({ ja, en })).toThrow(/parity FAIL/);
+  });
+});

--- a/packages/nene2-i18n/src/testing.ts
+++ b/packages/nene2-i18n/src/testing.ts
@@ -1,0 +1,14 @@
+/**
+ * `@hideyukimori/nene2-i18n/testing` — テスト専用のカタログ検証ヘルパ（0.2.0 ティア1・#129/#76）。
+ *
+ * 規約 04 §0 API 表の正本 import 経路。批准前提(b) `check:exemplars` の payout [X] アンカー
+ * （I18N-20 の locales.test.ts 等）は `import { expectCatalogParity } from
+ * '@hideyukimori/nene2-i18n/testing'` を解決する必要があり、これがその subpath 実体。
+ *
+ * `expectCatalogParity` は `.`（ルート）からも引き続き出す（非破壊）— どちらの import も解決する。
+ * `renderWithI18n`（React テストヘルパ）は `/react`（I18nProvider）依存＝**0.2.0 では未提供**。
+ * react subpath 設計後の 0.3.0（W0b）で足す（「無いものを配らない」— I18N-22 の沈黙 fallback を
+ * 再生産しないため react は設計してから）。
+ */
+export { expectCatalogParity } from './parity.js';
+export type { ParityOptions, ParityViolation } from './parity.js';


### PR DESCRIPTION
Closes #129

## これは何

nene2-i18n **0.2.0 ティア1**（親 #76）。批准前提(b) `check:exemplars` の payout [X] exemplar アンカー3本（I18N-6/20/22）が要る **`expectCatalogParity` を規約 04 §0 の正本 import 経路 `@hideyukimori/nene2-i18n/testing` から解決可能にする**。今夜の施主指示（区切り撤回・キュー再開）の①。

## 変更（小・非破壊）

- `src/testing.ts` バレル: `expectCatalogParity`＋型 `ParityOptions`/`ParityViolation` を再export（既存 `parity.ts` から）。**`.` からの export はそのまま維持**（両 import 経路が解決・非破壊）。
- `package.json`: exports に `./testing` 追加＋version 0.1.0 → **0.2.0**（minor）。tsconfig は `src/**/*.ts` include ゆえ変更不要。
- テスト3本＋publish.md 追随（i18n 0.2.0 節・未 publish を i18n 0.2.0 へ）。

## 実測

| 検証 | 結果 |
|---|---|
| `npm run check` | 🟢 28 files / **418 tests**（+3）・AM-2 gate PASS |
| `npm pack --dry-run` | version **0.2.0**・`dist/testing.{js,d.ts}` 同梱 |
| subpath 解決 | `import { expectCatalogParity } from '@hideyukimori/nene2-i18n/testing'` → **resolve OK: function**（node exports 解決・実測） |
| `.` と同一関数 | `fromTesting === fromRoot`（再export であってコピーでない） |

## スコープ外（分離）

- `renderWithI18n` は `/react`（I18nProvider）依存＝**0.3.0 W0b レーン**（「無いものを配らない」— I18N-22 の沈黙 fallback を再生産しないため react は設計してから）。payout B-2 は B-2a（本 0.2.0）/ B-2b（format 0.3.0）分割（hub 台帳）。

## 後続

merge → 施主が i18n 0.2.0 publish（施主 seam・今夜中に通せる規模）→ payout 側で [X] アンカー3本植栽＋`check:exemplars --ref origin/main` で green（payout レーン同時）＝**批准前提(b) 解除**。

マージは施主 seam。hub レビュー依頼。