### PR TITLE
fix(standards): gate-integrity の偽陽性 — canonical off × 製品にルール不在を緩和と誤検出（#178）

### DIFF
--- a/packages/nene2-standards/src/checks/gate-integrity.ts
+++ b/packages/nene2-standards/src/checks/gate-integrity.ts
@@ -151,8 +151,12 @@ export async function checkGateIntegrity(options: GateIntegrityOptions): Promise
     const canon = canonTable[i];
     const prod = productTable[i];
     if (!canon || !prod) continue;
-    const sevCanon = canon.severity ?? -1;
-    const sevProd = prod.severity ?? -1;
+    // ルール不在（severity null）と off（0）は**同じ実効挙動**（そのルールは走らない）。
+    // 不在を -1 に落とすと「canonical が off・製品が不在」を緩和と誤検出する（#178 実測: origin の
+    // `no-restricted-globals: 実効 -1 < canonical 0`）。緩和とは「canonical が走らせるものを
+    // 製品が走らせない/弱める」ことなので、走らない同士の比較は差ではない。
+    const sevCanon = canon.severity ?? 0;
+    const sevProd = prod.severity ?? 0;
     // 緩和（canonical より弱い severity）= FAIL。強化は oracle 正本（O-5）に反し得るが
     // gate-integrity の管轄は「差異登録なき緩和」— 強化の是非は check:tw-oracle 側。
     if (sevProd < sevCanon) {

--- a/packages/nene2-standards/tests/nene2-check.test.ts
+++ b/packages/nene2-standards/tests/nene2-check.test.ts
@@ -144,6 +144,32 @@ describe('gate-integrity（05 §5.2 #15 — 実効 severity / オプション欠
     }
   }, 60_000);
 
+  it('🔴 偽陽性を出さない: canonical が off のセルは、製品にルールが無くても緩和ではない（#178）', async () => {
+    // canonical は `src/shared/api/client.ts` の no-restricted-globals / no-restricted-imports を
+    // **severity 0（off）**で持つ（canonicalSeverityTable 実測）。製品側にそのルールが「無い」のも
+    // 実効挙動は同じ＝走らない。不在を -1 に落として 0 と比較すると緩和と誤検出する
+    // （origin 素振り実測: `no-restricted-globals: 実効 severity -1 < canonical 0` が red に混ざった）。
+    const productWithoutRule = composedConfig().map((block) => {
+      if (!block.rules) return block;
+      const rules = { ...block.rules };
+      delete rules['no-restricted-globals'];
+      delete rules['no-restricted-imports'];
+      return { ...block, rules };
+    });
+    const result = await checkGateIntegrity({
+      cwd: probeApp,
+      productConfigOverride: productWithoutRule,
+    });
+    // canonical が off の座席（client.ts）については、緩和が1件も出ないこと
+    const offSeatNoise =
+      result.state === 'red'
+        ? result.details.filter(
+            (d) => d.startsWith('src/shared/api/client.ts /') && d.includes('緩和'),
+          )
+        : [];
+    expect(offSeatNoise).toEqual([]);
+  }, 60_000);
+
   it('fail-closed: eslint.config.js 不在 = unknown(not-installed)', async () => {
     const result = await checkGateIntegrity({ cwd: checkApp });
     expect(result.state).toBe('unknown');


### PR DESCRIPTION
## 概要

`gate-integrity` が「canonical で **off（0）** のルールを製品側が**持っていない**」場合を「差異登録なき緩和」として red に数えていた偽陽性を直す（Refs #178）。

## 原因

```ts
const sevCanon = canon.severity ?? -1;
const sevProd  = prod.severity  ?? -1;
if (sevProd < sevCanon) { /* 緩和 */ }
```

ルール**不在**（`severity` が null）を `-1` に落としていたため、canonical が `0`（明示 off）のセルで `-1 < 0` が成立してしまう。だが「canonical で off」＝そのルールは走らない、「製品に不在」＝やはり走らない、で**実効挙動は同一**。緩和とは「canonical が走らせるものを製品が走らせない／弱める」ことなので、走らない同士の比較は差ではない。`null → 0` へ正規化する。

他の象限は挙動不変（canonical 2 × 製品不在 → 0 < 2 で緩和のまま検出／canonical 不在 × 製品 error → 強化なので非報告のまま）。

## 実測

- **origin 素振り**（#178 の初報で発見した現物）: gate-integrity の red 詳細 **13件 → 12件**。消えたのは `src/shared/api/client.ts / no-restricted-globals: 実効 severity -1 < canonical 0` の1件のみで、**他の判定は一切変わっていない**。
- **canonical に severity 0 のセルが実在すること**を確認（`canonicalSeverityTable` 実測 — `src/shared/api/client.ts` の `no-restricted-globals` / `no-restricted-imports`）。この座席が偽陽性の発生源。
- **負の対照**: 修正を stash すると新規テストが落ちる（テストが実際に偽陽性を検出していることの確認）。
- `npm run check` **exit 0**・31ファイル・**439 tests**・AM-2 PASS・`MUST 総数 248` 不変。

## テストについて

`checkGateIntegrity` に **canonical 用の override オプションを足していない**（テストのためだけに API 面を広げないため）。canonical が現に off を持つ座席（`client.ts`）を使い、製品側から当該ルールを外して「その座席に緩和が1件も出ない」ことを固定している。

## なぜ先に直したか

#178（(c) 素振りレーン）の初報で「検査器の偽陽性疑い」として切り分けた1件。**W1 対象6リポすべての素振りに同じノイズが乗る**ため、残り5リポを測る前に潰す価値が高いと判断した（#178 の「次の手」順序案の1番）。

## 凍結との関係

既存検査器の欠陥修正＝bug-fix 相当で凍結対象外（hub 裁定B・#159・#176 と同じ理路）。mustTotal 不変を実測済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
