### PR TITLE
feat(i18n): 0.3.0 §6-① createTranslator options（nested/二重括弧/key-echo・後方互換 byte 同一）（Refs #137）

### DIFF
--- a/docs/i18n-0.3.0-design.md
+++ b/docs/i18n-0.3.0-design.md
@@ -1,0 +1,76 @@
+# nene2-i18n 0.3.0 設計スペック（W0b / react レーン）— 2026-07-21
+
+起草: 統合リナ（hub）。発端: 施主指示「0.3.0 を隔離ブランチで進める」。
+根拠: vault C4b 実測（07-21・runtime 昇格の実ブロッカー3点）＋会議軸7＋T2 と無関係の runtime レーン。
+ブランチ: `feat/nene2-i18n-0.3.0-react`（scratchpad 隔離 clone）。**Issue 駆動**: 実装 PR 前に fleet で Issue 起票（本スペックを本文に）。
+
+## 0. 目的
+
+nene2-i18n を「flat・throw・単括弧のトイ translator」から「**製品 runtime を実際に置換できる共有パッケージ**」へ拡張する。vault が自前 runtime を捨てて昇格できる状態を作る（0.2.0 では物理的に不能を実測済み）。**後方互換を壊さない**（0.2.0 の `.` export の既定挙動は不変）。
+
+## 1. 施主フォークの前提裁定（hub 推し＝A）
+
+会議「昇格（100行以内）」のミニマル思想と vault 実需の衝突。→ **A: 共有物が実需を吸って適度に太る**（可視 fallback は本物の堅牢性機能・捨てない）。「100行以内」は撤廃せず「**コア translator は小さく・挙動はオプションで注入**」で両立させる（コアは分岐を持たず strategy を受ける）。※最終確定は施主（board のフォーク項）。本実装は A 前提で進め、B なら options 既定を締めるだけで縮退可能な設計にする。
+
+## 2. runtime translator の拡張（`.` export・後方互換）
+
+`createTranslator(catalog, options?)` に**第2引数 options を追加**（既定＝現行挙動＝破壊なし）:
+
+```ts
+interface TranslatorOptions {
+  // 欠落キー戦略（既定 'throw'＝現行）
+  onMissing?: 'throw' | 'key-echo' | ((key: string) => string);
+  // 補間デリミタ（既定 'single' = {name}＝現行）。'double' = {{name}}
+  interpolation?: 'single' | 'double';
+  // カタログ形（既定 'flat'＝現行）。'nested' は dot-path lookup を有効化
+  catalogShape?: 'flat' | 'nested';
+}
+```
+
+- **onMissing**: vault の監査動的キー（`audit_event.action.*`）が要る可視 fallback を `'key-echo'` で。任意関数も許容（製品固有整形）。既定 throw は不変。
+- **interpolation**: vault の `{{name}}` を `'double'` で。正規表現を戦略で切替（single=`/\{(\w+)\}/g`・double=`/\{\{(\w+)\}\}/g`）。
+- **catalogShape**: `'nested'` で `common.buttons.close` のドット探索（内部は flatten 1回 or 再帰 lookup）。MessageKey 型導出も nested 対応（DotPaths 型）。
+- **コア純度**: translator 本体は分岐を持たず、上記3 strategy を**注入された関数**として呼ぶ（「100行以内」思想＝コアは薄い・挙動は外から）。
+
+受入: 既定引数で 0.2.0 と byte 同一挙動（既存テスト不変）＋各 option の単体テスト（vault 3乖離の再現＝nested lookup / double 補間 / key-echo）。
+
+## 3. `/react` subpath（新設・I18nProvider + renderWithI18n）
+
+```ts
+// @hideyukimori/nene2-i18n/react
+export function I18nProvider(props: {
+  catalogs: Record<Locale, Catalog>;
+  locale: Locale;
+  options?: TranslatorOptions;      // §2 と同一
+  children: ReactNode;
+}): JSX.Element;
+export function useTranslation(): { t: (key, params?) => string; locale: Locale; setLocale: (l) => void };
+```
+
+- **module store**: `useSyncExternalStore`（会議 CS-2・vault auth-store exemplar と同型）で locale を購読。lang 属性同期（AM-18: I18nProvider の scope 要素に lang）。
+- **沈黙フォールバック禁止（I18N-22）**: options.onMissing の既定は provider でも throw だが、製品は key-echo を選べる（vault 実需）。
+- `renderWithI18n(ui, { locale, catalogs, options })`（`/testing` へ再export 可）: RTL render を provider で包むテストヘルパ。
+
+受入: provider 配下で t() 解決・setLocale で再レンダ・lang 属性追随・renderWithI18n が RTL で動く。peer=react（焼き込まない）。
+
+## 4. exports / 版
+
+- package.json exports に `./react` 追加。version 0.2.0→**0.3.0**（minor: 新 subpath＋後方互換オプション）。
+- `/testing` に renderWithI18n を再export（04 §0 の表の W0b 目標形を実体化）。
+
+## 5. vault 昇格の受入（0.3.0 landed 後・別レポ作業）
+
+vault は `createTranslator(catalogs.ja, {catalogShape:'nested', interpolation:'double', onMissing:'key-echo'})` で自前 translate.ts を置換・i18n-context.tsx を I18nProvider へ。→ C4b クローズ＝vault 完全クローズ。
+
+## 6. 実装順（このブランチ）
+
+1. §2 translator options（後方互換・コア薄く strategy 注入）＋テスト。← 最初のコミット
+2. §3 `/react` I18nProvider + useTranslation（useSyncExternalStore）＋テスト。
+3. renderWithI18n（`/react` + `/testing` 再export）＋テスト。
+4. exports/version 0.3.0・publish.md 追記（publish は施主 seam）。
+5. fleet で Issue 起票（本スペック）→ PR → hub レビュー → 施主 merge/publish。
+
+## 7. 非目標（0.3.0 に含めない）
+
+- format 系（Intl 通貨/日付＝I18N-13）は payout B-2b の別供給。混ぜない。
+- 焼き込み（各リポへのコピー）はしない（共有 npm 1層のみ・T2 と同じ原則）。

