### PR TITLE
fix(standards): root entry が optional peer の stylelint を静的に巻き込む（#189 摩擦1）

### DIFF
--- a/packages/nene2-standards/src/checks/init-scan.ts
+++ b/packages/nene2-standards/src/checks/init-scan.ts
@@ -13,7 +13,6 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
 import baseStylelintConfig from '../stylelint/index.js';
-import stylelintPlugins from '../stylelint/plugin.js';
 import { classTokens, layerParamsInclude } from '../stylelint/helpers.js';
 import type {
   ComponentsAllowlistEntry,
@@ -58,6 +57,10 @@ export async function scanLintBaselines(cwd: string): Promise<InitScanResult['li
   const sources = enumerateStyleSources(cwd).filter((p) => p.endsWith('.css'));
   if (sources.length === 0) return [];
   const stylelint = (await import('stylelint')).default;
+  // plugin.js は `stylelint` を静的 import するので、ここでも遅延読み込みする。
+  // 静的 import にすると root entry（ESLint 用 config）から stylelint へ到達し、
+  // eslint だけ配線する艦で ERR_MODULE_NOT_FOUND になる（#189 摩擦1）。
+  const stylelintPlugins = (await import('../stylelint/plugin.js')).default;
   const runnable = { ...baseStylelintConfig, plugins: stylelintPlugins };
   const { results } = await stylelint.lint({
     files: sources.map((rel) => path.join(cwd, rel)),

--- a/packages/nene2-standards/tests/entry-optional-peer.test.ts
+++ b/packages/nene2-standards/tests/entry-optional-peer.test.ts
@@ -1,0 +1,113 @@
+/**
+ * root entry（`@hideyukimori/nene2-standards` = ESLint flat config の消費口）から
+ * **optional peer へ静的に到達しない**ことの回帰テスト（#189 摩擦1）。
+ *
+ * 事故の形: `checks/init-scan.ts` が `../stylelint/plugin.js` を静的 import しており、
+ * plugin.js は `stylelint` を静的 import する。root entry は checks を re-export するので、
+ * `import nene2 from '@hideyukimori/nene2-standards'` だけで stylelint の解決が要求され、
+ * **eslint だけ配線する艦が ERR_MODULE_NOT_FOUND で config を読めなかった**
+ * （2026-07-30 origin ゲート導入 PR で実踏）。manifest は
+ * `peerDependenciesMeta.stylelint.optional = true` と宣言しているので、
+ * コードが宣言に追いついていなかった＝宣言の側が正。
+ *
+ * 実行時に消費する側（scanLintBaselines）は既に `await import('stylelint')` の遅延形なので、
+ * 遅延は設計意図であり、静的 import がその意図を無効化していた。
+ *
+ * 検査は**静的 import グラフの到達可能性**で行う（`import type` は実行時に消えるので除外）。
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const SRC = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src');
+
+/** package.json で optional 宣言された peer = root entry から静的に到達してはいけない */
+const OPTIONAL_PEERS = ['stylelint'];
+
+/**
+ * `from '...'` の静的 import 元を返す（`import type` / `export type` は実行時に残らないので除外・
+ * `await import(...)` は動的なので拾わない）。
+ */
+function staticImportsOf(file: string): string[] {
+  const source = readFileSync(file, 'utf8');
+  const specs: string[] = [];
+  const re = /(?:^|\n)\s*(?:import|export)\s+([^'"\n;]*?)\s*from\s*['"]([^'"]+)['"]/g;
+  for (const m of source.matchAll(re)) {
+    const clause = m[1] ?? '';
+    const spec = m[2] ?? '';
+    if (/^type\b/.test(clause.trim())) continue; // `import type { X } from` — 実行時に消える
+    specs.push(spec);
+  }
+  return specs;
+}
+
+/** src 内の相対 import を実ファイルへ解決する（`.js` 指定 → `.ts` 実体） */
+function resolveLocal(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith('.')) return null;
+  const abs = path.resolve(path.dirname(fromFile), spec);
+  for (const cand of [abs.replace(/\.js$/, '.ts'), `${abs}.ts`, path.join(abs, 'index.ts')]) {
+    try {
+      readFileSync(cand);
+      return cand;
+    } catch {
+      /* 次の候補へ */
+    }
+  }
+  return null;
+}
+
+/** entry から静的 import だけを辿り、到達した (bare specifier → 経路) を集める */
+function staticReachability(entry: string): Map<string, string[]> {
+  const hits = new Map<string, string[]>();
+  const seen = new Set<string>();
+  const walk = (file: string, trail: string[]): void => {
+    if (seen.has(file)) return;
+    seen.add(file);
+    for (const spec of staticImportsOf(file)) {
+      const local = resolveLocal(file, spec);
+      if (local) {
+        walk(local, [...trail, path.relative(SRC, local)]);
+        continue;
+      }
+      const pkg = spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0];
+      if (pkg && !hits.has(pkg)) hits.set(pkg, [...trail, spec]);
+    }
+  };
+  walk(entry, [path.relative(SRC, entry)]);
+  return hits;
+}
+
+describe('root entry から optional peer への静的到達（#189 摩擦1）', () => {
+  const reachable = staticReachability(path.join(SRC, 'index.ts'));
+
+  it.each(OPTIONAL_PEERS)('root entry は %s を静的 import しない', (peer) => {
+    const trail = reachable.get(peer);
+    expect(
+      trail,
+      trail
+        ? `root entry から ${peer} へ静的到達している: ${trail.join(' → ')}\n` +
+            `${peer} は optional peer なので、消費側（await import）で遅延読み込みすること。`
+        : undefined,
+    ).toBeUndefined();
+  });
+
+  it('検査自体が空振りしていない（陽性対照 = plugin.ts は stylelint へ静的到達する）', () => {
+    // 検査器が「何も見ていないのに green」を返していないことの確認（G-6）。
+    expect(staticReachability(path.join(SRC, 'stylelint', 'plugin.ts')).has('stylelint')).toBe(
+      true,
+    );
+  });
+
+  it('optional peer の一覧が package.json の宣言と一致している', () => {
+    const manifest = JSON.parse(
+      readFileSync(path.join(SRC, '..', 'package.json'), 'utf8'),
+    ) as Record<string, Record<string, { optional?: boolean }>>;
+    const declared = Object.entries(manifest.peerDependenciesMeta ?? {})
+      .filter(([, v]) => v?.optional === true)
+      .map(([k]) => k)
+      .sort();
+    expect(declared).toEqual([...OPTIONAL_PEERS].sort());
+  });
+});


### PR DESCRIPTION
## 何を直したか

**root entry（`@hideyukimori/nene2-standards` = ESLint flat config の消費口）が optional peer の
`stylelint` を静的に巻き込んでいた**ため、eslint だけ配線する艦は
`import nene2 from '@hideyukimori/nene2-standards'` の時点で config を読めなかった。
2026-07-30 の origin ゲート導入で実踏した摩擦1（#189）。

### 経路（実測）

```
dist/index.js
  → (line 22 の re-export) checks/init-scan.js
    → (静的 import) ../stylelint/plugin.js
      → (静的 import) 'stylelint'   ← optional peer なのに必須化
```

`peerDependenciesMeta.stylelint.optional = true` と宣言済みで、実際に stylelint を使う
`scanLintBaselines()` も **既に `await import('stylelint')` の遅延形**だった。
つまり遅延は元からの設計意図であり、`plugin.js` の静的 import 1行だけがそれを無効化していた。
→ 同じ関数内で `await import('../stylelint/plugin.js')` に変更（**宣言と設計意図の側が正**）。

## 実測（before / after）

loader hook で `stylelint` を解決不能にした環境（= 未 install 艦の再現）で root entry を import:

| | 結果 |
|---|---|
| 公開 2.2.0（origin の node_modules 実物） | 🔴 `ERR_MODULE_NOT_FOUND: Cannot find package 'stylelint'` |
| 本ブランチ | 🟢 読み込み OK（`base` 6 blocks・`initScan` export も維持） |

- `npm run check` **exit 0** — 32 files / **459 tests** pass ／ `AM-2 release gate: PASS`〔自分で実測〕
- **API 変更なし**（`initScan` / `initCheck` の署名不変・`scanLintBaselines` は既に async）

## 回帰テスト

`packages/nene2-standards/tests/entry-optional-peer.test.ts` — 静的 import グラフの到達可能性で検査する
（`import type` は実行時に消えるので除外）。3本:

1. root entry から `stylelint` へ静的到達しない（失敗時は経路を全部出す）
2. **陽性対照**: `stylelint/plugin.ts` からは静的到達する ＝ 検査器が空振りで green を返していないことの確認（G-6）
3. 検査対象の optional peer 一覧が `package.json` の宣言と一致（宣言が増えたらテストも追随する）

## 射程外（#189 に残す）

- **摩擦2（jsx-a11y 再定義）**: 真因は「同じパッケージの別の層を登録している」参照不一致だった。
  standards は `flatConfigs.recommended.plugins['jsx-a11y']`（`{meta, rules}`）を、製品は module default
  （`{meta, rules, configs, flatConfigs}`）を登録 → ESLint は**参照が違うときだけ** `Cannot redefine plugin`
  を投げる（同一参照は共存可＝実測）。どちらの層に合わせるかは全艦に効くので **hub 裁定待ち**。
- **摩擦3（@stylistic 180件）**: 配布物は無罪。origin 側 report-only 降格ブロックが `Object.keys()` で
  canonical の **off まで warn に昇格**させていたのが原因（ESLint は off の未定義プラグインを許容・
  severity>0 で config 読み込み拒否＝実測）。修正は導入 PR 側。

詳細な切り分けは #189 のコメントに実測つきで記録した。

Refs #189
