### PR TITLE
chore(standards): 2.2.0 minor bump — #159/#176/#178 の出荷（#186）

### DIFF
--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-standards",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules, A1 hooks→model migration codemod",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## 概要

`@hideyukimori/nene2-standards` **2.1.1 → 2.2.0**（Closes #186）。施主 GO（2026-07-30・hide 本人より fleet セッションで直接受領）に基づく出荷。

## 内容セット（これ以外は積んでいない）

| PR | 内容 | 効果 |
|---|---|---|
| #174 | registries の `scoped-theme` を stylelint 合成で消費（#159） | **deal の C5 theme-migration が解放される**（登録した複合セレクタが効くようになる） |
| #179 | gate-integrity の偽陽性修正（#178） | 「canonical off × 製品にルール不在」の誤検出が消える |
| #180 | legacy-manifest の size-ratchet 実装（#176） | cap の比較が効くようになる＋`--enforce-legacy-size` |

**次の波（2.3.0 候補・本 bump には含めない）**: #181 `init --remeasure` ／ #183 provenance ／ #185 文言修正。飛行中の内容追加は承認の前提を変えるため（hub 裁定）。

## minor 判定

新しい挙動（**登録が効くようになる**・新フラグ）を含み、既存の挙動を壊さない。

## 検証（main 取り込み後）

`npm run check` **exit 0**・31ファイル・**456 tests**・AM-2 gate PASS・`MUST 総数 248` 不変。

## 出荷後の連鎖

publish 完了時に fleet から一報 → deal（theme-migration 解放＋`--enforce-legacy-size` 可用化）／origin・field（ゲート導入 PR 着手）の号令を hub が流す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)