### PR TITLE
chore(fleet-baseline): i18n を ^0.3.0 へ追随（0.3.0 publish landed・AM-12・Closes #140）

### DIFF
--- a/docs/fleet-baseline.test.ts
+++ b/docs/fleet-baseline.test.ts
@@ -41,7 +41,7 @@ describe('fleet-baseline.json', () => {
     }
   });
 
-  it('発効済み: client ^1.1.0・tokens ^1.1.0・standards ^2.0.0（2026-07-21 publish landed で実在版追随・npm 公開実測 shasum standards 20e4f3e0 / tokens e18befd5）・i18n ^0.1.0', () => {
+  it('発効済み: client ^1.1.0・tokens ^1.1.0・standards ^2.0.0・i18n ^0.3.0（2026-07-21 publish landed で実在版追随・npm 公開実測 shasum standards 20e4f3e0 / tokens e18befd5 / i18n 8c2e2b08）', () => {
     expect(baseline.packages['@hideyukimori/nene2-client']).toBe('^1.1.0');
     // tokens ^1.1.0: 2026-07-18 publish landed（写像表 v1 payout 分＋codemod ランナー同梱の最低版）。
     // npm latest=1.1.0・dist.shasum e18befd55354be6002b236859746ebcf89399b91（fleet-tooling 実測）。
@@ -51,8 +51,10 @@ describe('fleet-baseline.json', () => {
     // BREAKING なので caret でも 1.x は拾わない（意図どおり）。
     // #57 順序規範（publish→座席充填）どおり、publish 実在確認後にフロアを実在版へ追随。
     expect(baseline.packages['@hideyukimori/nene2-standards']).toBe('^2.0.0');
-    // null（座席のみ）→ ^0.1.0。rc で出すと範囲が ^0.1.0-rc.1 になり、それは 0.1.0 も 0.1.1 も
-    // 拾う（semver 実測）ため、版が進んでも全消費リポに prerelease 範囲が残り続ける（#44）
-    expect(baseline.packages['@hideyukimori/nene2-i18n']).toBe('^0.1.0');
+    // i18n ^0.3.0: 2026-07-21 publish landed（runtime translator options＋/react I18nProvider＋
+    // renderWithI18n＝runtime 昇格レーン W0b・#137/#138/#139）。npm latest=0.3.0・
+    // dist.shasum 8c2e2b08c5e603117e941f99ceed3d696bf08cb6（fleet-tooling 実測）。
+    // 0.x caret ゆえ ^0.3.0 = >=0.3.0 <0.4.0。#57 順序規範（publish→座席充填）どおり実在確認後に追随。
+    expect(baseline.packages['@hideyukimori/nene2-i18n']).toBe('^0.3.0');
   });
 });

--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -5,6 +5,6 @@
     "@hideyukimori/nene2-client": "^1.1.0",
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.0.0",
-    "@hideyukimori/nene2-i18n": "^0.1.0"
+    "@hideyukimori/nene2-i18n": "^0.3.0"
   }
 }


### PR DESCRIPTION
Closes #140 — nene2-i18n 0.3.0 publish landed を受けた fleet-baseline 追随（`docs/publish.md`「publish 成功後にやること」）。

## 変更
- `fleet-baseline.json`: `@hideyukimori/nene2-i18n` **`^0.1.0` → `^0.3.0`**。
- `docs/fleet-baseline.test.ts`: 発効済み検査の i18n 期待値＋コメント更新。

## 実測（誠実性ガード解除の根拠）
- `npm view @hideyukimori/nene2-i18n version` = **0.3.0**、`dist.shasum` = `8c2e2b08c5e603117e941f99ceed3d696bf08cb6`（独立実測）。
- `npm run check` rc=0（fleet-baseline.test 緑・AM-2 PASS）。
- 0.x caret ゆえ `^0.3.0` = `>=0.3.0 <0.4.0`。#57 順序規範（publish→座席充填）遵守。

未公開版を書かない誠実性ガード（AM-12）を、実在版確認のうえ解除。