### PR TITLE
fix(standards): arbitrary-value セレクタから arbitrary VARIANT を除外（#142）

### DIFF
--- a/packages/nene2-standards/src/selectors.ts
+++ b/packages/nene2-standards/src/selectors.ts
@@ -28,8 +28,11 @@ export const API_FETCH_SYNTAX: readonly SyntaxSelector[] = [
 /** 05 §2.2.4 styling の7セレクタ（会議R1⑤・R2⑥・R4 AM-5/AM-8/AM-13・R5議題(3)決定）。 */
 export const STYLING_SYNTAX: readonly SyntaxSelector[] = [
   {
-    // Tailwind arbitrary value 禁止（9リポの既存 lint の共通化 — 会議R1⑤決定）
-    selector: String.raw`JSXAttribute[name.name='className'] Literal[value=/(^|[\s'"!])[\w:-]*\[/]`,
+    // Tailwind arbitrary value 禁止（9リポの既存 lint の共通化 — 会議R1⑤決定）。
+    // arbitrary VARIANT（data-[tone=x]:… 等 = FC-1 blessed idiom）は対象外 MUST —
+    // `](?!:)` で「] の後に : が続く」＝ variant 形を除外する（#142）。
+    // 残ギャップ: data-[x]:bg-[17px]（variant 直後の arbitrary value）は boundary の制約で漏れる。
+    selector: String.raw`JSXAttribute[name.name='className'] Literal[value=/(^|[\s'"!])[\w:-]*\[[^\]]*\](?!:)/]`,
     message:
       'arbitrary value（p-[17px] 等）MUST NOT。値はトークン由来ユーティリティのみ（会議R1⑤決定）。',
   },

--- a/packages/nene2-standards/tests/composed-config.probes.test.ts
+++ b/packages/nene2-standards/tests/composed-config.probes.test.ts
@@ -127,6 +127,15 @@ describe('検出プローブ — styling（R1⑤・R2⑥・R4 AM-5/AM-8/AM-13）
     }
   });
 
+  it('arbitrary VARIANT（data-[tone=x]: 等）は誤検知せず、variant 下の arbitrary VALUE は検知する（#142）', () => {
+    const msgs = messagesFor('src/features/probe-slice/arbitrary-variant-probe.tsx').filter(
+      (m) => m.ruleId === 'no-restricted-syntax' && m.message.includes('arbitrary value'),
+    );
+    // fixture 内の flag 対象は hover:p-[17px] の1行のみ（data-[tone=x]:… / [&:nth-child]:… は許容）
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].message).toContain('arbitrary value');
+  });
+
   it('style prop は CSS 変数注入のみ許可（nene2/style-prop-css-vars-only）', () => {
     const msgs = messagesFor('src/features/probe-slice/style-prop-probe.tsx').filter(
       (m) => m.ruleId === 'nene2/style-prop-css-vars-only',

--- a/packages/nene2-standards/tests/fixtures/probe-app/src/features/probe-slice/arbitrary-variant-probe.tsx
+++ b/packages/nene2-standards/tests/fixtures/probe-app/src/features/probe-slice/arbitrary-variant-probe.tsx
@@ -1,0 +1,9 @@
+// arbitrary VARIANT（FC-1 blessed idiom）は許容・variant 下の arbitrary VALUE は検知（#142）
+export function ArbitraryVariantProbe() {
+  return (
+    <div className="data-[tone=danger]:bg-danger-soft">
+      <span className="[&:nth-child(2)]:w-4">variant は許容</span>
+      <span className="hover:p-[17px]">value は検知</span>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #142

## 変更

`packages/nene2-standards/src/selectors.ts` の arbitrary-value セレクタ（STYLING_SYNTAX 先頭・会議R1⑤）の値 regex を

```
(^|[\s'"!])[\w:-]*\[   →   (^|[\s'"!])[\w:-]*\[[^\]]*\](?!:)
```

に変更。negative-lookahead で「`]` の後に `:` が続く」＝ **arbitrary VARIANT 形を除外**する（vault と合意済みの方針）。

## 挙動マトリクス（テストでロック済み）

| className | 判定 | 根拠 |
|---|---|---|
| `p-[17px]` | **flag** | 値＝負債（既存挙動維持・styling-probe） |
| `hover:p-[17px]` | **flag** | 正常 variant 下の値も捕捉維持（新 probe） |
| `data-[tone=danger]:bg-danger-soft` | 許容 | FC-1 blessed idiom（新 probe） |
| `[&:nth-child(2)]:w-4` | 許容 | 判例#33 express 戦略（新 probe) |

## 既知の残ギャップ（スコープ外・src コメントに明記）

`data-[x]:bg-[17px]`（arbitrary variant 直後の arbitrary value）は boundary の制約で漏れる。極稀＋FC-1 は値を常にトークンにするため実害なし。厳密化（`:` を boundary に追加）は follow-up 可。

## 実測

- `vitest run packages/nene2-standards` → **15 files / 216 tests 全緑**（合成済み最終 config への実 ESLint 実行プローブ含む）
- `tsc --build` → 緑（dist は publish 時生成・git 管理外）
- 新 fixture `arbitrary-variant-probe.tsx`＝variant 2形の非検知＋variant 下 value 1件の検知を同一ファイルで両断ロック

## 後続（PR 外）

- publish は施主 seam（2手: dry_run→本番＋fleet-baseline version floor bump）
- merge 後 PR# を vault（#322 緑化待ち・data-variant 波 B-E）へ共有
- 判例#32 への追記（point6「tooling 改修不要」は CSS 属性セレクタ側の話・本件は eslint className 側）

🤖 Generated with [Claude Code](https://claude.com/claude-code)