### PR TITLE
fix(standards): 非 Tailwind 艦の Tailwind 依存ルールを「緩和」と報告しない（#163）

### DIFF
--- a/packages/nene2-standards/src/checks/gate-integrity.ts
+++ b/packages/nene2-standards/src/checks/gate-integrity.ts
@@ -18,6 +18,7 @@ import { ESLint, type Linter } from 'eslint';
 
 import { composedConfig } from '../index.js';
 import type { KeyState } from './conformance.js';
+import { detectTailwind, TAILWIND_DEPENDENT_RULES } from './tailwind-presence.js';
 
 /**
  * 照合マトリクス: 「(仮想パス, ルール) → canonical 実効 severity」。
@@ -146,11 +147,25 @@ export async function checkGateIntegrity(options: GateIntegrityOptions): Promise
     return { state: 'unknown', reason: 'crashed', details: [(e as Error).message] };
   }
 
+  // Tailwind 実 entry を要求する検査器は、非 Tailwind 艦では「検査不能」であって「緩和」ではない
+  // （#163・concierge 照会 + fleet 横断実測。非 Tailwind は concierge/serve/corpus/suite の4艦）。
+  // 4艦に同じ差異登録を手書きさせるのは G-7 に反するので canonical 側（ここ）で表現する。
+  // 判定は**依存の実測**（艦の申告ではない）— 「styling 軸を展開していない」を理由に外すと
+  // 「外せば緩和が消える」抜け道になる。
+  const tailwind = detectTailwind(cwd);
+  const outOfScope = new Set(tailwind.present ? [] : TAILWIND_DEPENDENT_RULES);
+
   const details: string[] = [];
+  const skipped: string[] = [];
   for (let i = 0; i < canonTable.length; i++) {
     const canon = canonTable[i];
     const prod = productTable[i];
     if (!canon || !prod) continue;
+    if (outOfScope.has(canon.rule)) {
+      // 対象外は**黙って飛ばさない**（隠れた不検査を作らないため・G-6 の趣旨）。
+      if (!skipped.includes(canon.rule)) skipped.push(canon.rule);
+      continue;
+    }
     // ルール不在（severity null）と off（0）は**同じ実効挙動**（そのルールは走らない）。
     // 不在を -1 に落とすと「canonical が off・製品が不在」を緩和と誤検出する（#178 実測: origin の
     // `no-restricted-globals: 実効 -1 < canonical 0`）。緩和とは「canonical が走らせるものを
@@ -177,7 +192,39 @@ export async function checkGateIntegrity(options: GateIntegrityOptions): Promise
     }
   }
 
-  return details.length === 0 ? { state: 'green' } : { state: 'red', details };
+  // 対象外にしたルールは green/red のどちらでも必ず出す（「何を見ていないか」を隠さない）。
+  const scopeNote =
+    skipped.length > 0
+      ? [
+          `照合対象外 ${skipped.length}件（Tailwind 非依存艦のため）: ${skipped.join(', ')}` +
+            ` — 判定根拠: ${tailwind.reason}。Tailwind 実 entry を要する検査器は非 Tailwind 艦では` +
+            `検査不能であって緩和ではない（#163）。`,
+        ]
+      : [];
+
+  // green の KeyState はスキーマ（nene2-conformance/1）が details を持たないので、
+  // green のときは付けられない。**代わりに `gateIntegrityScope()` で機械可読に外へ出す**
+  // （呼び出し側＝レポートや他レーンが「何を見ていないか」を取れる）。
+  // green に details を持たせるのはスキーマ変更＝凍結明けの案件（本 PR の射程外）。
+  if (details.length === 0) return { state: 'green' };
+  return { state: 'red', details: [...details, ...scopeNote] };
+}
+
+/**
+ * この艦で **照合対象から外れるルール**とその根拠（#163）。
+ *
+ * `checkGateIntegrity` が green を返したときは KeyState に details を積めない
+ * （`nene2-conformance/1` の green は details を持たない）ため、「何を見ていないか」は
+ * ここから取る。**黙って飛ばした対象外を作らない**ための問い合わせ口。
+ */
+export function gateIntegrityScope(cwd: string): { excluded: string[]; reason: string } {
+  const tailwind = detectTailwind(cwd);
+  return {
+    excluded: tailwind.present ? [] : [...TAILWIND_DEPENDENT_RULES],
+    reason: tailwind.present
+      ? `Tailwind 依存を実測（${tailwind.reason}）— 全ルールが照合対象`
+      : `Tailwind 非依存（${tailwind.reason}）— Tailwind 実 entry を要する検査器は検査不能であり緩和ではない（#163）`,
+  };
 }
 
 /** src/**' の適用ファイル数（G-6 の空虚合格検査）。 */

