### PR TITLE
fix(standards): 制定した本人を罰しない — provider/テーマモジュールの誤検知（#118・#130）

### DIFF
--- a/packages/nene2-standards/src/configs/restrictions.ts
+++ b/packages/nene2-standards/src/configs/restrictions.ts
@@ -23,7 +23,9 @@ import type { Linter } from 'eslint';
 
 import {
   API_FETCH_SYNTAX,
+  I18N_LANG_SYNTAX,
   I18N_RUNTIME_SYNTAX,
+  STYLING_DATA_THEME_SYNTAX,
   STYLING_SYNTAX,
   TESTING_SYNTAX,
   type SyntaxSelector,
@@ -65,6 +67,21 @@ export const CLIENT_TS = 'src/shared/api/client.ts';
 export const MESSAGES_GLOB = 'src/shared/i18n/messages/**/*.{ts,tsx}';
 export const SLICES_GLOB = 'src/{features,pages,entities}/**/*.{ts,tsx}';
 export const SHARED_UI_GLOB = 'src/shared/ui/**/*.{ts,tsx}';
+/**
+ * I18nProvider 実装の正準座席（#118）。AM-18 は「lang の設定は I18nProvider の scope 同期のみ」
+ * なので、**この1ファイルだけ** lang 群を外す（他の禁止は全部かける）。
+ * フリート実測（2026-07-30）: payout / deal / vault / invoice がこの配置。
+ */
+export const I18N_PROVIDER_GLOB = 'src/shared/i18n/i18n-context.{ts,tsx}';
+/**
+ * 登録テーマモジュールの正準座席（#130）。会議R2⑥/R5 は「data-theme の付与・読み取りは
+ * 登録テーマモジュールのみ」なので、**このモジュール配下だけ** data-theme 群を外す。
+ * フリート実測（2026-07-30・`setAttribute('data-theme')` の実在ファイル）:
+ * contact / deal / serve = `src/shared/theme/index.ts`・origin = `src/shared/theme/ThemeProvider.tsx`
+ * ＝**ファイル名は艦ごとに違うがモジュール（ディレクトリ）は共通**なので、条文の語（「テーマモジュール」）
+ * に合わせてディレクトリ単位で表現する。
+ */
+export const THEME_MODULE_GLOB = 'src/shared/theme/**/*.{ts,tsx}';
 export const TEST_FILE_GLOBS = [
   'src/**/*.test.{ts,tsx}',
   'src/**/*.stories.{ts,tsx}',
@@ -86,7 +103,13 @@ export const restrictions: Linter.Config[] = [
   {
     name: 'nene2/restrictions/syntax-app',
     files: [APP_GLOB],
-    ignores: [CLIENT_TS, MESSAGES_GLOB, ...TEST_IGNORE_GLOBS],
+    ignores: [
+      CLIENT_TS,
+      MESSAGES_GLOB,
+      I18N_PROVIDER_GLOB,
+      THEME_MODULE_GLOB,
+      ...TEST_IGNORE_GLOBS,
+    ],
     rules: {
       'no-restricted-syntax': syntaxRule([
         ...API_FETCH_SYNTAX,
@@ -124,6 +147,39 @@ export const restrictions: Linter.Config[] = [
       // gate-integrity canonical 表に登録済みの off（05 §2.2 冒頭の唯一の例外）
       'no-restricted-globals': 'off',
       'no-restricted-imports': 'off',
+    },
+  },
+  {
+    // I18nProvider 実装（#118）。AM-18 が唯一許している座席なので **lang 群だけ**外す。
+    // 条文意図は「I18nProvider 以外が lang を触るのを禁止」であり、provider 本体が同じルールで
+    // 罰されるのは条文と逆だった（payout C3a-3 で実害・各艦が file override で退避していた）。
+    // 他の禁止（fetch / styling / Intl / JP）は**かけたまま**——「1ルール丸ごと off」にしない。
+    name: 'nene2/restrictions/syntax-i18n-provider',
+    files: [I18N_PROVIDER_GLOB],
+    ignores: TEST_IGNORE_GLOBS,
+    rules: {
+      'no-restricted-syntax': syntaxRule([
+        ...API_FETCH_SYNTAX,
+        ...STYLING_SYNTAX,
+        ...I18N_RUNTIME_SYNTAX.filter((s) => !I18N_LANG_SYNTAX.includes(s)),
+        ...I18N_JP_SYNTAX,
+      ]),
+    },
+  },
+  {
+    // 登録テーマモジュール（#130）。会議R2⑥/R5 が唯一許している座席なので **data-theme 群だけ**外す。
+    // #118 と同型（制定した本人が自分の条文で罰される形）。deal C3a-3 で実害。
+    // arbitrary value / dark: variant 等の styling 禁止は**かけたまま**。
+    name: 'nene2/restrictions/syntax-theme-module',
+    files: [THEME_MODULE_GLOB],
+    ignores: TEST_IGNORE_GLOBS,
+    rules: {
+      'no-restricted-syntax': syntaxRule([
+        ...API_FETCH_SYNTAX,
+        ...STYLING_SYNTAX.filter((s) => !STYLING_DATA_THEME_SYNTAX.includes(s)),
+        ...I18N_RUNTIME_SYNTAX,
+        ...I18N_JP_SYNTAX,
+      ]),
     },
   },
   {

--- a/packages/nene2-standards/src/selectors.ts
+++ b/packages/nene2-standards/src/selectors.ts
@@ -25,6 +25,24 @@ export const API_FETCH_SYNTAX: readonly SyntaxSelector[] = [
   },
 ];
 
+/**
+ * data-theme の付与／読み取り（会議R2⑥・R5）。**登録テーマモジュール本体は唯一の正当な座席**なので、
+ * restrictions 側でそのファイル集合だけこの群を外す（#130 — コントローラ本体が自分の条文で
+ * 罰されるのは条文と逆）。`STYLING_SYNTAX` には含まれるので、他のファイルでの挙動は変わらない。
+ */
+export const STYLING_DATA_THEME_SYNTAX: readonly SyntaxSelector[] = [
+  {
+    // data-theme 付与はテーマコントローラ1ファイルのみ（会議R2⑥決定）
+    selector: "CallExpression[callee.property.name='setAttribute'][arguments.0.value='data-theme']",
+    message: 'data-theme の JS 付与は登録テーマコントローラのみ（会議R2⑥決定）。',
+  },
+  {
+    // コンポーネント内テーマ分岐禁止（会議R5議題(6) タグ発明で MUST 維持）
+    selector: "CallExpression[callee.property.name='getAttribute'][arguments.0.value='data-theme']",
+    message: '登録テーマモジュール外での data-theme 読み取り MUST NOT（会議R5決定）。',
+  },
+];
+
 /** 05 §2.2.4 styling の7セレクタ（会議R1⑤・R2⑥・R4 AM-5/AM-8/AM-13・R5議題(3)決定）。 */
 export const STYLING_SYNTAX: readonly SyntaxSelector[] = [
   {
@@ -46,16 +64,7 @@ export const STYLING_SYNTAX: readonly SyntaxSelector[] = [
     selector: String.raw`TemplateLiteral > TemplateElement[value.cooked=/(^|\s)(text|bg|border)-$/]`,
     message: '色系クラスの文字列補間（text-${x}）MUST NOT。variant map（*_CLASS 定数）を使う。',
   },
-  {
-    // data-theme 付与はテーマコントローラ1ファイルのみ（会議R2⑥決定）
-    selector: "CallExpression[callee.property.name='setAttribute'][arguments.0.value='data-theme']",
-    message: 'data-theme の JS 付与は登録テーマコントローラのみ（会議R2⑥決定）。',
-  },
-  {
-    // コンポーネント内テーマ分岐禁止（会議R5議題(6) タグ発明で MUST 維持）
-    selector: "CallExpression[callee.property.name='getAttribute'][arguments.0.value='data-theme']",
-    message: '登録テーマモジュール外での data-theme 読み取り MUST NOT（会議R5決定）。',
-  },
+  ...STYLING_DATA_THEME_SYNTAX,
   {
     // ランタイム CSS 変数注入は登録注入器ファイルのみ（会議R4 AM-5決定）
     selector: String.raw`CallExpression[callee.property.name='setProperty'][arguments.0.value=/^--/]`,
@@ -69,6 +78,18 @@ export const STYLING_SYNTAX: readonly SyntaxSelector[] = [
   },
 ];
 
+/**
+ * lang 属性の設定（会議R4 AM-18）。**I18nProvider 実装は唯一の正当な座席**なので、restrictions 側で
+ * そのファイルだけこの群を外す（#118 — provider 本体が自分の条文で罰されるのは条文と逆）。
+ * `I18N_RUNTIME_SYNTAX` には含まれるので、他のファイルでの挙動は変わらない。
+ */
+export const I18N_LANG_SYNTAX: readonly SyntaxSelector[] = [
+  {
+    selector: "AssignmentExpression[left.property.name='lang']",
+    message: 'lang 属性の設定は I18nProvider の scope 同期のみ（会議R4 AM-18決定）。',
+  },
+];
+
 /** 05 §2.2.5 の Intl / lang 系（JP 3ノードは別群 — W0a JP lint PR で追加）。 */
 export const I18N_RUNTIME_SYNTAX: readonly SyntaxSelector[] = [
   {
@@ -79,10 +100,7 @@ export const I18N_RUNTIME_SYNTAX: readonly SyntaxSelector[] = [
     selector: "NewExpression[callee.object.name='Intl']",
     message: '同上。Intl 直呼びは nene2-i18n の format 実装内のみ。',
   },
-  {
-    selector: "AssignmentExpression[left.property.name='lang']",
-    message: 'lang 属性の設定は I18nProvider の scope 同期のみ（会議R4 AM-18決定）。',
-  },
+  ...I18N_LANG_SYNTAX,
 ];
 
 /**

--- a/packages/nene2-standards/tests/composed-config.probes.test.ts
+++ b/packages/nene2-standards/tests/composed-config.probes.test.ts
@@ -236,3 +236,35 @@ function msgText(m: Linter.LintMessage, name: string): boolean {
   // no-restricted-imports のメッセージにパッケージ名が含まれない ESLint 版のフォールバック
   return (m.message.match(/'[^']+'/)?.[0] ?? '').includes(name);
 }
+
+describe('検出プローブ — 制定した本人を罰しない（#118 / #130）', () => {
+  const messageTexts = (rel: string): string[] => messagesFor(rel).map((m) => m.message);
+
+  it('I18nProvider 実装での lang 付与は検知しない（#118・AM-18 が許す唯一の座席）', () => {
+    const texts = messageTexts('src/shared/i18n/i18n-context.tsx');
+    expect(texts.some((t) => t.includes('lang 属性の設定は'))).toBe(false);
+  });
+
+  it('🔴 provider でも lang 以外は検知する（1ルール丸ごと off にしていない）', () => {
+    const texts = messageTexts('src/shared/i18n/i18n-context.tsx');
+    expect(texts.some((t) => t.includes('Intl 直呼び'))).toBe(true);
+  });
+
+  it('登録テーマモジュールでの data-theme 付与／読み取りは検知しない（#130・R2⑥/R5 が許す唯一の座席）', () => {
+    const texts = messageTexts('src/shared/theme/index.ts');
+    expect(texts.some((t) => t.includes('data-theme の JS 付与'))).toBe(false);
+    expect(texts.some((t) => t.includes('data-theme 読み取り'))).toBe(false);
+  });
+
+  it('🔴 テーマモジュールでも data-theme 以外は検知する（1ルール丸ごと off にしていない）', () => {
+    const texts = messageTexts('src/shared/theme/index.ts');
+    expect(texts.some((t) => t.includes('t() 経由'))).toBe(true);
+  });
+
+  it('🔴 陽性対照: 座席の外では lang / data-theme を今も検知する（免除が広がっていない）', () => {
+    const intl = messageTexts('src/features/probe-slice/intl-probe.ts');
+    const styling = messageTexts('src/features/probe-slice/styling-probe.tsx');
+    expect(intl.some((t) => t.includes('lang 属性の設定は'))).toBe(true);
+    expect(styling.some((t) => t.includes('data-theme'))).toBe(true);
+  });
+});

--- a/packages/nene2-standards/tests/fixtures/probe-app/src/shared/i18n/i18n-context.tsx
+++ b/packages/nene2-standards/tests/fixtures/probe-app/src/shared/i18n/i18n-context.tsx
@@ -1,0 +1,10 @@
+// #118 プローブ: I18nProvider 実装（AM-18 が唯一許している座席）。
+// ここでの lang 付与は**検知されてはいけない**（条文が許可している唯一の場所）。
+// 一方、他の禁止（Intl 直呼び）は**ここでも検知される**べき＝1ルール丸ごと off にしていないことの確認。
+export function syncLang(el: HTMLElement, locale: string): void {
+  el.lang = locale;
+}
+
+export function badIntl(): string {
+  return new Intl.NumberFormat('ja-JP').format(1);
+}

--- a/packages/nene2-standards/tests/fixtures/probe-app/src/shared/theme/index.ts
+++ b/packages/nene2-standards/tests/fixtures/probe-app/src/shared/theme/index.ts
@@ -1,0 +1,12 @@
+// #130 プローブ: 登録テーマモジュール（会議R2⑥/R5 が唯一許している座席）。
+// data-theme の付与・読み取りは**検知されてはいけない**。
+// 一方、他の禁止（JP リテラル）は**ここでも検知される**べき＝1ルール丸ごと off にしていないことの確認。
+export function applyTheme(theme: string): void {
+  document.documentElement.setAttribute('data-theme', theme);
+}
+
+export function currentTheme(): string | null {
+  return document.documentElement.getAttribute('data-theme');
+}
+
+export const BAD_LABEL = 'テーマ';


### PR DESCRIPTION
## 直したこと

canonical の `no-restricted-syntax` が、**条文が唯一許している座席そのもの**を誤検知していました。

| issue | 条文 | 誤検知していた対象 | 実害の発見元 |
|---|---|---|---|
| **#118** | lang の設定は I18nProvider の scope 同期のみ（AM-18） | **当の I18nProvider 実装** | payout C3a-3 |
| **#130** | data-theme の付与／読み取りは登録テーマモジュールのみ（R2⑥/R5） | **当のテーマコントローラ本体** | deal C3a-3 |

条文意図は「**それ以外**が触るのを禁止」なので、許可された唯一の場所が同じルールで罰されるのは条文と逆です。各艦は file×rule override で退避していました＝**配布物の欠陥を艦が肩代わりしていた**状態です。

## 直し方

セレクタ群を named 定数に切り出し（`I18N_LANG_SYNTAX` / `STYLING_DATA_THEME_SYNTAX`）、restrictions 側で**座席のファイル集合だけ当該群を外す**形にしました。`STYLING_SYNTAX` / `I18N_RUNTIME_SYNTAX` の中身は不変なので、**他のファイルでの挙動は変わりません**。

- 🔴 **1ルール丸ごと off にはしません。** provider では lang 群だけ、テーマモジュールでは data-theme 群だけを外し、fetch / styling / Intl / JP の禁止は**かけたまま**です。
- ファイル集合の**互いに素**（05 §2.2 冒頭 MUST）を保ちます。新集合を `syntax-app` の `ignores` に足し、**後置き `off` は使いません**。test/story は従来どおり `syntax-tests` 側へ流します。

## 座席は実測で決めました（発明していません）

- **provider**: `src/shared/i18n/i18n-context.{ts,tsx}` — payout / deal / vault / invoice で実在確認。
- **テーマモジュール**: `src/shared/theme/**/*.{ts,tsx}` — `setAttribute('data-theme')` の実在ファイルは contact / deal / serve が `index.ts`、origin が `ThemeProvider.tsx`。**ファイル名は艦ごとに違うがモジュール（ディレクトリ）は共通**なので、条文の語（「テーマモジュール」）に合わせてディレクトリ単位で表現しました。

## プローブ（#118 が明示的に依頼していた形）

`composed-config.probes.test.ts` に5本追加しました（gate-integrity では検出できない合成故障様式のため）。

1. provider の lang 付与は**検知しない**
2. 🔴 **provider でも Intl は検知する**（1ルール丸ごと off にしていないことの確認）
3. テーマモジュールの data-theme 付与・読み取りは**検知しない**
4. 🔴 **テーマモジュールでも JP リテラルは検知する**
5. 🔴 **陽性対照**: 座席の外では lang / data-theme を**今も検知する**（免除が広がっていない）

## 実測

`npm run check` **exit 0** — 31 files / **461 tests** pass ／ `AM-2 release gate: PASS`。

## 出荷後に各艦がやること

payout（#118 の退避）・deal（#130 の退避）の file×rule override を**撤去できます**。同型の provider / テーマモジュールを持つ他艦（vault / records / invoice / contact / serve / origin）も、退避を入れていれば同様に撤去可です。

Closes #118
Closes #130
