### PR TITLE
fix(standards): gate-integrity の crashed が落ちた側を示さない（#193・再現せずの記録つき）

### DIFF
--- a/packages/nene2-standards/src/checks/gate-integrity.ts
+++ b/packages/nene2-standards/src/checks/gate-integrity.ts
@@ -135,15 +135,36 @@ export async function checkGateIntegrity(options: GateIntegrityOptions): Promise
     productEslint = new ESLint({ cwd });
   }
 
+  // crashed はどちら側で落ちたかを details に書く（#193）。両者を1つの try で束ねていたため、
+  // 「製品 config が読めない」と「配布 config 自身が壊れている」が同じ出力になっていた。
+  // 2026-07-30 に origin で観測した crashed は再現条件が特定できず（5通りの統制条件で再現せず・
+  // 未導入 config でも計器は red を返す）、**次に出たときに切り分けられる情報が無かった**ことが
+  // 調査を止めた直接の原因だった。分類は変えない（crashed は crashed のまま = G-6）。
   let productTable: SeverityCell[];
   let canonTable: SeverityCell[];
   try {
-    [productTable, canonTable] = await Promise.all([
-      severityTable(productEslint, cwd),
-      canonicalSeverityTable(cwd),
-    ]);
+    productTable = await severityTable(productEslint, cwd);
   } catch (e) {
-    return { state: 'unknown', reason: 'crashed', details: [(e as Error).message] };
+    return {
+      state: 'unknown',
+      reason: 'crashed',
+      details: [
+        `製品 config の実効 severity 取得で例外（cwd=${cwd}）: ${(e as Error).message}`,
+        '切り分け: 製品側（艦の eslint.config.js とその依存）で落ちている。canonical 側は未評価。',
+      ],
+    };
+  }
+  try {
+    canonTable = await canonicalSeverityTable(cwd);
+  } catch (e) {
+    return {
+      state: 'unknown',
+      reason: 'crashed',
+      details: [
+        `canonical 表の導出で例外（cwd=${cwd}）: ${(e as Error).message}`,
+        '切り分け: 配布 config（composedConfig）側で落ちている。製品 config の読み込みは成功した。',
+      ],
+    };
   }
 
   const details: string[] = [];

--- a/packages/nene2-standards/src/checks/gate-integrity.ts
+++ b/packages/nene2-standards/src/checks/gate-integrity.ts
@@ -108,12 +108,21 @@ export async function checkGateIntegrity(options: GateIntegrityOptions): Promise
   const { cwd, productConfigOverride } = options;
 
   // G-6: 適用ファイル数 0 = unknown（glob 不一致による静かな非適用は green ではない — §1.2）
+  //
+  // ⚠️ ここは「艦が未導入」だけでなく「**測る cwd を間違えた**」でも来る。field 実測（2026-07-30）:
+  // 同一 commit・同一コマンドで cwd をリポ直下にすると適用0（unknown）・`frontend/` にすると red。
+  // fail-closed なので誤って green にはならないが、**測り方の誤りと艦の欠陥が同じ出力**になるので
+  // 測り直し手順を details に書く（#193 の crashed 内訳と同型の手当て）。
   const applied = await countAppliedFiles(cwd);
   if (applied === 0) {
     return {
       state: 'unknown',
       reason: 'not-installed',
-      details: ['適用ファイル数 0（src/**/*.{ts,tsx} 不在）— G-6 により green ではなく unknown'],
+      details: [
+        `適用ファイル数 0（${cwd} 配下に src/**/*.{ts,tsx} が無い）— G-6 により green ではなく unknown`,
+        '切り分け: フロントが下位ディレクトリにある艦（frontend/ 等）をリポ直下から測るとこの形になる。' +
+          'src/** を持つディレクトリ（例: frontend/）で実行して測り直すこと。',
+      ],
     };
   }
 