--- a/packages/nene2-i18n/src/catalog.ts
+++ b/packages/nene2-i18n/src/catalog.ts
@@ -1,40 +1,126 @@
 /**
- * 型付きカタログ（規約 04 §1 の骨格 — W0a）。
+ * 型付きカタログ（規約 04 §1 — W0a 骨格＋0.3.0 W0b runtime options）。
  *
  * - ja が権威カタログ（キー集合の正本）。MessageKey はカタログから型導出する。
- * - ランタイムは最小（ICU パーサ禁止 — 会議R1⑦。補間は {name} 置換のみ）。
- * - plural / format（Intl ラッパ）/ react（I18nProvider・useTranslation）/ vault JSON 形
- *   （DotPaths）は W0b — 本骨格には**存在しない**（未実装を明記）。
+ * - ランタイムは最小（ICU パーサ禁止 — 会議R1⑦）。コア `t()` は分岐を持たず、
+ *   3 つの strategy（lookup / interpolate / onMissing）を**注入された関数**として呼ぶ
+ *   （「100行以内」思想＝コアは薄い・挙動は options で外から差す・スペック §2）。
+ * - 既定引数（options 省略）は 0.2.0 と **byte 同一挙動**（後方互換最優先）。
+ * - plural / format（Intl ラッパ）/ react（I18nProvider・useTranslation）は別レーン。
  */
 
 /** メッセージカタログ（flat key → 文字列値）。キーの綴り規約は 04 が正本。 */
 export type MessageCatalog = Record<string, string>;
 
+/** nested カタログ（`common.buttons.close` を入れ子オブジェクトで持つ・dot-path 探索用）。 */
+export type NestedCatalog = { [key: string]: string | NestedCatalog };
+
 /** 権威カタログからの MessageKey 型導出（`satisfies` と併用する）。 */
 export type MessageKeyOf<T extends MessageCatalog> = keyof T & string;
 
