### PR TITLE
chore(standards): 2.1.1 パッチ bump（#144）

### DIFF
--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-standards",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules, A1 hooks→model migration codemod",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Closes #144. #143（arbitrary-VARIANT 誤検知修正）出荷のためのパッチ bump。npm 実測: 2.1.0 は publish 済み→本修正は 2.1.1。fleet-baseline floor bump は publish 後（未公開版を書かない裁定）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)