### PR TITLE
fix(standards): legacy-manifest の size-ratchet を実装 — cap が一度も比較されていなかった（#176）

### DIFF
--- a/packages/nene2-standards/src/checks/cli.ts
+++ b/packages/nene2-standards/src/checks/cli.ts
@@ -156,7 +156,33 @@ async function main(): Promise<number> {
             `  advisory（縮小可）: ${s.rule} @ ${s.file} — frozenCount ${s.frozenCount} → 実測 ${s.liveCount}（registry を下げられる）`,
           );
         }
-        return unclassified + regressions > 0 ? 1 : 0;
+        // legacy-manifest size-ratchet（#176）。**超過は常に表示する**（実在の負債を隠さない）が、
+        // exit code への算入は `--enforce-legacy-size` を付けた艦だけ＝段階的 enforce（hub 裁定 2026-07-30:
+        // 各艦の C5/W3 レーン合流時に enforce へ・未合流艦は warn 表示のみ。一斉赤化は drain 計画と
+        // 無関係な艦を止めるだけ）。表示しないのではなく、止めるかどうかだけを艦の進度に合わせる。
+        const sizeRegressions = report.legacyManifestRegressions;
+        const enforceLegacySize = flags.has('enforce-legacy-size');
+        for (const r of sizeRegressions) {
+          const over: string[] = [];
+          if (r.liveLines > r.capLines) over.push(`行 ${r.capLines} → ${r.liveLines}`);
+          if (r.liveBytes > r.capBytes) over.push(`byte ${r.capBytes} → ${r.liveBytes}`);
+          console.error(
+            `  ${enforceLegacySize ? '回帰' : 'warn（未 enforce）'}: legacy ${r.path} — ` +
+              `${over.join(' / ')}（cap 超過・AM-14 縮小単調違反）`,
+          );
+        }
+        for (const s of report.legacyManifestShrinkable) {
+          console.error(
+            `  advisory（縮小可）: legacy ${s.path} — 行 ${s.capLines} → ${s.liveLines} / ` +
+              `byte ${s.capBytes} → ${s.liveBytes}（registry を下げられる）`,
+          );
+        }
+        console.error(
+          `init --check: legacy size 超過 ${sizeRegressions.length} 件` +
+            `（${enforceLegacySize ? 'enforce — FAIL 条件' : 'warn 表示のみ — --enforce-legacy-size で FAIL 化'}・#176）`,
+        );
+        const sizeFail = enforceLegacySize ? sizeRegressions.length : 0;
+        return unclassified + regressions + sizeFail > 0 ? 1 : 0;
       }
       if (!flags.has('scan')) {
         console.error('init は --scan（生成）か --check（読み取り専用再走査）を指定する');

--- a/packages/nene2-standards/src/checks/init-scan.ts
+++ b/packages/nene2-standards/src/checks/init-scan.ts
@@ -17,6 +17,7 @@ import stylelintPlugins from '../stylelint/plugin.js';
 import { classTokens, layerParamsInclude } from '../stylelint/helpers.js';
 import type {
   ComponentsAllowlistEntry,
+  LegacyManifestEntry,
   LintBaselineEntry,
   RegistriesDocument,
   RegistryEntry,
@@ -212,6 +213,25 @@ export interface InitCheckReport {
   lintBaselineRegressions: LintBaselineDelta[];
   /** baselined (rule,file) で live < frozenCount（縮小＝歓迎・frozenCount を下げられる advisory・非 FAIL）。 */
   lintBaselineShrinkable: LintBaselineDelta[];
+  /**
+   * legacy-manifest の size-ratchet 超過（**回帰**・AM-14 縮小単調違反・#176）。
+   * 登録 cap（maxLines / maxBytes）を実測が超えた分。lint-baseline の count-ratchet と同じ役割を
+   * legacy CSS の量に対して負う。**行数は必ず `formattedLineCount`（pinned prettier 整形後・空行除外）
+   * で測る** — 登録時と同じ尺度でなければ比較が意味を持たない（#176 実測: raw `wc -l` で登録された
+   * cap が混在していた）。
+   */
+  legacyManifestRegressions: LegacyManifestDelta[];
+  /** cap 未満（縮小＝歓迎・cap を下げられる advisory・非 FAIL）。 */
+  legacyManifestShrinkable: LegacyManifestDelta[];
+}
+
+/** legacy-manifest size-ratchet の1件（#176）。cap = 登録凍結値・live = 実測。 */
+export interface LegacyManifestDelta {
+  path: string;
+  capLines: number;
+  liveLines: number;
+  capBytes: number;
+  liveBytes: number;
 }
 
 /** `--check`（読み取り専用再走査）: 台帳との差分を報告する。 */
@@ -264,6 +284,37 @@ export async function initCheck(
     (a, b) => a.rule.localeCompare(b.rule) || a.file.localeCompare(b.file),
   );
 
+  // legacy-manifest size-ratchet（#176）: 登録 cap と実測を突き合わせる。
+  // initScan は各ファイルの maxLines / maxBytes を実測しているが、従来は `.path` だけ取り出して
+  // 集合差分に使い、**測った値を比較せずに捨てていた**（lint-baseline に count-ratchet があるのと
+  // 非対称だった）。deal 実測では cap を 20倍超過しても init --check が緑になっていた。
+  const capByPath = new Map<string, { lines: number; bytes: number }>();
+  for (const e of registries.entries) {
+    if (e.kind !== 'legacy-manifest' || e.repo !== repo) continue;
+    const m = e as LegacyManifestEntry;
+    capByPath.set(m.path, { lines: m.maxLines, bytes: m.maxBytes });
+  }
+  const legacyManifestRegressions: LegacyManifestDelta[] = [];
+  const legacyManifestShrinkable: LegacyManifestDelta[] = [];
+  for (const live of scan.legacyManifest) {
+    const cap = capByPath.get(live.path);
+    if (cap === undefined) continue; // 未登録ファイルは unregisteredLegacyFiles の管轄
+    const delta: LegacyManifestDelta = {
+      path: live.path,
+      capLines: cap.lines,
+      liveLines: live.maxLines,
+      capBytes: cap.bytes,
+      liveBytes: live.maxBytes,
+    };
+    // どちらか一方でも超えたら回帰（行だけ・バイトだけ増える改変を両方とも捕まえる）
+    if (live.maxLines > cap.lines || live.maxBytes > cap.bytes)
+      legacyManifestRegressions.push(delta);
+    else if (live.maxLines < cap.lines || live.maxBytes < cap.bytes)
+      legacyManifestShrinkable.push(delta);
+  }
+  legacyManifestRegressions.sort((a, b) => a.path.localeCompare(b.path));
+  legacyManifestShrinkable.sort((a, b) => a.path.localeCompare(b.path));
+
   return {
     unregisteredClasses: scan.allowedClasses.filter((c) => !registeredClasses.has(c)),
     unregisteredLegacyFiles: scan.legacyManifest
@@ -271,5 +322,7 @@ export async function initCheck(
       .filter((p) => !manifestPaths.has(p)),
     lintBaselineRegressions,
     lintBaselineShrinkable,
+    legacyManifestRegressions,
+    legacyManifestShrinkable,
   };
 }

--- a/packages/nene2-standards/tests/nene2-check.test.ts
+++ b/packages/nene2-standards/tests/nene2-check.test.ts
@@ -2,7 +2,7 @@
  * nene2-check（conformance skeleton）— fail-closed（G-6）・5状態ユニオン・gate-integrity・
  * scan-coverage・init --scan の両方向（green＋故意 fail）検査。
  */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -293,6 +293,95 @@ describe('init --scan（T-3/AM-10 — 走査生成・一度きり・--check 読�
     ]);
     expect(ledgersAlreadyInitialized(withCa, 'nene-x').componentsAllowlist).toBe(true);
     expect(ledgersAlreadyInitialized(EMPTY_REGISTRIES, 'nene-x').componentsAllowlist).toBe(false);
+  });
+
+  // #176 size-ratchet。**陽性対照つき**（hub 受入条件 2026-07-30）: 検査器を足すときは
+  // 「本当に検出できること」を故意 fail で示す。#159→#176 と「登録しても効かない」が2件続いた原因は、
+  // 登録経路のテストはあっても**検出経路の負テストが無かった**こと。
+  describe('legacy-manifest size-ratchet（#176 — cap 超過の検出）', () => {
+    const legacyPath = 'src/legacy-styles.css';
+    const capOf = (maxLines: number, maxBytes: number): ReturnType<typeof registriesWith> =>
+      registriesWith([
+        {
+          kind: 'legacy-manifest',
+          id: 'x-legacy',
+          repo: 'nene-x',
+          path: legacyPath,
+          maxLines,
+          maxBytes,
+        },
+      ]);
+
+    it('🔴 陽性対照: cap を下回る値で登録すると回帰として検出する（従来は緑になっていた）', async () => {
+      const scan = await initScan(initApp);
+      const live = scan.legacyManifest.find((e) => e.path === legacyPath);
+      expect(live).toBeDefined();
+      // 実測より小さい cap＝超過している状態
+      const report = await initCheck(
+        initApp,
+        'nene-x',
+        capOf(live!.maxLines - 1, live!.maxBytes - 1),
+      );
+      expect(report.legacyManifestRegressions).toHaveLength(1);
+      expect(report.legacyManifestRegressions[0]).toMatchObject({
+        path: legacyPath,
+        liveLines: live!.maxLines,
+        liveBytes: live!.maxBytes,
+      });
+    });
+
+    it('行だけ超過・byte だけ超過のどちらも検出する（片側だけ見る実装を許さない）', async () => {
+      const scan = await initScan(initApp);
+      const live = scan.legacyManifest.find((e) => e.path === legacyPath)!;
+      const linesOnly = await initCheck(
+        initApp,
+        'nene-x',
+        capOf(live.maxLines - 1, live.maxBytes + 999),
+      );
+      expect(linesOnly.legacyManifestRegressions).toHaveLength(1);
+      const bytesOnly = await initCheck(
+        initApp,
+        'nene-x',
+        capOf(live.maxLines + 999, live.maxBytes - 1),
+      );
+      expect(bytesOnly.legacyManifestRegressions).toHaveLength(1);
+    });
+
+    it('cap ちょうど = 回帰でない（境界は超過に含めない）', async () => {
+      const scan = await initScan(initApp);
+      const live = scan.legacyManifest.find((e) => e.path === legacyPath)!;
+      const report = await initCheck(initApp, 'nene-x', capOf(live.maxLines, live.maxBytes));
+      expect(report.legacyManifestRegressions).toEqual([]);
+      expect(report.legacyManifestShrinkable).toEqual([]);
+    });
+
+    it('cap を下回っていれば advisory（縮小可）— FAIL ではない', async () => {
+      const scan = await initScan(initApp);
+      const live = scan.legacyManifest.find((e) => e.path === legacyPath)!;
+      const report = await initCheck(
+        initApp,
+        'nene-x',
+        capOf(live.maxLines + 10, live.maxBytes + 10),
+      );
+      expect(report.legacyManifestRegressions).toEqual([]);
+      expect(report.legacyManifestShrinkable).toHaveLength(1);
+    });
+
+    it('未登録ファイルは size-ratchet の対象外（unregisteredLegacyFiles の管轄）', async () => {
+      const report = await initCheck(initApp, 'nene-x', EMPTY_REGISTRIES);
+      expect(report.legacyManifestRegressions).toEqual([]);
+      expect(report.unregisteredLegacyFiles).toEqual([legacyPath]);
+    });
+
+    it('🔴 行数は formattedLineCount で測る（raw wc -l ではない — #176 の単位ズレ）', async () => {
+      const scan = await initScan(initApp);
+      const live = scan.legacyManifest.find((e) => e.path === legacyPath)!;
+      const raw = readFileSync(path.join(initApp, legacyPath), 'utf8');
+      const rawLineCount = raw.split('\n').length;
+      // 実測が raw 行数と一致してしまうと、raw で登録された cap との差が見えなくなる。
+      // 尺度が違うことをテストで固定する（一致する場合はフィクスチャを空行入りに直すこと）。
+      expect(live.maxLines).not.toBe(rawLineCount);
+    });
   });
 
   it('--check は登録済み components-allowlist を差し引いた未分類クラスを報告する（#65 — 全報告でなく差分）', async () => {


### PR DESCRIPTION
## 概要

`legacy-manifest` の `maxLines` / `maxBytes` が**一度も比較されていなかった**欠陥を直す（Refs #176・hub 裁定 2026-07-30 の実施順②）。

`initScan` は各ファイルのサイズを**実測して持っている**のに、`initCheck` が `.path` だけ取り出して集合差分に使い、**測った値を捨てていた**。結果「legacy CSS を増やすな」の ratchet（AM-14 縮小単調）が完全に空振りしていた。`lint-baseline` に (rule,file) count-ratchet が実装されているのと非対称。

## 変更

- `initCheck` に `legacyManifestRegressions` / `legacyManifestShrinkable` を追加。
  - **行・byte のどちらか一方の超過でも回帰**（片側だけ増える改変を捕まえる）。
  - **境界（cap ちょうど）は超過に含めない**。
  - 未登録ファイルは対象外（`unregisteredLegacyFiles` の管轄）。
- 行数は **`formattedLineCount`（pinned prettier 整形後・空行除外）**で測る＝登録時と同じ尺度。
- **段階的 enforce**（hub 裁定）: 超過は**常に表示**するが、exit code への算入は `--enforce-legacy-size` を付けた艦だけ。実在の負債は隠さず、止めるかどうかだけを各艦の C5/W3 レーン合流に合わせる。一斉赤化は drain 計画と無関係な艦を止めるだけ、という裁定に沿う。

## 実測

CLI の両段を実地で確認（cap 10行/100byte・実測 602行/6908byte の fixture）:

```
--- warn 段（既定） ---
  warn（未 enforce）: legacy src/app/design/styles.css — 行 10 → 602 / byte 100 → 6908（cap 超過）
  init --check: legacy size 超過 1 件（warn 表示のみ — --enforce-legacy-size で FAIL 化・#176）
  EXIT=0

--- enforce 段 ---
  回帰: legacy src/app/design/styles.css — 行 10 → 602 / byte 100 → 6908（cap 超過）
  EXIT=1
```

`npm run check` **exit 0**・31ファイル・**444 tests**（+5）・AM-2 PASS・`MUST 総数 248` 不変。

## 負テスト（陽性対照）— hub 受入条件

`#159 → #176` と「**台帳に登録しても効かない**」が2件続いた原因は、登録経路のテストはあっても**検出経路の負テストが無かった**こと。同じ穴を三度作らないため、故意 fail を6本同梱した:

| テスト | 押さえるもの |
|---|---|
| 🔴 陽性対照: cap を下回る値で登録 → 回帰として検出 | **従来は緑になっていた**現象そのもの |
| 行だけ超過 / byte だけ超過の両方 | 片側しか見ない実装を許さない |
| cap ちょうど = 回帰でない | 境界の定義 |
| cap 未満 = advisory（非 FAIL） | 縮小は歓迎 |
| 未登録ファイルは対象外 | 管轄の分離 |
| 🔴 行数は `formattedLineCount`（raw `wc -l` ではない） | **単位ズレ**（下記）の再発防止 |

**実装を外すと新規6件のうち5件が落ちる**ことを確認済み（負の対照）。

## 🔴 続きの作業（本 PR のスコープ外・#176 に記録済み）

①の全艦実測で、**既存 cap の単位が検査器の測定単位と違う**ことが判明している（記録された `maxLines` は raw `wc -l`・検査器は `formattedLineCount`）。本 PR は**検査器を正しい尺度で実装する**ところまでで、**既存 cap の正規化（②'）は別作業**:

- deal の per-repo registries.jsonc の cap 正規化（1008→985 / 1656→1621）＝**deal 手番**（依頼が要る）
- 「cap は `init --scan` 経路のみ・手書き禁止」の条文化（hub 承認済み・**凍結明け**）
- 中央 `fleet.jsonc` の stale 解消（hub 裁定=手書きの二重台帳を禁止・生成物化するか中央から落とすか。fleet 判断・別 PR）

**現時点でフリート全体の cap 超過は 0 件**（①実測）なので、本 PR を入れても既存艦が新たに落ちることはない。

## 凍結との関係

既存検査器の欠陥修正＝bug-fix 相当で凍結対象外（hub 裁定B・#159・#179 と同じ理路）。`MUST 総数 248` 不変を実測済み。条文化を伴う部分は凍結明けに分離した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