+/**
+ * runtime translator の挙動注入（スペック §2）。既定は現行挙動＝破壊なし。
+ */
+export interface TranslatorOptions {
+  /**
+   * 欠落キー戦略（既定 'throw'＝現行・fail-closed）。
+   * - 'key-echo': key をそのまま返す（可視 fallback・vault の監査動的キー等・I18N-22 の趣旨＝可視化）。
+   * - 関数: 製品固有整形（任意）。
+   */
+  onMissing?: 'throw' | 'key-echo' | ((key: string) => string);
+  /** 補間デリミタ（既定 'single'＝`{name}`・現行）。'double'＝`{{name}}`（vault 実需）。 */
+  interpolation?: 'single' | 'double';
+  /** カタログ形（既定 'flat'＝現行）。'nested' で dot-path lookup を有効化。 */
+  catalogShape?: 'flat' | 'nested';
+}
+
+/** 型付き translator（flat・既定）。未知キーはコンパイル時に落ちる。 */
 export interface Translator<T extends MessageCatalog> {
-  /** 型付き解決。未知キーはコンパイル時に落ちる（実行時到達は Error — fail-closed）。 */
+  /** 型付き解決。実行時到達の未知キーは onMissing 戦略（既定 throw＝fail-closed）。 */
   t(key: MessageKeyOf<T>, params?: Record<string, string | number>): string;
 }
 
 /**
- * カタログ束からの translator 生成（骨格）。
- * ロケール解決・fallback 連鎖・scope 同期（AM-18）は W0b の I18nProvider 管轄。
+ * 緩い translator（nested・key は string）。
+ * DotPaths 型導出は将来課題として保留し、over-engineer を避けて key を string に緩めている
+ * （hub 裁定・#137）。runtime の dot-path 探索は正しく動く。
  */
