### PR TITLE
fix(standards): registries の scoped-theme を stylelint 合成で消費する（#159・S 判定→実装）

### DIFF
--- a/packages/nene2-standards/src/stylelint/index.ts
+++ b/packages/nene2-standards/src/stylelint/index.ts
@@ -92,12 +92,29 @@ export default config;
 /** themes override が持つ rule 名（scoped-theme の secondary を焼く先 — #159）。 */
 const THEMES_TOKEN_ONLY = 'nene2/themes-token-only';
 
+/**
+ * 合成 config に、**意図的に落とした登録**を残すための非標準キー（#159 受入条件・hub 裁定 2026-07-29）。
+ *
+ * 不可視のスキップは「なぜ widget が無いのか」の調査コストとして後で必ず請求される。合成の入力
+ * （registries）と出力（config）を突き合わせた人が、差分の理由を**生成物だけで**読めるようにする。
+ * `stylelint --print-config` に現れるので、実運用の確認経路がそのまま診断経路になる。
+ *
+ * stylelint は未知のトップレベルキーを無視する（2026-07-29 実測: 警告も invalidOptionWarnings も出ない）。
+ */
+export const EXCLUDED_KEY = 'nene2ExcludedFromSynthesis';
+
+/** 合成結果（stylelint Config ＋ 意図的スキップの記録）。 */
+export type SynthesizedConfig = Config & { [EXCLUDED_KEY]?: string[] };
+
 const KNOWN_STYLELINT_RULES: ReadonlySet<string> = new Set<string>([
   ...Object.keys(config.rules ?? {}),
   ...(config.overrides ?? []).flatMap((o) => Object.keys(o.rules ?? {})),
 ]);
 
-export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: string): Config {
+export function stylelintConfigFromRegistries(
+  doc: RegistriesDocument,
+  repo: string,
+): SynthesizedConfig {
   const forRepo = doc.entries.filter((e) => e.repo === repo);
   const classes = forRepo
     .filter((e): e is ComponentsAllowlistEntry => e.kind === 'components-allowlist')
@@ -123,11 +140,18 @@ export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: str
   //   （現物は `"(widget mount root)"` というプレースホルダ）。themes/*.css の話ではないので
   //   **意図的にスキップする**。lint-baseline の loud error（語彙内 rule に file 無し）と違い、
   //   widget エントリは「stylelint 合成にとって無関係」であって「壊れた登録」ではないため throw しない
-  //   （throw にすると corpus / concierge が config 生成できなくなる）。この意図は下のテストが固定する。
-  const scopeSelectors = forRepo
-    .filter((e): e is ScopedThemeEntry => e.kind === 'scoped-theme')
-    .filter((e) => e.variant === 'local')
-    .map((e) => e.selector);
+  //   （throw にすると corpus / concierge が config 生成できなくなる）。ただし**黙って落とさない**:
+  //   スキップした事実と理由を `EXCLUDED_KEY` で生成物に残す（#92「表に無いものを黙って処理しない」
+  //   との整合 — 明示分岐＋生成物での可視化＋テストで意図を固定する三点で担保）。
+  const scopedThemes = forRepo.filter((e): e is ScopedThemeEntry => e.kind === 'scoped-theme');
+  const scopeSelectors = scopedThemes.filter((e) => e.variant === 'local').map((e) => e.selector);
+  const excluded = scopedThemes
+    .filter((e) => e.variant !== 'local')
+    .map(
+      (e) =>
+        `scoped-theme "${e.id}" (variant=${e.variant}): マウントルート要素の記述でセレクタではないため ` +
+        `${THEMES_TOKEN_ONLY} の additionalScopeSelectors に焼かない（by design — #159）`,
+    );
 
   // base の override 要素は**複製して差し替える**（in-place 変更 MUST NOT）。`config` はモジュール
   // レベルの単一インスタンスであり、要素を直接書き換えると以後の全呼び出しへ漏れる（呼び出し順
@@ -158,7 +182,10 @@ export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: str
     overrides.push({ files: [b.file], rules: { [b.rule]: null } });
   }
 
-  return { ...config, rules, overrides };
+  // 意図的スキップは**あったときだけ**生成物へ残す（無いときにキーを生やすと差分がノイズになる）。
+  return excluded.length > 0
+    ? { ...config, rules, overrides, [EXCLUDED_KEY]: excluded }
+    : { ...config, rules, overrides };
 }
 
 /**
@@ -176,7 +203,10 @@ export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: str
  * - 読んだ registry に**別 repo のエントリが混じる → loud error**（取り違え検出 — 別リポの
  *   registries.jsonc を偶然拾う事故を静かに通さない。B1 追加受入条件）。
  */