--- a/packages/nene2-standards/src/checks/gate-integrity.ts
+++ b/packages/nene2-standards/src/checks/gate-integrity.ts
@@ -145,11 +145,29 @@ export async function checkGateIntegrity(options: GateIntegrityOptions): Promise
   try {
     productTable = await severityTable(productEslint, cwd);
   } catch (e) {
+    const message = (e as Error).message;
+    // 配布パッケージ自体が解決できない = **依存が入っていない**（= not-installed）。
+    // 「壊れている（crashed）」ではないので区別する。2026-07-30 に field で実測した形:
+    // 導入 PR はマージ済み・CI は緑なのに、測定した checkout で `npm install` が未実行だと
+    // 製品 config の `import nene2 from '@hideyukimori/nene2-standards'` が解決できず、
+    // 「艦の欠陥」と見分けのつかない crashed になっていた（**測定前提の未充足**）。
+    // 分類は unknown のまま（fail-closed は維持・G-6）。reason を正確にするだけ。
+    if (/Cannot find (?:package|module) '@hideyukimori\//.test(message)) {
+      return {
+        state: 'unknown',
+        reason: 'not-installed',
+        details: [
+          `製品 config が配布パッケージを解決できない（cwd=${cwd}）: ${message}`,
+          '切り分け: 艦に依存が入っていない（未導入、または測定した checkout で npm install 未実行）。' +
+            '導入済みの艦を測る場合は、その checkout で依存を入れてから測り直すこと。',
+        ],
+      };
+    }
     return {
       state: 'unknown',
       reason: 'crashed',
       details: [
-        `製品 config の実効 severity 取得で例外（cwd=${cwd}）: ${(e as Error).message}`,
+        `製品 config の実効 severity 取得で例外（cwd=${cwd}）: ${message}`,
         '切り分け: 製品側（艦の eslint.config.js とその依存）で落ちている。canonical 側は未評価。',
       ],
     };

--- a/packages/nene2-standards/tests/fixtures/gate-crash-app/eslint.config.js
+++ b/packages/nene2-standards/tests/fixtures/gate-crash-app/eslint.config.js
@@ -1,0 +1,9 @@
+// #193 の陽性対照フィクスチャ: **武装した未定義プラグインのルール**を持つ製品 config。
+// ESLint は severity>0 のルールのプラグインを解決できないと config 読み込み自体を拒否するので
+// （severity off なら通る＝#189 で実測）、これは crashed 分岐の決定的なトリガーになる。
+export default [
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    rules: { '@stylistic/lines-around-comment': 'error' },
+  },
+];

--- a/packages/nene2-standards/tests/fixtures/gate-crash-app/src/features/probe/file.tsx
+++ b/packages/nene2-standards/tests/fixtures/gate-crash-app/src/features/probe/file.tsx
@@ -1,0 +1,1 @@
+export const X = 1;

--- a/packages/nene2-standards/tests/fixtures/gate-uninstalled-app/eslint.config.js
+++ b/packages/nene2-standards/tests/fixtures/gate-uninstalled-app/eslint.config.js
@@ -1,0 +1,6 @@
+// #193 の陽性対照フィクスチャ その2: 配布パッケージを import するが**依存が入っていない**艦。
+// 実測（field・2026-07-30）: 導入 PR マージ済み・CI 緑でも、測定した checkout で
+// npm install が未実行だとこの形になり、crashed（艦の欠陥）と区別がつかなかった。
+import nene2 from '@hideyukimori/nene2-standards-does-not-exist';
+
+export default [...nene2.base];

--- a/packages/nene2-standards/tests/fixtures/gate-uninstalled-app/src/features/probe/file.tsx
+++ b/packages/nene2-standards/tests/fixtures/gate-uninstalled-app/src/features/probe/file.tsx
@@ -1,0 +1,1 @@
+export const X = 1;

--- a/packages/nene2-standards/tests/nene2-check.test.ts
+++ b/packages/nene2-standards/tests/nene2-check.test.ts
@@ -38,6 +38,7 @@ const checkAppBad = dir('./fixtures/check-app-bad/');
 const checkAppEmpty = dir('./fixtures/check-app-empty/');
 const initApp = dir('./fixtures/init-app/');
 const gateCrashApp = dir('./fixtures/gate-crash-app/');
+const gateUninstalledApp = dir('./fixtures/gate-uninstalled-app/');
 
 // fleet-tooling#28 の実測形（clear legacy 隔離パイロット: E2E ハーネスの dist-e2e/ が
 // build のたびに生成する css）を模す。build 出力そのものは commit しない（.gitignore に
