### PR TITLE
feat(standards): reportOnly — ゲート導入段の降格を配布側で持つ（#189・生成器同梱）

### DIFF
--- a/packages/nene2-standards/src/configs/report-only.ts
+++ b/packages/nene2-standards/src/configs/report-only.ts
@@ -1,0 +1,203 @@
+/**
+ * `reportOnly` — ゲート導入段（report-only）の降格ブロックを配布側で持つ（#189・hub 裁定 2026-07-30）。
+ *
+ * ## なぜ配布側に置くか
+ *
+ * 2026-07-30 の origin / field 導入で、各艦が同じ降格コードを書いた結果 **3つの事故形**が出た:
+ *
+ * 1. `Object.keys(canonical).map(r => [r, 'warn'])` — severity を捨てるため、canonical が
+ *    **意図的に off にしている 386件**（eslint-config-prettier 由来の衝突回避セット）まで武装し、
+ *    未定義プラグインの解決が要求されて **config 読み込み自体が落ちる**。
+ *    武装側で解こうとすると 12 名前空間（`@stylistic` / `vue` / `flowtype` …）の install が必要で
+ *    構造的に不可能（field 実測）。→ **off のルールは降格対象から外す**。
+ * 2. runtime 導出（現在の canonical から毎回作る）は、**canonical が将来追加するルールまで黙って
+ *    off に吸収する**。導入段の台帳は「今ある負債」を凍結するものなので、追加分は素通しにせず
+ *    差分としてレビューに出したい。→ **既定は凍結台帳（呼び出し側が rule id を渡す）**。
+ * 3. `warn` へ落とせば CI が緑になるとは限らない。**両艦とも `eslint . --max-warnings 0`** で、
+ *    warn は赤だった。→ **既定 severity は `off`**（負債は conformance / gate-integrity の red と
+ *    週次 rollup 側で見える。lint を緑に保つことと負債を隠すことは別）。
+ *
+ * ## 使い方（艦側）
+ *
+ * ```js
+ * import nene2 from '@hideyukimori/nene2-standards';
+ * import { canonicalOff } from './eslint.canonical-off.js'; // 生成物（下記の生成器で作る）
+ *
+ * export default tseslint.config(
+ *   { ignores: [...] },
+ *   // canonical は**艦自前ブロックより前**に置く（後勝ちで艦の既存ゲートを守る — §摩擦6）
+ *   ...nene2.base, ...nene2.fsd, ...nene2.api, ...nene2.stylingWith(),
+ *   nene2.reportOnly({ ruleIds: canonicalOff }),
+ *   ...艦自前のブロック,
+ *   nene2.toolingExemption(), // どの tsconfig にも属さない JS ツーリング（§摩擦5）
+ * );
+ * ```
+ *
+ * 台帳の生成は `renderReportOnlyLedger()` を使う（手書き列挙 MUST NOT — AM-10/G-7 と同旨）。
+ */
+import type { Linter } from 'eslint';
+
+import { api } from './api.js';
+import { base } from './base.js';
+import { fsd } from './fsd.js';
+import { styling, stylingWith } from './styling.js';
+
+/** 導入段で降格に使う severity。`off` 既定 = 艦の `--max-warnings 0` を壊さない。 */
+export type ReportOnlySeverity = 'off' | 'warn';
+
+export interface ReportOnlyOptions {
+  /**
+   * 降格対象のルール id（**凍結台帳**）。`renderReportOnlyLedger()` の生成物を渡す。
+   * ここに無いルールは降格されない ＝ canonical が後から追加したものは
+   * canonical の severity で発火し、差分としてレビューに出る（意図した挙動）。
+   */
+  ruleIds: readonly string[];
+  /** 既定 `'off'`。`'warn'` は「warning を許容する CI」の艦だけが選ぶ。 */
+  severity?: ReportOnlySeverity;
+  /** 既定は全ファイル（`files` を付けない）。座席を絞る艦だけが渡す。 */
+  files?: string[];
+  /** config オブジェクト名。既定 `'nene2/report-only'`。 */
+  name?: string;
+}
+
+export interface CanonicalAxesOptions {
+  /** `stylingWith()` に渡す Tailwind エントリ（艦の実配置）。 */
+  entryPoint?: string;
+}
+
+const severityOf = (entry: Linter.RuleEntry | undefined): unknown =>
+  Array.isArray(entry) ? entry[0] : entry;
+
+const isOff = (entry: Linter.RuleEntry | undefined): boolean => {
+  const s = severityOf(entry);
+  return s === 0 || s === 'off';
+};
+
+/**
+ * 導入段で展開する4軸（i18n / testing は導入段では展開しない — #189 摩擦2）。
+ *
+ * `entryPoint` 未指定なら **`styling`（正準エントリで組んだ静的版）**を使う。`stylingWith()` は
+ * エントリの実在を cwd 基準で確認して fail-loud に throw するので、台帳生成やルール id の
+ * 問い合わせ（＝艦の cwd で走るとは限らない）で呼ぶと、艦の配置と無関係に落ちる。
+ * `composedConfig()` が `styling` を使っているのと同じ理由。
+ */
+function introductionAxes(options: CanonicalAxesOptions = {}): Linter.Config[] {
+  const stylingAxis = options.entryPoint
+    ? stylingWith({ entryPoint: options.entryPoint })
+    : styling;
+  return [...base, ...fsd, ...api, ...stylingAxis];
+}
+
+/**
+ * canonical が **武装している**（severity > 0）ルール id を返す。
+ * off のものは含めない（含めると降格で武装してしまい config が落ちる — 事故形1）。
+ */
+export function canonicalRuleIds(options: CanonicalAxesOptions = {}): string[] {
+  const merged: Record<string, Linter.RuleEntry> = {};
+  for (const block of introductionAxes(options)) Object.assign(merged, block.rules ?? {});
+  return Object.entries(merged)
+    .filter(([, entry]) => !isOff(entry))
+    .map(([id]) => id)
+    .sort();
+}
+
+/**
+ * 凍結台帳が canonical に追随できていない差分を返す（台帳に無い = 降格されず発火する）。
+ * 艦の CI / conformance が「台帳が stale」を機械的に言えるようにするための問い合わせ口。
+ */
+export function reportOnlyStaleRules(
+  ruleIds: readonly string[],
+  options: CanonicalAxesOptions = {},
+): string[] {
+  const frozen = new Set(ruleIds);
+  return canonicalRuleIds(options).filter((id) => !frozen.has(id));
+}
+
+/**
+ * 降格ブロックを返す。渡された rule id を一律 `severity` にする。
+ *
+ * **canonical の off を武装させない**ため、ここでは渡された id をそのまま使う
+ * （`canonicalRuleIds()` が既に off を除いている）。台帳を手書きした艦が off のルールを
+ * 混ぜてきた場合も `'off'` 既定なら無害で、`'warn'` 指定時のみ危険なので fail-loud にする。
+ */
+export function reportOnly(options: ReportOnlyOptions): Linter.Config {
+  const { ruleIds, severity = 'off', files, name = 'nene2/report-only' } = options;
+
+  if (severity === 'warn') {
+    // canonical が off にしているルールを warn に上げると、未定義プラグインの解決が要求されて
+    // config 読み込みが落ちる（#189 摩擦3 の事故形そのもの）。静かに通さず、ここで止める。
+    const canonOff = new Set(
+      introductionAxes()
+        .flatMap((b) => Object.entries(b.rules ?? {}))
+        .filter(([, entry]) => isOff(entry))
+        .map(([id]) => id),
+    );
+    const armed = ruleIds.filter((id) => canonOff.has(id));
+    if (armed.length > 0) {
+      throw new Error(
+        `[nene2/reportOnly] canonical が off にしているルールを 'warn' で武装させようとしている（${armed.length}件）: ` +
+          `${armed.slice(0, 5).join(', ')}${armed.length > 5 ? ' …' : ''}\n` +
+          'これらは eslint-config-prettier 由来の衝突回避セットで、武装するとプラグイン解決が' +
+          '要求され config 読み込みが落ちる（#189 摩擦3）。台帳は renderReportOnlyLedger() で生成すること。',
+      );
+    }
+  }
+
+  const rules = Object.fromEntries(ruleIds.map((id) => [id, severity])) as Linter.RulesRecord;
+  return files ? { name, files, rules } : { name, rules };
+}
+
+/**
+ * どの TS プログラムにも属さないツーリングファイルの除外ブロック（#189 摩擦5）。
+ *
+ * canonical は `parserOptions.projectService: true` を全ファイルに宣言するので、
+ * `allowJs` の無い艦では `.js` / `.mjs` / `.cjs` が
+ * `Parsing error: ... was not found by the project service` になる。
+ * **パースエラーは severity 降格の対象外**なので report-only では緑にできない。
+ *
+ * ⚠️ 艦が既に同等の除外（`ignores` や `disableTypeChecked` ブロック）を **canonical より後ろに**
+ * 持っているなら不要（origin は既に持っていたので追加作業 0 だった）。
+ */
+export function toolingExemption(options: { files?: string[]; name?: string } = {}): Linter.Config {
+  const {
+    files = ['**/*.js', '**/*.mjs', '**/*.cjs', 'eslint.config.js'],
+    name = 'nene2/tooling-exemption',
+  } = options;
+  return { name, files, languageOptions: { parserOptions: { projectService: false } } };
+}
+
+/**
+ * 凍結台帳ファイルの中身を生成する（**生成器を配布側に持つ** — 各艦が写経しないため）。
+ *
+ * 艦側は3行のスクリプトで足りる:
+ * ```js
+ * import { renderReportOnlyLedger } from '@hideyukimori/nene2-standards';
+ * import { writeFileSync } from 'node:fs';
+ * writeFileSync('eslint.canonical-off.js', renderReportOnlyLedger({ entryPoint: 'src/index.css' }));
+ * ```
+ */
+export function renderReportOnlyLedger(
+  options: CanonicalAxesOptions & { standardsVersion?: string; exportName?: string } = {},
+): string {
+  const { standardsVersion, exportName = 'canonicalOff' } = options;
+  const ids = canonicalRuleIds(options);
+  const isBareKey = (id: string): boolean => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(id);
+  const body = ids.map((id) => `  ${isBareKey(id) ? id : `'${id}'`},`).join('\n');
+  return [
+    '// 自動生成物 — 手で編集しない（再生成: 艦の生成スクリプト）。',
+    '//',
+    '// nene2-standards の canonical が **武装している**ルール id の凍結台帳。',
+    '// ゲート導入段（report-only）で nene2.reportOnly({ ruleIds }) に渡す。',
+    '//',
+    '// canonical が後から追加したルールはこの台帳に無いので降格されず、canonical の severity で',
+    '// 発火する ＝ 新しい負債が黙って吸収されない（差分としてレビューに出る）。追随するときは',
+    '// 再生成し、増えた行を意図的にレビューすること。',
+    standardsVersion ? `//\n// 生成時の @hideyukimori/nene2-standards: ${standardsVersion}` : '//',
+    `// ルール数: ${ids.length}`,
+    '',
+    `export const ${exportName} = [`,
+    body,
+    '];',
+    '',
+  ].join('\n');
+}

