### PR TITLE
docs(daily): 2026-07-22 の日報（i18n 0.3.0 完走・Closes #149）

### DIFF
--- a/docs/daily/2026-07-22.md
+++ b/docs/daily/2026-07-22.md
@@ -62,4 +62,25 @@
 2. **設計3件の hub レビュー→施主裁定→実装**: Packagist 統一／nene2-e2e 骨子（承認後スケルトン実装 PR→施主 publish）。
 3. **enhancement #132-135 の実装**（1.2.1/1.3.0・第二波台帳・#135 は run-once 厳守で当面回避）。
 4. **横展開**（ガード解除済み）: origin #300 栓解除（tokens 1.2.0 landed で可）／field W1 再開／vault・残艦。
-5. **i18n 0.3.0（W0b）**: /react＋/format＋renderWithI18n（payout B-2b 同根）。
+5. **i18n 0.3.0（W0b）**: /react＋/format＋renderWithI18n（payout B-2b 同根）。→ **本日、/react＋renderWithI18n は別席で landed**（下記「追補」・/format は 0.3.0 対象外のまま）。
+
+---
+
+## 追補: nene2-i18n 0.3.0 席（W0b・runtime 昇格レーン）
+
+> 上記は統合席の日報。以下は 0.3.0 専任席（hub 発令で起動した別 worktree／別ブランチ）の追補。実作業は **2026-07-21 夜 JST**（commit 19:49–20:24・merge 20:29–21:34）。上記「明日への引き継ぎ」項5 のうち **/react＋renderWithI18n は本セッションで landed**（/format＝I18N-13 は payout B-2b の別供給で 0.3.0 対象外）。vault C4b 実測の runtime 昇格ブロッカー3点（nested catalog／二重括弧補間／欠落キーの可視 fallback）＋/react を、後方互換 byte 同一を最優先に実装。設計判断は都度 hub 照会・merge/publish seam は施主本人に直接確認。
+
+### 成果（時系列・Issue #137 アンブレラ駆動・スペック §6 全消化）
+
+- **① translator options（PR #138・merged `0d4dd8e`）**: `createTranslator(catalog, options?)` に第2引数（`onMissing` throw既定/key-echo/関数・`interpolation` single既定/double・`catalogShape` flat既定/nested dot-path）。コア `t()` は分岐を持たず3 strategy 注入。**既定引数は 0.2.0 と byte 同一＝既存テスト不変・回帰0**〔自分で実測〕。nested の key 型は over-engineer 回避で `string` に緩め（DotPaths は 0.3.x 別 issue・hub 裁定）。
+- **②③④ /react（PR #139・merged `510daf2`・案A で1本の /react PR に集約）**: ② `I18nProvider`＋`useTranslation`（`useSyncExternalStore`・scope 要素に lang＝AM-18・既定 `<div lang>`＋`as`・provider 外/未知 locale は throw）。③ `renderWithI18n`（RTL ヘルパ・production /react を RTL 非結合にする `render.ts` 分離・/testing 再export）。④ exports に `./react`・version 0.2.0→0.3.0・publish.md 0.3.0 節。react/RTL は optional peerDependency。**#137 Closed**。
+- **publish 0.3.0（施主実行）→ fleet-baseline 追随（#140／PR #141・merged `28fe0ac`・Closes #140）**: `fleet-baseline.json` i18n `^0.1.0→^0.3.0`＋test 更新。#57 順序規範どおり実在確認後に追随＝未公開版ガード（AM-12）解除。〔npm latest=0.3.0/shasum `8c2e2b08…` を独立裏取りしてから〕。
+- 施主直接指示で旧日報 PR **#71（2026-07-17）を代行 merge**（`411b8b7`・docs のみ・競合なし〔自分で実測〕）。
+
+### 📊 数字（nene2-i18n 席・すべて自分で実測。渡された数字は明示）
+
+- **PR**: 起票3・merged3（#138 ①／#139 ②③④／#141 baseline・全 squash・CI 緑）＋ #71 代行 merge。〔gh 実測〕
+- **Issue**: 起票2（#137・#140）＋本日報 #149。Closed 2（#137・#140）。〔gh 実測〕
+- **test**: 全 suite **418 → 437 passed（+19・31 files）**（translator-options 10／react 6／render 2／testing 再export 1）・AM-2 PASS。〔`npm run check` rc=0 自分で実測〕
+- **publish**: i18n **0.3.0**（施主実行）・npm latest=0.3.0/shasum 8c2e2b08〔独立裏取り〕。
+- **seam**: merge は施主 in-session 許可で代行（#138/#139 都度・#141 以降 standing・hub PASS＋CI 緑条件）。publish は施主の手（④は version bump のみ）。hub 経由の「施主GO」は毎回本人許可に紐づけた。

--- a/docs/daily/README.md
+++ b/docs/daily/README.md
@@ -7,5 +7,7 @@
 
 ## 索引（新しい順）
 
+- [2026-07-22](2026-07-22.md) — 判例20 実閉鎖＋D-invoice/deal gate 発効・tokens1.2.0/standards2.1.0/i18n0.2.0 publish（統合席）／**i18n 0.3.0（/react・runtime 昇格）完走**（i18n 席・PR #138/#139/#141 マージ・追補節）
+- [2026-07-18](2026-07-18.md) — 完全準拠キャンペーン初日: 批准前提(a) を red→green で1日クローズ＋#65 components-allowlist kind 実装3枚（PR #77/#78/#79 マージ）
 - [2026-07-17](2026-07-17.md) — A1 codemod 実装・publish（PR #67/#68 マージ）／批准前提(a) 全119件仕分け完了で 07-21 green 確定／concierge C1 sanction
 - [2026-07-16](2026-07-16.md) — `check:exemplars` が規約 A-10 に違反していた日（PR 6本マージ・Issue 7本起票）


### PR DESCRIPTION
Closes #149 — nene2-i18n 席の 2026-07-22 日報（実作業は 07-21 夜 JST・跨ぎ扱い）。docs のみ・追加ファイル1＋索引更新。数字は実測/伝聞を書き分け（publish は施主実行→npm view で独立裏取り・latest=0.3.0/shasum 8c2e2b08）。