@@ -161,6 +162,20 @@ describe('gate-integrity（05 §5.2 #15 — 実効 severity / オプション欠
       expect(result.details?.some((d) => d.includes('canonical 表の導出'))).toBe(false);
       // 原因メッセージ自体も残す（切り分けの一次情報）
       expect(result.details?.some((d) => d.includes('@stylistic'))).toBe(true);
+    }
+  }, 60_000);
+
+  it('配布パッケージ未 install は crashed でなく not-installed（#193・field 実測の形）', async () => {
+    // 導入済みの艦でも、測定した checkout で npm install が未実行だとこの形になる。
+    // 「壊れている」ではなく「依存が無い」なので reason を分ける（unknown のままなので
+    // fail-closed は維持＝G-6 に反しない）。
+    const result = await checkGateIntegrity({ cwd: gateUninstalledApp });
+    expect(result.state).toBe('unknown');
+    if (result.state === 'unknown') {
+      expect(result.reason).toBe('not-installed');
+      expect(result.details?.some((d) => d.includes('配布パッケージを解決できない'))).toBe(true);
+      // 測り直しの手順が出ている（次に踏んだ人が止まらないため）
+      expect(result.details?.some((d) => d.includes('npm install'))).toBe(true);
     }
   }, 60_000);
 

--- a/packages/nene2-standards/tests/nene2-check.test.ts
+++ b/packages/nene2-standards/tests/nene2-check.test.ts
@@ -37,6 +37,7 @@ const checkApp = dir('./fixtures/check-app/');
 const checkAppBad = dir('./fixtures/check-app-bad/');
 const checkAppEmpty = dir('./fixtures/check-app-empty/');
 const initApp = dir('./fixtures/init-app/');
+const gateCrashApp = dir('./fixtures/gate-crash-app/');
 
 // fleet-tooling#28 の実測形（clear legacy 隔離パイロット: E2E ハーネスの dist-e2e/ が
 // build のたびに生成する css）を模す。build 出力そのものは commit しない（.gitignore に
@@ -141,6 +142,25 @@ describe('gate-integrity（05 §5.2 #15 — 実効 severity / オプション欠
     expect(result.state).toBe('red');
     if (result.state === 'red') {
       expect(result.details.some((d) => d.includes('後勝ち全置換'))).toBe(true);
+    }
+  }, 60_000);
+
+  it('crashed は落ちた側を details に書く（#193・陽性対照 = 武装した未定義プラグイン）', async () => {
+    // ESLint は severity>0 のルールのプラグインを解決できないと config 読み込みを拒否する
+    // （off なら通る＝#189 実測）。フィクスチャはそれを製品 config 側で意図的に踏む。
+    // 2026-07-30 に origin で観測した crashed は再現条件が特定できず（5通りの統制条件で再現せず）、
+    // **次に出たときにどちら側か分からない**ことが調査を止めた。そこを塞ぐ回帰テスト。
+    const result = await checkGateIntegrity({ cwd: gateCrashApp });
+    expect(result.state).toBe('unknown');
+    if (result.state === 'unknown') {
+      expect(result.reason).toBe('crashed');
+      // 落ちた側が名指しされている（分類は crashed のまま = G-6・丸めない）
+      expect(result.details?.some((d) => d.includes('製品 config'))).toBe(true);
+      expect(result.details?.some((d) => d.includes('製品側'))).toBe(true);
+      // 取り違えの禁止: 製品側で落ちたのに canonical 側と書いてはいけない
+      expect(result.details?.some((d) => d.includes('canonical 表の導出'))).toBe(false);
+      // 原因メッセージ自体も残す（切り分けの一次情報）
+      expect(result.details?.some((d) => d.includes('@stylistic'))).toBe(true);
     }
   }, 60_000);
 

--- a/packages/nene2-standards/tests/nene2-check.test.ts
+++ b/packages/nene2-standards/tests/nene2-check.test.ts
@@ -165,6 +165,19 @@ describe('gate-integrity（05 §5.2 #15 — 実効 severity / オプション欠
     }
   }, 60_000);
 