--- a/packages/nene2-standards/src/index.ts
+++ b/packages/nene2-standards/src/index.ts
@@ -13,6 +13,13 @@
  */
 import type { Linter } from 'eslint';
 
+import {
+  canonicalRuleIds,
+  renderReportOnlyLedger,
+  reportOnly,
+  reportOnlyStaleRules,
+  toolingExemption,
+} from './configs/report-only.js';
 import { api } from './configs/api.js';
 import { base } from './configs/base.js';
 import { fsd } from './configs/fsd.js';
@@ -50,11 +57,39 @@ export type {
 } from './registries/schema.js';
 
 /** 全断片の正準合成（gate-integrity の canonical 表・パッケージテストの検出プローブが使用）。 */
+export {
+  canonicalRuleIds,
+  renderReportOnlyLedger,
+  reportOnly,
+  reportOnlyStaleRules,
+  toolingExemption,
+} from './configs/report-only.js';
+export type {
+  CanonicalAxesOptions,
+  ReportOnlyOptions,
+  ReportOnlySeverity,
+} from './configs/report-only.js';
+
 export function composedConfig(): Linter.Config[] {
   return [...base, ...fsd, ...api, ...styling, ...i18n, ...testing];
 }
 
-const nene2 = { base, fsd, api, styling, stylingWith, i18n, testing, overrides };
+const nene2 = {
+  base,
+  fsd,
+  api,
+  styling,
+  stylingWith,
+  i18n,
+  testing,
+  overrides,
+  // ゲート導入段（report-only）の配布ヘルパ（#189・hub 裁定 2026-07-30）
+  reportOnly,
+  toolingExemption,
+  canonicalRuleIds,
+  reportOnlyStaleRules,
+  renderReportOnlyLedger,
+};
 export default nene2;
 
 export {

--- a/packages/nene2-standards/tests/report-only.test.ts
+++ b/packages/nene2-standards/tests/report-only.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `reportOnly` ヘルパのテスト（#189・hub 裁定 2026-07-30）。
+ *
+ * 中心は**事故形の再発防止**。2026-07-30 の origin / field 導入で出た3形を、それぞれ
+ * 陽性対照つきで固定する:
+ *
+ * 1. canonical が off にしているルールを武装させると config 読み込みが落ちる → `'warn'` 指定で
+ *    台帳に off が混ざっていたら **fail-loud**（静かに壊れた config を出荷しない）。
+ * 2. runtime 導出は canonical の将来追加を黙って吸収する → 台帳は凍結し、追随漏れを
+ *    `reportOnlyStaleRules()` が言える。
+ * 3. `off` 形の降格が実際に効く（ESLint の実効 severity で確認 — 生成物を信じない）。
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ESLint, type Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+import {
+  canonicalRuleIds,
+  renderReportOnlyLedger,
+  reportOnly,
+  reportOnlyStaleRules,
+  toolingExemption,
+} from '../src/configs/report-only.js';
+import { composedConfig } from '../src/index.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const probeApp = path.join(here, 'fixtures', 'probe-app');
+
+/** canonical が off にしている代表例（eslint-config-prettier 由来・#189 実測） */
+const KNOWN_CANONICAL_OFF = '@stylistic/lines-around-comment';
+
+const severityOf = (entry: Linter.RuleEntry | undefined): unknown =>
+  Array.isArray(entry) ? entry[0] : entry;
+
+describe('canonicalRuleIds — 台帳の中身は「武装しているルール」だけ', () => {
+  it('off のルールを含めない（含めると warn 形で config が落ちる）', () => {
+    const ids = canonicalRuleIds();
+    expect(ids.length).toBeGreaterThan(0);
+    expect(ids).not.toContain(KNOWN_CANONICAL_OFF);
+  });
+
+  it('canonical の実装から導出している（手書き二重管理でない）', () => {
+    // composedConfig 側で武装しているルールは、i18n / testing 軸を除けば台帳に載る。
+    const armedInAxes = new Set(canonicalRuleIds());
+    expect(armedInAxes.has('no-restricted-syntax')).toBe(true);
+    expect(armedInAxes.has('no-restricted-imports')).toBe(true);
+  });
+
+  it('ソート済み・重複なし（差分レビューを安定させるため）', () => {
+    const ids = canonicalRuleIds();
+    expect([...ids].sort()).toEqual(ids);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('reportOnly — 降格ブロック', () => {
+  it('既定は off（艦の --max-warnings 0 を壊さない）', () => {
+    const block = reportOnly({ ruleIds: ['no-restricted-syntax'] });
+    expect(block.rules?.['no-restricted-syntax']).toBe('off');
+    expect(block.name).toBe('nene2/report-only');
+    expect(block.files).toBeUndefined();
+  });
+
+  it('warn も選べる（warning を許容する CI の艦だけ）', () => {
+    const block = reportOnly({ ruleIds: ['no-restricted-syntax'], severity: 'warn' });
+    expect(block.rules?.['no-restricted-syntax']).toBe('warn');
+  });
+
+  it('🔴 陽性対照: warn 形で canonical の off を武装させようとしたら throw（#189 摩擦3）', () => {
+    expect(() => reportOnly({ ruleIds: [KNOWN_CANONICAL_OFF], severity: 'warn' })).toThrowError(
+      /off にしているルールを 'warn' で武装/,
+    );
+  });
+
+  it('off 形なら off の混入は無害なので通す（実害が無いものを止めない）', () => {
+    const block = reportOnly({ ruleIds: [KNOWN_CANONICAL_OFF] });
+    expect(block.rules?.[KNOWN_CANONICAL_OFF]).toBe('off');
+  });
+
+  it('files を渡したときだけ座席が絞られる', () => {
+    const block = reportOnly({ ruleIds: ['no-restricted-syntax'], files: ['src/**/*.ts'] });
+    expect(block.files).toEqual(['src/**/*.ts']);
+  });
+});
+
+describe('reportOnlyStaleRules — 凍結台帳の追随漏れ', () => {
+  it('台帳に無い武装ルールを返す（canonical が後から増やした形）', () => {
+    const full = canonicalRuleIds();
+    const stale = reportOnlyStaleRules(full.slice(1));
+    expect(stale).toEqual([full[0]]);
+  });
+
+  it('追随できていれば空（空振りでないことは上のケースが担保）', () => {
+    expect(reportOnlyStaleRules(canonicalRuleIds())).toEqual([]);
+  });
+});
+
+describe('renderReportOnlyLedger — 生成器を配布側に持つ', () => {
+  it('件数注記が実際の件数と一致し、id は必要なときだけクォートされる', () => {
+    const out = renderReportOnlyLedger();
+    const ids = canonicalRuleIds();
+    expect(out).toContain(`// ルール数: ${ids.length}`);
+    expect(out).toContain('export const canonicalOff = [');
+    expect(out).toContain(`  'no-restricted-syntax',`);
+  });
+
+  it('生成物は実際に評価できる JS（生成できたことを動くことの証拠にしない）', async () => {
+    const src = renderReportOnlyLedger({ standardsVersion: '0.0.0-test' });
+    const mod = (await import(
+      `data:text/javascript;base64,${Buffer.from(src, 'utf8').toString('base64')}`
+    )) as { canonicalOff: string[] };
+    expect(mod.canonicalOff).toEqual(canonicalRuleIds());
+    expect(src).toContain('0.0.0-test');
+  });
+});
+
+describe('toolingExemption — 型付きプログラム外ファイル（#189 摩擦5）', () => {
+  it('projectService を切る（パースエラーは severity 降格で消せない）', () => {
+    const block = toolingExemption();
+    expect(block.languageOptions?.parserOptions?.projectService).toBe(false);
+    expect(block.files).toContain('**/*.mjs'); // `**/*.js` は .mjs を捕まえない（origin/field 実測）
+  });
+});
+
+describe('統合: 降格が ESLint の実効値として効く（生成物を信じない）', () => {
+  it('canonical + reportOnly(off) で canonical のルールが実効 off になる', async () => {
+    const config: Linter.Config[] = [
+      ...composedConfig(),
+      reportOnly({ ruleIds: canonicalRuleIds() }),
+    ];
+    const eslint = new ESLint({ cwd: probeApp, overrideConfigFile: true, overrideConfig: config });
+    const effective = (await eslint.calculateConfigForFile(
+      path.join(probeApp, 'src/features/probe/file.tsx'),
+    )) as { rules?: Record<string, Linter.RuleEntry> };
+    expect(severityOf(effective.rules?.['no-restricted-syntax'])).toBe(0);
+  }, 60_000);
+
+  it('🔴 陽性対照: 降格ブロックを外すと同じルールが武装している（検査が空振りしていない）', async () => {
+    const eslint = new ESLint({
+      cwd: probeApp,
+      overrideConfigFile: true,
+      overrideConfig: composedConfig(),
+    });
+    const effective = (await eslint.calculateConfigForFile(
+      path.join(probeApp, 'src/features/probe/file.tsx'),
+    )) as { rules?: Record<string, Linter.RuleEntry> };
+    expect(severityOf(effective.rules?.['no-restricted-syntax'])).toBe(2);
+  }, 60_000);
+});


### PR DESCRIPTION
## 何を配るか

ゲート導入段（report-only）の降格を **配布側のヘルパ**にした（hub 裁定 2026-07-30）。
各艦が降格コードを自作した結果、origin / field の導入で **3つの事故形**が出たので、そこを吸収する。

| # | 事故形（実測） | ヘルパでの扱い |
|---|---|---|
| 1 | `Object.keys(canonical).map(r => [r,'warn'])` が canonical の **off 386件**まで武装させ、未定義プラグインの解決要求で **config 読み込みが落ちる**（`@stylistic` 等 12 名前空間の install が必要＝構造的に不可能） | `canonicalRuleIds()` が **off を除外**。`severity:'warn'` で台帳に off が混ざっていたら **throw**（fail-loud） |
| 2 | runtime 導出は **canonical の将来追加を黙って off に吸収**する | **既定は凍結台帳**（呼び出し側が rule id を渡す）＋ `reportOnlyStaleRules()` で追随漏れを言える |
| 3 | `warn` に落としても CI は緑にならない（**両艦とも `--max-warnings 0`**） | **既定 `severity: 'off'`** |
| 5 | canonical の `projectService` が「型付きプログラム外ファイル」除外を上書きし Parsing error | `toolingExemption()`（既定 glob に **`**/*.mjs` / `**/*.cjs`** を含む — `**/*.js` は `.mjs` を捕まえない） |

## API

```js
import nene2 from '@hideyukimori/nene2-standards';
import { canonicalOff } from './eslint.canonical-off.js'; // 生成物

export default tseslint.config(
  { ignores: [...] },
  // canonical は艦自前ブロックより前（後勝ちで艦の既存ゲートを守る＝摩擦6）
  ...nene2.base, ...nene2.fsd, ...nene2.api, ...nene2.stylingWith(),
  nene2.reportOnly({ ruleIds: canonicalOff }),
  ...艦自前のブロック,
  nene2.toolingExemption(),
);
```

- `reportOnly({ ruleIds, severity = 'off', files?, name? })` → 降格ブロック
- `canonicalRuleIds({ entryPoint? })` → canonical が**武装している**ルール id（sorted・重複なし）
- `reportOnlyStaleRules(ruleIds, { entryPoint? })` → 凍結台帳の追随漏れ
- `renderReportOnlyLedger({ entryPoint?, standardsVersion?, exportName? })` → **生成器を配布側に持つ**（艦側は3行）
- `toolingExemption({ files? })` → `projectService: false` の除外ブロック

`nene2.*`（既定 export）と named export の両方から使えます。**既存 API は無変更**。

## 意味論の選択 — field 側を既定にした

runtime 導出（origin PR #477 = 私の実装）は **canonical が将来追加するルールまで黙って off に吸収**します。凍結台帳（field PR #141）なら追加分は未列挙のまま canonical の severity で発火し、**差分としてレビューに出る**。今日1日ずっと潰してきた「登録が効くことの負テストが無い」と同型なので、**弱い形は私の側**でした。origin は #480 で置換して揃えます（hub 承認済み・「統一済み」とは記録しない）。

なお `canonicalRuleIds()` は **武装している 80件だけ**を返します（field の台帳は off も含めた 466件）。off を混ぜても `off` 形なら無害ですが、**80件形なら艦が warn に切り替えても壊れません**。

## 実装上の注意（fail-loud の副作用を踏んだ）

`stylingWith()` はエントリの実在を **cwd 基準**で確認して throw します。台帳生成やルール id 問い合わせは艦の cwd で走るとは限らないので、`entryPoint` 未指定時は `composedConfig()` と同じく静的な `styling` を使います（この点はテストで踏んで直しました）。

## テスト（15本・すべて陽性対照つき）

- `warn` × canonical off → **throw**／`off` 形なら通す（実害の無いものは止めない）
- 台帳から1件抜くと `reportOnlyStaleRules()` がそれを返す／追随できていれば空
- **生成物を実際に import して評価**（「生成できた」を「動く」の証拠にしない）
- 降格が **ESLint の実効 severity** として 0 になる／**降格ブロックを外すと 2 に戻る**（空振り検査でないことの確認）

## 実測

`npm run check` **exit 0** — 32 files / **471 tests** pass ／ `AM-2 release gate: PASS`。

## 残タスク

- origin #480 でヘルパへ置換（機構を field 側へ揃える）・field も次の追随波で置換
- 摩擦2（`jsx-a11y` の参照層）は**未決**。ヘルパの射程外なので裁定待ち（i18n 軸を展開する段で効く）
- 出荷は次 minor 波（マージ・publish は施主 seam）

Refs #189