--- a/packages/nene2-standards/src/checks/tailwind-presence.ts
+++ b/packages/nene2-standards/src/checks/tailwind-presence.ts
@@ -1,0 +1,95 @@
+/**
+ * 艦が Tailwind を使っているかの**実測**判定（#163）。
+ *
+ * ## なぜ要るか
+ *
+ * canonical は `better-tailwindcss/no-unknown-classes` を武装して配る。この検査器は
+ * **Tailwind の実 entry を要求する**ので、非 Tailwind の艦では
+ *
+ * - entry が無くて throw する（＝検査不能）か
+ * - 既定 theme へ silent fallback して**偽陽性洪水**になる（payout#161 で 218件実測の型）
+ *
+ * のどちらかにしかならない。ところが gate-integrity はこの状態を
+ * 「実効 severity < canonical（差異登録なき緩和）」＝**違反**として報告していた。
+ * **検査不能を違反として罰している**ので、fail-closed の原則（検査不能=unknown・空虚合格禁止）
+ * から見て canonical 側の問題（concierge 照会・fleet 横断実測 2026-07-29）。
+ *
+ * 非 Tailwind は **concierge / serve / corpus / suite の4艦**（fleet 実測）。1艦なら registries の
+ * 差異登録で表現するのが妥当だが、**4艦は例外ではなく構造**であり、同じ差異登録を4艦に手書きさせるのは
+ * G-7（合成を被検査者の手から取り上げる・手書き列挙 MUST NOT）に反する。→ canonical 側で表現する。
+ *
+ * ## 判定は依存の実測で行う（自己申告に依存しない — G-7）
+ *
+ * 艦の `package.json` の依存に `tailwindcss` / `@tailwindcss/*` があるかで見る。
+ * 「eslint.config.js が styling 軸を展開しているか」では判定しない——それは
+ * **被検査者の申告**であり、「展開していない」ことを理由に検査対象外にすると
+ * 「外せば緩和が消える」抜け道になる。
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/** 依存として Tailwind を示す名前（v4 は `@tailwindcss/vite` 等のプラグイン経由もある）。 */
+const TAILWIND_DEP = /^(tailwindcss|@tailwindcss\/.+)$/;
+
+/** gate-integrity の照合対象から外すルール（Tailwind 実 entry を要求する検査器）。 */
+export const TAILWIND_DEPENDENT_RULES: readonly string[] = [
+  'better-tailwindcss/no-unknown-classes',
+];
+
+type Manifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+function manifestDeps(file: string): string[] {
+  try {
+    const json = JSON.parse(readFileSync(file, 'utf8')) as Manifest;
+    return [
+      ...Object.keys(json.dependencies ?? {}),
+      ...Object.keys(json.devDependencies ?? {}),
+      ...Object.keys(json.peerDependencies ?? {}),
+      ...Object.keys(json.optionalDependencies ?? {}),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+export interface TailwindPresence {
+  /** Tailwind 依存を実測できたか */
+  present: boolean;
+  /** 判定根拠（details にそのまま出せる文言） */
+  reason: string;
+}
+
+/**
+ * `cwd`（＝gate-integrity が測るディレクトリ）とその親1段の `package.json` を見て判定する。
+ *
+ * 親1段まで見るのは、フロントが `frontend/` にある艦で依存がそこに宣言される一方、
+ * リポ直下の manifest に宣言される艦もあるため（フリート実測）。**見つからなければ
+ * 「非 Tailwind」と断定せず、判定不能を `present: false` の理由に明記する**
+ * （呼び出し側が details に出して読み手が切り分けられるようにする）。
+ */
+export function detectTailwind(cwd: string): TailwindPresence {
+  const candidates = [path.join(cwd, 'package.json'), path.join(path.dirname(cwd), 'package.json')];
+  const seen: string[] = [];
+  for (const file of candidates) {
+    if (!existsSync(file)) continue;
+    seen.push(file);
+    const hit = manifestDeps(file).find((name) => TAILWIND_DEP.test(name));
+    if (hit)
+      return {
+        present: true,
+        reason: `${path.basename(path.dirname(file))}/package.json に ${hit}`,
+      };
+  }
+  if (seen.length === 0) {
+    return { present: false, reason: 'package.json が見つからない（cwd とその親を確認）' };
+  }
+  return {
+    present: false,
+    reason: `依存に tailwindcss / @tailwindcss/* が無い（確認: ${seen.length}件の package.json）`,
+  };
+}

--- a/packages/nene2-standards/src/index.ts
+++ b/packages/nene2-standards/src/index.ts
@@ -63,7 +63,13 @@ export {
   validateConformance,
 } from './checks/conformance.js';
 export type { ConformanceKey, ConformanceVector, KeyState } from './checks/conformance.js';
-export { checkGateIntegrity, canonicalSeverityTable } from './checks/gate-integrity.js';
+export {
+  canonicalSeverityTable,
+  checkGateIntegrity,
+  gateIntegrityScope,
+} from './checks/gate-integrity.js';
+export { detectTailwind, TAILWIND_DEPENDENT_RULES } from './checks/tailwind-presence.js';
+export type { TailwindPresence } from './checks/tailwind-presence.js';
 export { checkScanCoverage } from './checks/scan-coverage.js';
 export { initScan, initCheck } from './checks/init-scan.js';
 export { runConformance } from './checks/run.js';

--- a/packages/nene2-standards/tests/tailwind-presence.test.ts
+++ b/packages/nene2-standards/tests/tailwind-presence.test.ts
@@ -1,0 +1,121 @@
+/**
+ * 非 Tailwind 艦での gate-integrity 偽陽性の回帰テスト（#163）。
+ *
+ * 事故形: canonical は `better-tailwindcss/no-unknown-classes` を武装して配るが、この検査器は
+ * **Tailwind の実 entry を要求する**ので非 Tailwind 艦では検査不能（throw か偽陽性洪水）。
+ * それを gate-integrity が「差異登録なき緩和」＝違反として報告していた
+ * （concierge 照会・非 Tailwind は concierge/serve/corpus/suite の4艦＝fleet 実測）。
+ *
+ * **検査不能を違反として罰していた**のが本体なので、#178/#179（不在と off を差に数えない）と同じ類型。
+ * 陽性対照 = Tailwind 依存を足すと同じルールが照合対象へ戻ること（＝検査が空振りしていない）。
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { checkGateIntegrity, gateIntegrityScope, TAILWIND_DEPENDENT_RULES } from '../src/index.js';
+import { detectTailwind } from '../src/checks/tailwind-presence.js';
+
+const TW_RULE = TAILWIND_DEPENDENT_RULES[0]!;
+
+let root: string;
+/** 非 Tailwind 艦（依存に tailwindcss が無い） */
+let plain: string;
+/** Tailwind 艦（devDependencies に tailwindcss） */
+let tw: string;
+/** 依存が親（リポ直下）に宣言され、測るのは frontend/ の艦 */
+let nested: string;
+
+function ship(dir: string, manifest: object): void {
+  mkdirSync(path.join(dir, 'src', 'features', 'probe'), { recursive: true });
+  writeFileSync(path.join(dir, 'src', 'features', 'probe', 'file.tsx'), 'export const X = 1;\n');
+  writeFileSync(path.join(dir, 'package.json'), JSON.stringify(manifest, null, 2));
+  // canonical を展開しない最小 config（＝ styling 段を採っていない非 Tailwind 艦の形）
+  writeFileSync(path.join(dir, 'eslint.config.js'), 'export default [];\n');
+}
+
+beforeAll(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'nene2-tw-'));
+  plain = path.join(root, 'plain');
+  tw = path.join(root, 'tw');
+  nested = path.join(root, 'nested');
+  ship(plain, { name: 'plain', private: true, devDependencies: { eslint: '^9' } });
+  ship(tw, { name: 'tw', private: true, devDependencies: { eslint: '^9', tailwindcss: '^4.1.0' } });
+  // nested: frontend/ を測るが依存はリポ直下に宣言（フリートに実在する形）
+  ship(path.join(nested, 'frontend'), { name: 'nested-frontend', private: true });
+  writeFileSync(
+    path.join(nested, 'package.json'),
+    JSON.stringify({ name: 'nested', private: true, dependencies: { '@tailwindcss/vite': '^4' } }),
+  );
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('detectTailwind — 判定は依存の実測（艦の申告ではない）', () => {
+  it('依存が無ければ非 Tailwind と判定する', () => {
+    const r = detectTailwind(plain);
+    expect(r.present).toBe(false);
+    expect(r.reason).toContain('tailwindcss');
+  });
+
+  it('devDependencies の tailwindcss を拾う', () => {
+    expect(detectTailwind(tw).present).toBe(true);
+  });
+
+  it('親1段（リポ直下）の @tailwindcss/* も拾う（frontend/ を測る艦の形）', () => {
+    const r = detectTailwind(path.join(nested, 'frontend'));
+    expect(r.present).toBe(true);
+    expect(r.reason).toContain('@tailwindcss/vite');
+  });
+
+  it('package.json が見つからないときは「非 Tailwind と断定」ではなく判定不能を理由に出す', () => {
+    const r = detectTailwind(path.join(root, 'does-not-exist'));
+    expect(r.present).toBe(false);
+    expect(r.reason).toContain('package.json が見つからない');
+  });
+});
+
+describe('gateIntegrityScope — 何を見ていないかを機械可読に出す', () => {
+  it('非 Tailwind 艦では Tailwind 依存ルールが対象外として並ぶ', () => {
+    const scope = gateIntegrityScope(plain);
+    expect(scope.excluded).toEqual([...TAILWIND_DEPENDENT_RULES]);
+    expect(scope.reason).toContain('緩和ではない');
+  });
+
+  it('Tailwind 艦では対象外なし（＝全ルールが照合対象）', () => {
+    expect(gateIntegrityScope(tw).excluded).toEqual([]);
+  });
+});
+
+describe('checkGateIntegrity — 非 Tailwind 艦を「緩和」と報告しない', () => {
+  it('非 Tailwind 艦の red 詳細に Tailwind 依存ルールが出ない（#163 本体）', async () => {
+    const result = await checkGateIntegrity({ cwd: plain });
+    // canonical を展開していない艦なので他のルールでは red になる（それは正しい報告）。
+    expect(result.state).toBe('red');
+    if (result.state === 'red') {
+      // 注記自体が「緩和ではない」の語を含むので、**違反行の文言**で判定する
+      const violated = (d: string): boolean =>
+        d.includes(TW_RULE) && d.includes('差異登録なき緩和');
+      expect(result.details.some(violated)).toBe(false);
+      // 黙って飛ばさない: 対象外にした事実と根拠が details に出る
+      expect(result.details.some((d) => d.includes('照合対象外') && d.includes(TW_RULE))).toBe(
+        true,
+      );
+    }
+  }, 60_000);
+
+  it('🔴 陽性対照: Tailwind 依存を足すと同じルールが「緩和」として現れる（空振りでない）', async () => {
+    const result = await checkGateIntegrity({ cwd: tw });
+    expect(result.state).toBe('red');
+    if (result.state === 'red') {
+      const violated = (d: string): boolean =>
+        d.includes(TW_RULE) && d.includes('差異登録なき緩和');
+      expect(result.details.some(violated)).toBe(true);
+      expect(result.details.some((d) => d.includes('照合対象外'))).toBe(false);
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## 直したこと

`better-tailwindcss/no-unknown-classes` は **Tailwind の実 entry を要求する検査器**です。非 Tailwind の艦では

- entry が無くて throw する（＝**検査不能**）か
- 既定 theme へ silent fallback して**偽陽性洪水**になる（payout#161 で 218件実測の型）

のどちらかにしかなりません。ところが gate-integrity はこの状態を「実効 severity < canonical（**差異登録なき緩和**）」＝違反として報告していました。**検査不能を違反として罰している**ので、#178/#179（不在と off を差に数えない）と同じ類型の偽陽性です。

非 Tailwind は **concierge / serve / corpus / suite の4艦**（fleet 横断実測）。1艦なら registries の差異登録で表現するのが妥当ですが、**4艦は例外ではなく構造**で、同じ差異登録を4艦に手書きさせるのは G-7 に反します。→ **canonical 側（検査器）で表現**します（concierge の3択照会への回答 = **(2)**）。

## 実測（concierge = 照会元・読み取りのみ）

| | gate-integrity の details |
|---|---|
| 公開 2.2.0 | **2行** — `better-tailwindcss/no-unknown-classes` と `nene2/style-prop-css-vars-only` の両方を「緩和」と報告 |
| 本ブランチ | **1行**（`nene2/style-prop-css-vars-only` のみ）＋ **照合対象外の注記1行**（判定根拠つき） |

## 設計上の2点

**1. 判定は依存の実測。艦の申告では判定しない。**
`tailwindcss` / `@tailwindcss/*` を cwd とその親1段の `package.json` で見ます（依存がリポ直下宣言・測るのは `frontend/` という艦が実在するため）。「`eslint.config.js` が styling 軸を展開しているか」では判定しません — それは**被検査者の申告**で、「外せば緩和が消える」抜け道になります（G-7）。`package.json` が見つからないときは**非 Tailwind と断定せず**、判定不能を理由に明記します。

**2. 対象外は黙って飛ばさない。**
red の details に「照合対象外 N件（Tailwind 非依存艦のため）: … — 判定根拠: …」を出します。green のときは `nene2-conformance/1` の KeyState が details を持てないため付けられないので、代わりに **`gateIntegrityScope(cwd)`** を export して機械可読に外から取れるようにしました（green に details を積むのはスキーマ変更なので本 PR の射程外）。

## 🔴 残る1行は別論点（#163 §3・本 PR では直しません）

`nene2/style-prop-css-vars-only`（inline style 禁止）は **Tailwind と無関係**で、concierge が `styling` 断片を**丸ごと**外していることの副作用で外れています。筋は「断片を Tailwind 依存部と非依存部に分割する」ことですが、**配布 API の変更＝minor bump** になるため凍結中の扱いに hub 裁定が必要です。#163 は open のまま残します（`Closes` にしていません）。

## テスト（8本・陽性対照つき）

- 依存の実測: 無し／devDependencies の `tailwindcss`／**親1段の `@tailwindcss/vite`**／`package.json` 不在時は判定不能を明記
- `gateIntegrityScope`: 非 Tailwind で対象外が並ぶ／Tailwind 艦では空
- 本体: 非 Tailwind 艦の red に Tailwind 依存ルールの違反行が**出ない**／対象外注記が**出る**
- 🔴 **陽性対照**: Tailwind 依存を足すと同じルールが「差異登録なき緩和」として**再び現れる**（＝検査が空振りしていない）

※ 最初の版では assertion を `'緩和'` で書いたため、**注記の「緩和ではない」に一致して誤判定**しました。違反行の文言（`差異登録なき緩和`）で照合する形に直しています。

## 実測

`npm run check` **exit 0** — 32 files / **464 tests** pass ／ `AM-2 release gate: PASS`。

Refs #163