-export function createTranslator<T extends MessageCatalog>(catalog: T): Translator<T> {
+export interface LooseTranslator {
+  t(key: string, params?: Record<string, string | number>): string;
+}
+
+/** lookup strategy を解決（flat＝完全一致／nested＝dot-path 探索）。 */
+function resolveLookup(
+  shape: 'flat' | 'nested',
+): (catalog: MessageCatalog | NestedCatalog, key: string) => string | undefined {
+  if (shape === 'nested') {
+    return (catalog, key) => {
+      let node: string | NestedCatalog | undefined = catalog;
+      for (const segment of key.split('.')) {
+        if (node === undefined || typeof node === 'string') return undefined;
+        node = node[segment];
+      }
+      return typeof node === 'string' ? node : undefined;
+    };
+  }
+  // flat: キー自体がドット付き文字列（`common.total`）＝完全一致で引く（探索しない）。
+  return (catalog, key) => {
+    const value = (catalog as MessageCatalog)[key];
+    return typeof value === 'string' ? value : undefined;
+  };
+}
+
+/** interpolate strategy を解決（single＝`{name}`／double＝`{{name}}`）。 */
+function resolveInterpolate(
+  mode: 'single' | 'double',
+): (value: string, params?: Record<string, string | number>) => string {
+  const pattern = mode === 'double' ? /\{\{(\w+)\}\}/g : /\{(\w+)\}/g;
+  return (value, params) => {
+    if (!params) return value;
+    return value.replaceAll(pattern, (whole, name: string) => {
+      const p = params[name];
+      return p === undefined ? whole : String(p);
+    });
+  };
+}
+
+/** onMissing strategy を解決（throw＝fail-closed／key-echo＝可視 fallback／関数＝任意）。 */
+function resolveOnMissing(strategy: TranslatorOptions['onMissing']): (key: string) => string {
+  if (strategy === 'key-echo') return (key) => key;
+  if (typeof strategy === 'function') return strategy;
+  // 'throw'（既定）: 型を欺いて到達した未知キーは黙って key を返さない。
+  return (key) => {
+    throw new Error(`unknown MessageKey: ${key}`);
+  };
+}
+
+/**
+ * カタログ束からの translator 生成。
+ *
+ * options 省略時は 0.2.0 と byte 同一（flat / single 補間 / throw）。
+ * catalogShape:'nested' 指定時のみ key 型が string に緩む（上記 LooseTranslator）。
+ */
+export function createTranslator<T extends MessageCatalog>(
+  catalog: T,
+  options?: TranslatorOptions & { catalogShape?: 'flat' },
+): Translator<T>;
+export function createTranslator(
+  catalog: NestedCatalog,
+  options: TranslatorOptions & { catalogShape: 'nested' },
+): LooseTranslator;
+export function createTranslator(
+  catalog: MessageCatalog | NestedCatalog,
+  options: TranslatorOptions = {},
+): LooseTranslator {
+  // strategy を生成時に一度だけ解決 — コア t() は分岐を持たず注入関数を呼ぶだけ。
+  const lookup = resolveLookup(options.catalogShape ?? 'flat');
+  const interpolate = resolveInterpolate(options.interpolation ?? 'single');
+  const onMissing = resolveOnMissing(options.onMissing);
   return {
     t(key, params) {
-      const value = catalog[key];
-      if (value === undefined) {
-        // fail-closed: 型を欺いて到達した未知キーは黙って key を返さない
-        throw new Error(`unknown MessageKey: ${String(key)}`);
-      }
-      if (!params) return value;
-      return value.replaceAll(/\{(\w+)\}/g, (whole, name: string) => {
-        const p = params[name];
-        return p === undefined ? whole : String(p);
-      });
+      const value = lookup(catalog, key);
+      if (value === undefined) return onMissing(key);
+      return interpolate(value, params);
     },
   };
 }

--- a/packages/nene2-i18n/src/index.ts
+++ b/packages/nene2-i18n/src/index.ts
@@ -1,8 +1,17 @@
 /**
- * @hideyukimori/nene2-i18n — W0a 骨格（型付きカタログ＋parity）。
- * plural / format / react / vault JSON 形（DotPaths）は W0b — 未実装（README 参照）。
+ * @hideyukimori/nene2-i18n — 型付きカタログ＋parity＋runtime translator options（0.3.0 W0b）。
+ * runtime options: nested（dot-path・key は string に緩め・DotPaths 型は保留）/ 二重括弧補間 /
+ * 欠落キー可視 fallback（onMissing）。既定は 0.2.0 と byte 同一。
+ * plural / format（Intl）/ react（I18nProvider）は別レーン — 未実装（README 参照）。
  */
 export { createTranslator } from './catalog.js';
-export type { MessageCatalog, MessageKeyOf, Translator } from './catalog.js';
+export type {
+  LooseTranslator,
+  MessageCatalog,
+  MessageKeyOf,
+  NestedCatalog,
+  Translator,
+  TranslatorOptions,
+} from './catalog.js';
 export { checkCatalogParity, expectCatalogParity } from './parity.js';
 export type { ParityOptions, ParityViolation } from './parity.js';

--- a/packages/nene2-i18n/src/translator-options.test.ts
+++ b/packages/nene2-i18n/src/translator-options.test.ts
@@ -1,0 +1,99 @@
+/**
+ * translator options（0.3.0 W0b・スペック §2）— vault C4b 実測の runtime 昇格ブロッカー3点を
+ * 再現するテスト＋後方互換（既定引数で 0.2.0 と byte 同一）の固定。
+ *
+ * 3 乖離: nested catalog（dot-path）/ 二重括弧補間 {{name}} / 欠落キーの可視 fallback（key-echo）。
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { createTranslator } from './catalog.js';
+
+describe('後方互換: 既定引数（options 省略）は 0.2.0 と同一挙動', () => {
+  it('flat / 単括弧補間 / 未知キー throw が現行どおり', () => {
+    const { t } = createTranslator({ 'common.total': '合計 {count} 件' } as const);
+    expect(t('common.total', { count: 3 })).toBe('合計 3 件');
+    expect(t('common.total')).toBe('合計 {count} 件'); // params 無しは素通し
+    // @ts-expect-error 未知キーは型で落ちる（実行時到達は throw）
+    expect(() => t('common.unknown')).toThrow(/unknown MessageKey/);
+  });
+
+  it('空 options {} でも既定と同一（明示 flat/single/throw）', () => {
+    const { t } = createTranslator({ 'a.b': '{x}' } as const, {});
+    expect(t('a.b', { x: 'v' })).toBe('v');
+    // 二重括弧は single 既定では補間されない（byte 同一の裏取り）
+    const { t: t2 } = createTranslator({ 'a.b': '{{x}}' } as const);
+    expect(t2('a.b', { x: 'v' })).toBe('{v}'); // 外側 {x} だけ置換され {{x}}→{v}
+  });
+});
+
+describe('乖離① nested catalog（catalogShape: "nested"・dot-path lookup）', () => {
+  const nested = {
+    common: {
+      buttons: { close: '閉じる', save: '保存' },
+      greeting: 'こんにちは {name}',
+    },
+  };
+
+  it('dot-path で入れ子の葉を引く', () => {
+    const { t } = createTranslator(nested, { catalogShape: 'nested' });
+    expect(t('common.buttons.close')).toBe('閉じる');
+    expect(t('common.greeting', { name: 'ねね' })).toBe('こんにちは ねね');
+  });
+
+  it('中間ノード止まり・存在しない path は onMissing（既定 throw）', () => {
+    const { t } = createTranslator(nested, { catalogShape: 'nested' });
+    expect(() => t('common.buttons')).toThrow(/unknown MessageKey/); // 葉でない
+    expect(() => t('common.nope.deep')).toThrow(/unknown MessageKey/);
+  });
+
+  it('flat 既定では同じドットキーを完全一致で引く（探索しない＝現行不変）', () => {
+    const { t } = createTranslator({ 'common.buttons.close': '閉じる' } as const);
+    expect(t('common.buttons.close')).toBe('閉じる');
+  });
+});
+
+describe('乖離② 二重括弧補間（interpolation: "double"）', () => {
+  it('{{name}} を補間・単括弧 {name} は素通し', () => {
+    const { t } = createTranslator({ hi: 'Hi {{name}} / {literal}' } as const, {
+      interpolation: 'double',
+    });
+    expect(t('hi', { name: 'ねね', literal: 'X' })).toBe('Hi ねね / {literal}');
+  });
+
+  it('欠落 param は placeholder を残す（現行と同じ非破壊挙動）', () => {
+    const { t } = createTranslator({ hi: '{{a}}{{b}}' } as const, { interpolation: 'double' });
+    expect(t('hi', { a: '1' })).toBe('1{{b}}');
+  });
+});
+
+describe('乖離③ 欠落キーの可視 fallback（onMissing）', () => {
+  it("'key-echo' は key をそのまま返す（沈黙 fallback 禁止 I18N-22＝可視化）", () => {
+    const { t } = createTranslator({ known: 'K' } as const, { onMissing: 'key-echo' });
+    // @ts-expect-error 型では未知だが runtime は key を返す
+    expect(t('audit_event.action.login')).toBe('audit_event.action.login');
+    expect(t('known')).toBe('K');
+  });
+
+  it('関数 onMissing は製品固有整形を通す', () => {
+    const spy = vi.fn((key: string) => `[[${key}]]`);
+    const { t } = createTranslator({ known: 'K' } as const, { onMissing: spy });
+    // @ts-expect-error 未知キー
+    expect(t('x.y')).toBe('[[x.y]]');
+    expect(spy).toHaveBeenCalledWith('x.y');
+  });
+});
+
+describe('コア純度: 3 strategy の直交合成（nested × double × key-echo＝vault 実需の同時指定）', () => {
+  it('vault が渡す 3 option 同時指定で全て効く', () => {
+    const catalogs = {
+      audit_event: { action: { login: '{{user}} がログイン' } },
+    };
+    const { t } = createTranslator(catalogs, {
+      catalogShape: 'nested',
+      interpolation: 'double',
+      onMissing: 'key-echo',
+    });
+    expect(t('audit_event.action.login', { user: 'ねね' })).toBe('ねね がログイン');
+    expect(t('audit_event.action.logout')).toBe('audit_event.action.logout'); // 可視 fallback
+  });
+});


### PR DESCRIPTION
Refs #137 — 0.3.0 W0b 実装順 **①のみ**（②③④ は本PR merge 後に main から順次・アンブレラ #137 は open 維持）。

## 何を（スペック §2）

`createTranslator` に第2引数 `TranslatorOptions` を追加し、vault C4b 実測の runtime 昇格ブロッカー3点を吸収する。コア `t()` は**分岐を持たず**、生成時に解決した3つの strategy（lookup / interpolate / onMissing）を注入関数として呼ぶ（「コアは薄く・挙動は options で外から」）。

- `onMissing`: `'throw'`（既定・fail-closed）/ `'key-echo'`（可視 fallback・I18N-22）/ 関数
- `interpolation`: `'single'`（既定 `{name}`）/ `'double'`（`{{name}}`）
- `catalogShape`: `'flat'`（既定・完全一致）/ `'nested'`（dot-path 探索）

nested の key 型は `string` に緩め（`LooseTranslator`）。DotPaths 型導出は over-engineer 回避で #137 内の 0.3.x 課題として保留（コメント明記・runtime の dot-path は正しく動く）。

## 後方互換（最優先・実証）

options 省略時は flat / single / throw で **0.2.0 と byte 同一挙動**。既存テスト（`parity.test` 8・`testing.test` 3）を**1本も変更せず全緑**。

## 実測（`npm run check`・rc=0）

- type-check（tsc --build packages/*）: green
- lint / format:check: green
- **test: 29 files / 428 passed**（新規 `translator-options.test.ts` +10。**既存 418 全緑＝回帰0**）
- check:cli / conformance smoke（unknown 14＝W0a skeleton の既知・非blocker）/ **AM-2 gate: PASS**

## 備考

- doc `fcf2fb2`（0.3.0 設計スペック）を同梱。①の正本スペックのため1論点とみなす（hub 裁定・案A）。
- **未 publish**（施主 seam）。version bump 0.2.0→0.3.0 は ④（exports に ./react 追加時）で行う。