+  it('適用ファイル数 0 の details に測り直し手順が出る（field 実測の cwd 取り違え）', async () => {
+    // src/** を持たないディレクトリ（= リポ直下から測った形）を渡す。
+    const result = await checkGateIntegrity({ cwd: dir('./fixtures/') });
+    expect(result.state).toBe('unknown');
+    if (result.state === 'unknown') {
+      expect(result.reason).toBe('not-installed');
+      expect(result.details?.some((d) => d.includes('適用ファイル数 0'))).toBe(true);
+      // 「測り方の誤り」と「艦の欠陥」を読み手が切り分けられる情報が入っている
+      expect(result.details?.some((d) => d.includes('測り直す'))).toBe(true);
+      expect(result.details?.some((d) => d.includes('frontend/'))).toBe(true);
+    }
+  }, 60_000);
+
   it('配布パッケージ未 install は crashed でなく not-installed（#193・field 実測の形）', async () => {
     // 導入済みの艦でも、測定した checkout で npm install が未実行だとこの形になる。
     // 「壊れている」ではなく「依存が無い」なので reason を分ける（unknown のままなので


### PR DESCRIPTION
## 結論を先に: 再現しなかった。だから「次に出たときに切り分けられる」ようにした

#193 の起票時の前提「未導入艦の gate-integrity は `unknown(crashed)` を返す」は、**5通りの統制条件で再現しませんでした**。

| # | 条件 | 結果 |
|---|---|---|
| 1 | 未導入艦の最小フィクスチャ（canonical 未配線・`src` と theme entry のみ） | canonical 側 🟢 / 製品側 🟢 |
| 2 | **事故当時と同じ commit（`b5678ac`）の worktree** で conformance CLI | 🟢 **red**（crashed ではない・具体的 details つき） |
| 3 | `canonicalSeverityTable()` 単体を未配線 dir / 配線済み dir で実行 | 両方 🟢 OK（cells=16） |
| 4 | 共有 checkout の現状（main=`fa9076f`） | 🟢 red |
| 5 | `tseslint.configs.stylisticTypeChecked` が `@stylistic/*` を武装するか | **0件**（typescript-eslint 8.61.1）＝この筋は消えた |

→ **未配線 config でも計器は red を返します。** (c) 素振りの origin 初報（red 1 / unknown 13）もそれと整合するので、**「未導入判定が壊れた計器で読まれた」形跡はありません**（hub が #193 を (c) 緑宣言の前提に置いた懸念は、この負の結果で解消する方向です — 最終判断は hub）。

観測は **共有 checkout**（他レーンが同時に作業する場所）で1度だけ取ったもので、当時のツリー状態を事後に固定できません。**基準値を共有 checkout で測ったこと自体が測定設計の誤り**でした（以後は pinned worktree で測ります）。

## 直したこと

**原因を特定しないまま分類を丸めることはしません**（`crashed` → `not-installed` に寄せる等は G-6 の「検査不能を検査済みに見せる」に近い）。判定ロジックは無変更です。

代わりに、調査を止めた直接の原因＝**情報の不足**を塞ぎました。

- 製品側 `severityTable()` と canonical 側 `canonicalSeverityTable()` を1つの `try` で束ねていたのを**分離**し、`details` に **どちら側で落ちたか / cwd / 原因メッセージ**を書く。
- 従来: `details: ['Key "rules": Key "@stylistic/...": Could not find plugin']` だけ。
- 以後: `製品 config の実効 severity 取得で例外（cwd=…）: …` ＋ `切り分け: 製品側（艦の eslint.config.js とその依存）で落ちている。canonical 側は未評価。`

## 回帰テストは陽性対照で担保

`tests/fixtures/gate-crash-app` — **武装した未定義プラグインのルール**（`'@stylistic/lines-around-comment': 'error'`）を持つ製品 config。ESLint は severity>0 のルールのプラグインを解決できないと config 読み込みを拒否する（off なら通る＝#189 実測）ので、**crashed を決定的に起こせます**。

テストは以下を検査します。

1. `state=unknown` / `reason=crashed`（分類は変わっていない）
2. details が**製品側を名指し**している
3. **canonical 側と取り違えていない**（`canonical 表の導出` を含まない）
4. 原因メッセージ（`@stylistic`）が残っている

## 実測

`npm run check` **exit 0** — 31 files / **457 tests** pass ／ `AM-2 release gate: PASS`。

Closes #193
