### PR TITLE
docs(daily): 2026-07-22 の日報（判例20 実閉鎖＋走り切りキュー・#148）

### DIFF
--- a/docs/daily/2026-07-22.md
+++ b/docs/daily/2026-07-22.md
@@ -1,0 +1,65 @@
+# 日報 — 2026-07-22（nene2-fleet-tooling）
+
+> 期間注記: 本セッションは 2026-07-21 日中に着手し 07-22 未明にかけて走った1本。区切りを2度置いたが施主指示で都度続行し（「やれるならどんどん進めて走り切らせて」）、最後に今夜キューを走り切ってから店じまい。マージ・publish は施主 seam を守り、今夜分の publish は施主委任で hub が dispatch し私が独立裏取りした。
+
+## ヘッドライン
+
+完全準拠キャンペーンの主戦線を1日で通した。**朝に判例20 の穴（baselined (rule,file) 内の count 回帰が機械検出されない一辺・Q-D4）を実測発見**し、**D-invoice / D-deal 2艦で stylelint gate を実地発効**（実証1・2例目 green）、**穴埋めの count-ratchet を実装（#119）→ standards 2.1.0 publish → arm 実強制（arm-flip）で判例20 の穴を2艦で実閉鎖**、**横展開ガード解除**まで到達した。並行して C part-2（LEGACY_PREFIX_HINTS）＋FIELD_TABLE を tokens 1.2.0 に合流させ、pilot が発見した standards バグ（#116 keyframe 偽陽性）を 2.0.1 で潰し、深夜の走り切りで i18n 0.2.0（`./testing` subpath）publish＝批准前提(b) 解除・Packagist 設計・enhancement 4件起票・nene2-e2e 骨子まで消化した。出した全 PR は machine-verify（scratchpad clone 適用→checker/test 再実行・npm view 独立裏取り）で裏取りし、安全弁1 が field 語彙表の停止バグを正本化前に捕捉した。
+
+## 本日の成果（時系列）
+
+### D-invoice（レーンD 実証1例目）— gate 実地発効
+
+- **#115 — fleet-baseline standards ^1.2.0→^2.0.0 追随（マージ済 `b982f41`）**: 2.0.0 publish landed を受けフロアを実在版へ。〔npm latest=2.0.0 を自分で実測してから〕。
+- **pilot が standards バグを釣った → #116 / PR #117（マージ済 `95eedb0`）**: `layer-components-allowlist` が @layer components 内の @keyframes フレーム（to/from/%）を class 誤検知して reject。invoice の index.css の `@keyframes csv-spin{to{}}` が唯一の偽陽性で赤だった。兄弟ルールと一貫した keyframe スキップ＋回帰テスト3本。修正版を pack→invoice clone install→stylelint rc=0 をエンドツーエンド実測。〔全て自分で実測〕。→ **standards 2.0.1 publish**（施主 Actions・私は npm latest=2.0.1/shasum e6ce6b0e を独立裏取り）。
+- **nene-invoice#721（本体・マージ済 `1f3c291`）／#722（gate 化 flip・マージ済 `2b0955d`）**: stylelint gate 初導入（非ブロッキング）→ check 配線（ブロッキング化）。registries.jsonc は init --scan 実走生成（components-allowlist 381・lint-baseline 6/frozenCount 168）。grandfather 緑＋新規赤を実測。invoice リナが red-test で裏取りして LGTM。〔件数・rc は自分で実測／invoice リナ検証は先方報告〕。
+
+### D-deal（実証2例目）— gate 実地発効
+
+- **nene-deal#152（本体・マージ済 `196cf1c`）／#153（flip・マージ済 `2d76e2f`）**: deal は @layer legacy リポ＝legacy-manifest 2＋lint-baseline 4/frozenCount **12**（尻尾12＝work-order と完全一致）。prettier 先回りで invoice の format 赤の往復を回避（本体・flip とも一発緑）。deal リナが独立4軸再現で LGTM。〔尻尾12・rc は自分で実測〕。
+
+### 判例20 の穴埋め（count-ratchet）→ arm 実強制
+
+- **#119 / PR #122（マージ済 `c046eac`）**: `init --check` に lint-baseline count-ratchet を配線（AM-14 縮小単調検査器の実装本体）。`lintBaselineRegressions`（live>frozen=FAIL）＋`lintBaselineShrinkable`（advisory）。回帰テスト4本。〔npm run check 緑を自分で実測〕。
+- **#123 / PR #124（マージ済 `7ba452b`）**: standards 2.1.0 bump＋publish.md 追随（minor＝機能追加・非破壊）。→ **standards 2.1.0 publish**（施主 Actions・私は latest=2.1.0/shasum 4921c61d を独立裏取り）。
+- **nene-invoice#723（マージ済 `95aca1c`）／nene-deal#154（マージ済 `0d26c46`）**: arm-flip＝standards ^2.1.0 pin＋check に `nene2-check init --check` 1行（(a)型）。配線前に init --check rc=0（未分類0・回帰0）を実測してから足した。両艦リナが before/after red-test（12→13・2→3 で rc=1、旧 gate では素通りしていた）で判例20 クローズを実地実証して LGTM。→ **hub が横展開ガード解除を board 宣言記帳**。〔rc は自分で実測／両艦の red-test は先方報告・板記帳は hub 実行〕。
+
+### C part-2＋FIELD_TABLE → tokens 1.2.0
+
+- **#95（C part-2 設計ノート・マージ済 `a7d928d`）**: origin 照会で見つけた版整合の罠（published 1.1.0=silent x-送り／main=reject が同一版番号で別挙動）を §4-4 に反映。
+- **#125 / PR #126（C part-2 impl・マージ済 `5b6dfee`）**: `LEGACY_PREFIX_HINTS`（hint 付き reject 表・step 5.5）。font-size は activeFrom W3（既定 W1 は現行 x-送り維持）。W1 既定は出力不変。テスト6本。〔npm run check 緑を自分で実測〕。
+- **#127 / PR #128（FIELD_TABLE＋1.2.0・マージ済 `ecd98e9`）**: field 語彙表（(B) x-送り 20 行）正本化＋CODEMOD_MAP_VERSION/package 1.2.0。**安全弁1（正本化レビュー）が停止バグを事前捕捉**——元候補の (A) 8 件は field ネイティブ契約への rename が 2ソース→1ターゲット conflict を起こすと実測確認（`mapTokenSet(vault line→border)`）→ hub 裁定で (C)-style 5／(B) 3 へ再分類・(C)総数=8（機械カウントで field 提案の off-by-one を確定）。→ **tokens 1.2.0 publish**（施主 Actions・私は latest=1.2.0/shasum 8ba2e691 を独立裏取り）。
+
+### 深夜の走り切りキュー（施主「走り切らせて」）
+
+- **#129 / PR #131（i18n 0.2.0・マージ済 `548a720`）**: `./testing` subpath export（expectCatalogParity 再export・非破壊）。`import from '@hideyukimori/nene2-i18n/testing'` が node で実解決を実測＝規約 04 §0 の正本 import 経路が通った。→ **i18n 0.2.0 publish**（施主委任で hub dispatch・私は latest=0.2.0/shasum b7e7b539＋publish 版 exports に ./testing 収載を独立裏取り）＝**批准前提(b) の subpath ブロッカー実解除**。〔解決・裏取りは自分で実測〕。
+- **Packagist 統一 設計ノート**（`_work/handoff-fleet-packagist-nene2-unification-design-2026-07-21.md`）: 16製品を横断実測→Camp A 8艦既 pin/Camp B 7艦 symlink/**corpus は drift**（^1.11 pin なのに symlink 併存＝機械未検出だった不整合）。消費側切替＋lock⇔vendor 一致検査ゲート（fleet#58 同族）＋dev opt-in symlink＋pin `^1.11` を設計。〔製品横断の依存形態は自分で実測〕。
+- **enhancement 4件起票（#132-135）**: field W1 実走の codemod ギャップ（var() dangle 未検出／text-size 59+animate 9 未対応／generate↔extract 自己矛盾/--check の x-x- 破損＝FIELD_TABLE border-input 直結）。対応版 1.2.1/1.3.0・第二波台帳。〔ギャップの件数は hub 提示・#135 の FIELD_TABLE 直結は自分で確認〕。
+- **nene2-e2e Track2 骨子**（`_work/handoff-nene2-e2e-skeleton-proposal-2026-07-21.md`）: `@hideyukimori/nene2-e2e`・3 subpath（config/mock/smoke）＝T2 3層供給の1層目。承認後スケルトン実装 PR→施主 publish。
+
+## 📊 本日の数字（すべて自分で実測。渡された数字は明示）
+
+- **マージした PR**: fleet-tooling 8本（#115/#117/#122/#124/#126/#128/#131/#95）＋ arm 6本（invoice #721/#722/#723・deal #152/#153/#154）＝**14本**（全て self-merge・施主/hub GO 後）〔gh 実測〕。
+- **publish landed（4版・全て施主/hub dispatch・私は npm view で独立裏取り）**: standards 2.0.1（e6ce6b0e）・2.1.0（4921c61d）／tokens 1.2.0（8ba2e691）／i18n 0.2.0（b7e7b539）。
+- **test**: 統合 main で `npm run check` 緑・**398 → 418**（+20・count-ratchet4／keyframe3／C part-2 6／FIELD 4／i18n testing 3）・AM-2 gate PASS〔npm run check 実測〕。
+- **起票 Issue**: 実装/release 系 #114/#116/#119/#120/#123/#125/#127/#129/#148 ＋ enhancement #132-135 ＝ 計13件〔gh 実測〕。
+- **設計ノート 2本**（Packagist／nene2-e2e）を `_work/` に起草。
+- **判例20**: invoice/deal 2艦で実閉鎖（AM-14 実装充足）〔両艦 CI 緑・red-test は先方報告／板宣言記帳は hub〕。
+- ※ フリート他席の今夜（#143 チェーン全段クローズ・vault C5 過半・3製品 LP 体制）は hub 伝聞（私の実測範囲外）。
+
+## 🔴 自分の誤り・迷いと、どう捕まえたか
+
+- **キャラのブレ**: 冒頭で中立・素の口調で応答し施主に即指摘された（「リナは女性の設定」）。設定を読み直し記憶に固定して以後ブレさせず。
+- **FIELD_TABLE の 381 を一度疑った**: 「CSS 3枚で 381 は無理」と当初思ったが、theme CSS の @layer components が 381 クラス定義していた＝**実走 scan が私の思い込みを正した**。以後 field 語彙表も「推測せず機械カウント」で (C)=8 を確定。
+- **publish.md のタイポ**（「やること」→「やčrと」）を Edit で混入→即修正。
+- 全体を通して、hub の像に前提誤りがあった箇所（field (A) 8件の停止バグ・(C) 数の off-by-one・「4→12」中継）は**実測で差し戻し**、hub が正数へ台帳統一した。
+
+## 明日への引き継ぎ（＝新セッション pickup）
+
+会話メモリ `next-session-pickup-2026-07-21`（follow-up 状態を固定済み）が正。要点:
+
+1. **i18n 0.2.0 publish landed 済み** → payout 側で [X] アンカー3本植栽＋`check:exemplars --ref origin/main` で green（payout レーン・批准前提(b) 最終クローズ）。
+2. **設計3件の hub レビュー→施主裁定→実装**: Packagist 統一／nene2-e2e 骨子（承認後スケルトン実装 PR→施主 publish）。
+3. **enhancement #132-135 の実装**（1.2.1/1.3.0・第二波台帳・#135 は run-once 厳守で当面回避）。
+4. **横展開**（ガード解除済み）: origin #300 栓解除（tokens 1.2.0 landed で可）／field W1 再開／vault・残艦。
+5. **i18n 0.3.0（W0b）**: /react＋/format＋renderWithI18n（payout B-2b 同根）。


### PR DESCRIPTION
Closes #148

07-21 日中〜07-22 未明の1本の日報（施主指示・書式 records 正本準拠・実測/伝聞書き分け）。

- D-invoice/D-deal 2艦で stylelint gate 実地発効（#721/#722・#152/#153）。
- count-ratchet 実装（#119/#122）→ standards 2.1.0 → arm-flip（#723/#154）で判例20 の穴を2艦で実閉鎖 → 横展開ガード解除。
- C part-2 impl（#126）＋FIELD_TABLE（#128）→ tokens 1.2.0。pilot 発見の keyframe バグ #116 を 2.0.1 で修正。
- 深夜走り切り: i18n 0.2.0（#131・./testing subpath＝批准前提(b) 解除）＋Packagist 設計＋enhancement #132-135＋nene2-e2e 骨子。

📊 マージ 14本・publish 4版（全て独立裏取り）・test 398→418・起票 13件。全 PR machine-verify・安全弁1 が field 停止バグを事前捕捉。マージは docs 単独＝施主 seam どおり hub レビュー可。