-export function stylelintConfigFor(repo: string, opts?: { registriesPath?: string }): Config {
+export function stylelintConfigFor(
+  repo: string,
+  opts?: { registriesPath?: string },
+): SynthesizedConfig {
   const registriesPath = opts?.registriesPath ?? path.resolve(process.cwd(), 'registries.jsonc');
   if (!existsSync(registriesPath)) {
     throw new Error(

--- a/packages/nene2-standards/src/stylelint/index.ts
+++ b/packages/nene2-standards/src/stylelint/index.ts
@@ -19,6 +19,7 @@ import {
   type LegacyManifestEntry,
   type LintBaselineEntry,
   type RegistriesDocument,
+  type ScopedThemeEntry,
 } from '../registries/schema.js';
 
 const config: Config = {
@@ -77,7 +78,8 @@ export default config;
  * で持つ。本関数は**中央 registries の当該 repo エントリ**から実効値を焼く:
  * - components-allowlist（vault/invoice 型）→ `allowedClasses`
  * - legacy-manifest（deal 型）→ `files`
- * どちらのエントリも持たない repo（payout 型・未登録）は base のまま＝fail-closed（G-6）。
+ * - scoped-theme（records 型・variant=local）→ themes override の `additionalScopeSelectors`（#159）
+ * どのエントリも持たない repo（payout 型・未登録）は base のまま＝fail-closed（G-6）。
  *
  * **供給元は中央 registries のみ**（被検査者=product が書けるファイルは読まない）。これにより
  * 「合成そのものを被検査者の手から取り上げる」＝G-7 を API で強制する（手書き列挙 MUST NOT）。
@@ -87,6 +89,9 @@ export default config;
  * lint-baseline の rule がこの語彙内なら「合成が意味を理解できる rule」＝(rule,file) grandfather の対象。
  * 語彙外（eslint 系 noHardcodedJapanese 等）は stylelint config には無関係＝素通し。
  */
+/** themes override が持つ rule 名（scoped-theme の secondary を焼く先 — #159）。 */
+const THEMES_TOKEN_ONLY = 'nene2/themes-token-only';
+
 const KNOWN_STYLELINT_RULES: ReadonlySet<string> = new Set<string>([
   ...Object.keys(config.rules ?? {}),
   ...(config.overrides ?? []).flatMap((o) => Object.keys(o.rules ?? {})),
@@ -108,10 +113,39 @@ export function stylelintConfigFromRegistries(doc: RegistriesDocument, repo: str
     rules['nene2/layer-legacy-manifest-only'] = [true, { files: [...files].sort() }];
   }
 
+  // scoped-theme を themes override の additionalScopeSelectors へ焼く（#159 — #65 根治の取りこぼし）。
+  //
+  // variant による扱い分け MUST:
+  // - `local`（records `.nene-public[data-theme]` 型）= themes/*.css のトップレベルに現れる実セレクタ。
+  //   themes-token-only の既定パターン `[data-theme='x']` 単体に合致しないため、**焼かなければ
+  //   台帳に登録しても効かない**（registries 登録が無意味になり、各艦が手書き列挙へ逃げる＝G-7 違反）。
+  // - `widget`（corpus / concierge）= マウントルート**要素**の記述であってセレクタ文字列ではない
+  //   （現物は `"(widget mount root)"` というプレースホルダ）。themes/*.css の話ではないので
+  //   **意図的にスキップする**。lint-baseline の loud error（語彙内 rule に file 無し）と違い、
+  //   widget エントリは「stylelint 合成にとって無関係」であって「壊れた登録」ではないため throw しない
+  //   （throw にすると corpus / concierge が config 生成できなくなる）。この意図は下のテストが固定する。
+  const scopeSelectors = forRepo
+    .filter((e): e is ScopedThemeEntry => e.kind === 'scoped-theme')
+    .filter((e) => e.variant === 'local')
+    .map((e) => e.selector);
+
+  // base の override 要素は**複製して差し替える**（in-place 変更 MUST NOT）。`config` はモジュール
+  // レベルの単一インスタンスであり、要素を直接書き換えると以後の全呼び出しへ漏れる（呼び出し順
+  // 依存の汚染）。
+  const overrides = (config.overrides ?? []).map((o) => {
+    if (scopeSelectors.length === 0) return o;
+    if (o.rules?.[THEMES_TOKEN_ONLY] === undefined) return o;
+    return {
+      ...o,
+      rules: {
+        ...o.rules,
+        [THEMES_TOKEN_ONLY]: [true, { additionalScopeSelectors: [...scopeSelectors].sort() }],
+      },
+    };
+  });
   // (rule,file) lint-baseline を per-file grandfather の override として焼く（P2 §2・#101）。
   // 語彙内の rule が file 無しで来たら loud error（黙って未消費の座席にしない — invoice 座席事件 /
   // #92「表に無いものを黙って処理しない」と同族。file 有無 × 語彙内外の4象限を全て明示挙動に）。
-  const overrides = config.overrides ? [...config.overrides] : [];
   const baselines = forRepo.filter((e): e is LintBaselineEntry => e.kind === 'lint-baseline');
   for (const b of baselines) {
     if (!KNOWN_STYLELINT_RULES.has(b.rule)) continue; // 語彙外（eslint 系）は stylelint 合成に無関係＝素通し

--- a/packages/nene2-standards/src/stylelint/registry-config.test.ts
+++ b/packages/nene2-standards/src/stylelint/registry-config.test.ts
@@ -15,7 +15,11 @@ import {
   REGISTRIES_SCHEMA_ID,
   type RegistriesDocument,
 } from '../registries/schema.js';
-import config, { stylelintConfigFor, stylelintConfigFromRegistries } from './index.js';
+import config, {
+  EXCLUDED_KEY,
+  stylelintConfigFor,
+  stylelintConfigFromRegistries,
+} from './index.js';
 
 /** 中央 source fleet.jsonc（リポ内・tarball 非同梱）を repo でスライスした per-repo registry を temp に書く。 */
 const centralSource = readFileSync(
@@ -158,6 +162,47 @@ describe('stylelintConfigFromRegistries — 台帳由来 secondary の合成', (
       (o) => o.rules?.['nene2/themes-token-only'] !== undefined,
     );
     expect(themes[0]?.rules?.['nene2/themes-token-only']).toBe(true);
+  });
+
+  it('🔴 スキップは生成物から見える: widget の除外理由が config に残る（#159 hub 受入条件）', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'scoped-theme',
+          id: 'corpus-widget-scoped-theme',
+          repo: 'nene-corpus',
+          variant: 'widget',
+          selector: '(widget mount root)',
+          reasonRef: 'council:minutes#R2-6-widget-scope',
+        },
+      ]),
+      'nene-corpus',
+    );
+    const excluded = r[EXCLUDED_KEY];
+    expect(excluded).toHaveLength(1);
+    // 「どのエントリが・なぜ」落ちたかを生成物だけで読めること（半年後の調査コストを作らない）
+    expect(excluded?.[0]).toContain('corpus-widget-scoped-theme');
+    expect(excluded?.[0]).toContain('variant=widget');
+    expect(excluded?.[0]).toContain('by design');
+  });
+
+  it('スキップが無いときは診断キーを生やさない（無変更 config に差分ノイズを作らない）', () => {
+    const noEntries = stylelintConfigFromRegistries(docOf([]), 'nene-payout');
+    expect(EXCLUDED_KEY in noEntries).toBe(false);
+    const localOnly = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'scoped-theme',
+          id: 'r',
+          repo: 'nene-records',
+          variant: 'local',
+          selector: '.nene-public[data-theme]',
+          reasonRef: 'r',
+        },
+      ]),
+      'nene-records',
+    );
+    expect(EXCLUDED_KEY in localOnly).toBe(false);
   });
 
   it('local と widget の混在: local だけ焼く（複数 local はソート済み）', () => {

--- a/packages/nene2-standards/src/stylelint/registry-config.test.ts
+++ b/packages/nene2-standards/src/stylelint/registry-config.test.ts
@@ -7,6 +7,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import stylelint from 'stylelint';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -114,6 +115,119 @@ describe('stylelintConfigFromRegistries — 台帳由来 secondary の合成', (
     expect(r.rules?.['nene2/layer-components-allowlist']).toBe(true);
   });
 
+  it('records 型（scoped-theme variant=local）: themes override に additionalScopeSelectors を焼く（#159）', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'scoped-theme',
+          id: 'records-public-scoped-theme',
+          repo: 'nene-records',
+          variant: 'local',
+          selector: '.nene-public[data-theme]',
+          reasonRef: 'council:minutes#R2-6-records-local-scope',
+        },
+      ]),
+      'nene-records',
+    );
+    const themes = (r.overrides ?? []).filter(
+      (o) => o.rules?.['nene2/themes-token-only'] !== undefined,
+    );
+    expect(themes).toHaveLength(1);
+    expect(themes[0]?.rules?.['nene2/themes-token-only']).toEqual([
+      true,
+      { additionalScopeSelectors: ['.nene-public[data-theme]'] },
+    ]);
+  });
+
+  it('🔴 scoped-theme variant=widget は焼かない（意図的スキップ・throw もしない — corpus/concierge 型）', () => {
+    const widgetEntries = docOf([
+      {
+        kind: 'scoped-theme',
+        id: 'corpus-widget-scoped-theme',
+        repo: 'nene-corpus',
+        variant: 'widget',
+        // 現物はセレクタでなくマウントルート要素のプレースホルダ（焼くと無意味・有害）
+        selector: '(widget mount root)',
+        reasonRef: 'council:minutes#R2-6-widget-scope',
+      },
+    ]);
+    // config 生成自体は成功する（widget 艦を壊さない）
+    const r = stylelintConfigFromRegistries(widgetEntries, 'nene-corpus');
+    // themes override は base のまま＝secondary 無し（`true` 単体）
+    const themes = (r.overrides ?? []).filter(
+      (o) => o.rules?.['nene2/themes-token-only'] !== undefined,
+    );
+    expect(themes[0]?.rules?.['nene2/themes-token-only']).toBe(true);
+  });
+
+  it('local と widget の混在: local だけ焼く（複数 local はソート済み）', () => {
+    const r = stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'scoped-theme',
+          id: 'x-widget',
+          repo: 'nene-x',
+          variant: 'widget',
+          selector: '(widget mount root)',
+          reasonRef: 'r',
+        },
+        {
+          kind: 'scoped-theme',
+          id: 'x-local-b',
+          repo: 'nene-x',
+          variant: 'local',
+          selector: "[data-design='calm'][data-theme='dark']",
+          reasonRef: 'r',
+        },
+        {
+          kind: 'scoped-theme',
+          id: 'x-local-a',
+          repo: 'nene-x',
+          variant: 'local',
+          selector: '.nene-public[data-theme]',
+          reasonRef: 'r',
+        },
+      ]),
+      'nene-x',
+    );
+    const themes = (r.overrides ?? []).find(
+      (o) => o.rules?.['nene2/themes-token-only'] !== undefined,
+    );
+    expect(themes?.rules?.['nene2/themes-token-only']).toEqual([
+      true,
+      {
+        additionalScopeSelectors: [
+          '.nene-public[data-theme]',
+          "[data-design='calm'][data-theme='dark']",
+        ],
+      },
+    ]);
+  });
+
+  it('🔴 base config を汚染しない（module レベル config の override を in-place で書き換えない）', () => {
+    const before = JSON.stringify(config.overrides);
+    stylelintConfigFromRegistries(
+      docOf([
+        {
+          kind: 'scoped-theme',
+          id: 'r',
+          repo: 'nene-records',
+          variant: 'local',
+          selector: '.nene-public[data-theme]',
+          reasonRef: 'r',
+        },
+      ]),
+      'nene-records',
+    );
+    // 合成後も base は secondary 無しのまま（次の呼び出しへ漏れない）
+    expect(JSON.stringify(config.overrides)).toBe(before);
+    const fresh = stylelintConfigFromRegistries(docOf([]), 'nene-records');
+    const themes = (fresh.overrides ?? []).find(
+      (o) => o.rules?.['nene2/themes-token-only'] !== undefined,
+    );
+    expect(themes?.rules?.['nene2/themes-token-only']).toBe(true);
+  });
+
   it('base config の他ルール・overrides は保持する（rules を破壊しない）', () => {
     const r = stylelintConfigFromRegistries(
       docOf([{ kind: 'components-allowlist', id: 'x', repo: 'nene-vault', classes: ['a'] }]),
@@ -121,6 +235,77 @@ describe('stylelintConfigFromRegistries — 台帳由来 secondary の合成', (
     );
     expect(r.rules?.['color-no-hex']).toBe(true);
     expect(r.overrides).toEqual(config.overrides);
+  });
+});
+
+/**
+ * 合成 config の「形」だけでなく **lint の結果が変わること** を実 stylelint で固定する（#159）。
+ * config オブジェクトの shape だけを見るテストは、rule 側が secondary を無視していても緑になる
+ * （＝空虚合格）。#159 の本体はまさに「供給経路が塞がっていて登録が効かない」だったので、
+ * ここは実行結果で押さえる。
+ */
+describe('🔴 scoped-theme の供給が lint 挙動に届く（実 stylelint・#159）', () => {
+  const themeCss = (selector: string) => `${selector} {\n  --x-color-bg: oklch(0.2 0 0);\n}\n`;
+  const localEntry = (repo: string, selector: string): RegistriesDocument['entries'][number] => ({
+    kind: 'scoped-theme',
+    id: `${repo}-local`,
+    repo,
+    variant: 'local',
+    selector,
+    reasonRef: 'council:minutes#R2-6-records-local-scope',
+  });
+
+  async function themeWarnings(
+    doc: RegistriesDocument,
+    repo: string,
+    selector: string,
+  ): Promise<string[]> {
+    const synthesized = stylelintConfigFromRegistries(doc, repo);
+    const { results } = await stylelint.lint({
+      code: themeCss(selector),
+      config: synthesized,
+      // themes override（`!(*.components).css`）に載る位置で検査する
+      codeFilename: 'src/shared/ui/theme/themes/default.css',
+    });
+    return results[0].warnings
+      .filter((w) => w.rule === 'nene2/themes-token-only')
+      .map((w) => w.text);
+  }
+
+  it('登録前（scoped-theme 無し）: 局所スコープは badScope で落ちる＝#159 の現象', async () => {
+    const warnings = await themeWarnings(docOf([]), 'nene-records', '.nene-public[data-theme]');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/登録スコープセレクタのみ/);
+  });
+
+  it('登録後（variant=local）: 同じ CSS が通る＝台帳登録が効く', async () => {
+    const warnings = await themeWarnings(
+      docOf([localEntry('nene-records', '.nene-public[data-theme]')]),
+      'nene-records',
+      '.nene-public[data-theme]',
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it('複合セレクタ（deal C5 型 [data-design][data-theme]）も登録で通る', async () => {
+    const selector = "[data-design='calm'][data-theme='dark']";
+    expect(await themeWarnings(docOf([]), 'nene-deal', selector)).toHaveLength(1);
+    expect(
+      await themeWarnings(docOf([localEntry('nene-deal', selector)]), 'nene-deal', selector),
+    ).toEqual([]);
+  });
+
+  it('登録は完全一致（別セレクタを登録しても通らない＝借用できない）', async () => {
+    const warnings = await themeWarnings(
+      docOf([localEntry('nene-deal', '.nene-public[data-theme]')]),
+      'nene-deal',
+      "[data-design='calm'][data-theme='dark']",
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("既定パターン（[data-theme='x'] 単体）は登録に関係なく通る（回帰）", async () => {
+    expect(await themeWarnings(docOf([]), 'nene-records', "[data-theme='dark']")).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## 概要

`stylelintConfigFromRegistries()` が `scoped-theme` エントリを消費していなかった欠陥を直す（Closes #159）。#65「供給経路の欠落の根治」から1種だけ漏れていた形。**台帳に登録しても効かない**ため各艦が `additionalScopeSelectors` を手書きするしかなく、G-7（合成を被検査者の手から取り上げる）と衝突していた。

## サイジング結果（hub 依頼への回答）: **S**

実装は1関数・約20行、設計判断は `variant` の扱い1点のみ。**S と判定したので裁定どおり批准前提(c) の前に実装**した。

## 変更

- `variant === 'local'` の `selector` を themes override（`themes/!(*.components).css`）の `additionalScopeSelectors` へ焼く。
- `variant === 'widget'`（corpus / concierge）は**意図的にスキップ**。現物は `"(widget mount root)"` というプレースホルダで**セレクタ文字列ではない**ため、焼くと無意味あるいは有害。`lint-baseline` の loud error（語彙内 rule に file 無し）と違い、widget エントリは「stylelint 合成にとって無関係」であって「壊れた登録」ではないので **throw しない**（throw にすると widget 艦が config を生成できなくなる）。この意図はテストで固定した。
- base の override 要素は**複製して差し替え**（module レベル `config` の in-place 変更を回避 — 呼び出し順依存の汚染を作らないため。専用テストあり）。

## 実測

- **負の対照**: 実装を stash して回すと**新規9件のうち4件が落ちる**ことを確認。テストが空虚合格でないことを実測で担保。
- **実 stylelint で挙動を固定**（config の shape だけを見るテストは、rule 側が secondary を無視していても緑になる＝#159 の再発を検出できない）:
  - 登録前 `.nene-public[data-theme]` → badScope で落ちる（#159 の現象そのもの）
  - 登録後 → 通る
  - **複合セレクタ `[data-design='calm'][data-theme='dark']`（deal C5 型）も登録で通る**
  - 登録は完全一致（他repo・別セレクタは借用できない）
  - 既定パターン `[data-theme='x']` 単体は登録に関係なく通る（回帰）
- `npm run check` **exit 0** ／ **31ファイル・447 tests pass**（+9）／ AM-2 gate PASS。
- **`MUST 総数 248・タグ欠落 0`**（`check:standards-doc` 実測）＝ 批准前提(a) GREEN 時の値と一致。**mustTotal 不変**。

## 凍結との関係

既存検査器の**欠陥修正＝bug-fix 相当**で、新文書・新条文・新検査器のいずれでもないため凍結に抵触しない（hub 裁定B と同じ理路）。挙動変更なので **minor bump 同乗が筋**だが、bump は #143→#145→#147 の慣行どおり**別 PR**とする（本 PR は fix のみ）。

## 未計測・残論点（正直に）

- 🔴 **records が実際に赤かは依然として未計測**。本 PR が証明したのは「合成が secondary を出すようになった」ことと「出せば通る」ことまで。records の公開面テーマファイルが `themes/!(*.components).css` にマッチする配置かは本リポからは分からない。
- 🔴 **deal の C5 6件が通るには deal 側の registries 登録が要る**（per-repo registries.jsonc・B1）。完全一致マッチなので **6セレクタ = 6エントリ**（schema の `selector` は単数）。deal の6件が直交2軸の組み合わせ（design × theme）なら、軸が増えると組み合わせ爆発する。
- **別論点（本 PR のスコープ外）**: `DEFAULT_SCOPE_PATTERN` を緩めて複合セレクタを構造的に許すか。影響範囲が広く **hub 裁定が要る**ため #159 の提案3どおり別 issue とする。上の「6エントリ問題」はその判断材料。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
