### PR TITLE
fix(standards): HTML 埋め込み <style> の不可視領域で green を返さない（#164・Wave 表 218→487 の再実測つき）

### DIFF
--- a/packages/nene2-standards/src/checks/scan-coverage.ts
+++ b/packages/nene2-standards/src/checks/scan-coverage.ts
@@ -8,7 +8,7 @@
  * - 台帳（registries）が与えられない場合は unknown(not-installed) — fail-closed（G-6）。
  */
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import type { RegistriesDocument } from '../registries/schema.js';
@@ -81,6 +81,48 @@ export function enumerateStyleSources(cwd: string): string[] {
   return found.sort();
 }
 
+/**
+ * HTML 埋め込み `<style>` の実測（#164）。
+ *
+ * 現行の**測定経路**（`init --scan` / lint-baseline / run）は `.css` だけを見る。一方 scan-coverage は
+ * `index.html` を `CANONICAL_ALLOWED` で**無条件に allowed** にしていたため、
+ * **埋め込み `<style>` が台帳にも lint にも載らないまま green** になっていた
+ * （＝不可視領域があるのに green・G-6 の現物）。実在例: concierge
+ * `public_html/admin/index.html`（52KB・`<style>` 1ブロック・fleet 実測 2026-07-30）。
+ *
+ * 依存を増やさずに済む範囲で検出する（走査対象としての抽出＝postcss-html 経路は別作業）。
+ * コメント内の `<style` は拾いうるが、**過検出は fail-closed 側に倒れる**ので許容する
+ * （見落として green を返すより安全 — 逆向きの誤りは G-6 違反になる）。
+ */
+export function htmlEmbeddedStyle(cwd: string, rel: string): { blocks: number; lines: number } {
+  let text: string;
+  try {
+    text = readFileSync(path.join(cwd, rel), 'utf8');
+  } catch {
+    return { blocks: 0, lines: 0 };
+  }
+  const re = /<style\b[^>]*>([\s\S]*?)<\/style\s*>/gi;
+  let blocks = 0;
+  let lines = 0;
+  for (const m of text.matchAll(re)) {
+    const body = (m[1] ?? '').trim();
+    if (body === '') continue; // 空 <style> は不可視領域ではない
+    blocks++;
+    lines += body.split('\n').length;
+  }
+  return { blocks, lines };
+}
+
+/** `cwd` 配下の HTML のうち、埋め込み `<style>` を持つもの（#164 の不可視領域の列挙）。 */
+export function htmlEmbeddedStyleSources(
+  cwd: string,
+): Array<{ path: string; blocks: number; lines: number }> {
+  return enumerateStyleSources(cwd)
+    .filter((rel) => rel.endsWith('.html'))
+    .map((rel) => ({ path: rel, ...htmlEmbeddedStyle(cwd, rel) }))
+    .filter((e) => e.blocks > 0);
+}
+
 export interface ScanCoverageOptions {
   cwd: string;
   repo: string;
@@ -113,20 +155,53 @@ export function checkScanCoverage(options: ScanCoverageOptions): KeyState {
     }
   }
 
+  // 測定経路が `.css` だけを見るため、**台帳に載っていても実測できない**領域（#164）。
+  // 「登録されていない」（= red）と「登録されているが測れない」（= unknown）は別物なので分ける。
+  const unmeasurable: string[] = [];
+
   const sources = enumerateStyleSources(cwd);
   for (const rel of sources) {
     if (BANNED_EXT.test(rel)) {
       details.push(`css/html 以外の style 拡張子は即 red（R5(5)）: ${rel}`);
       continue;
     }
-    const allowed =
-      CANONICAL_ALLOWED.some((re) => re.test(rel)) ||
-      manifestPaths.includes(rel) ||
-      widgetEntryFiles.includes(rel);
+    const registered = manifestPaths.includes(rel) || widgetEntryFiles.includes(rel);
+    // 🔴 HTML は**埋め込み `<style>` を持つ限り無条件 allowed にしない**（#164）。
+    // 正準配置（index.html）であっても、中の CSS は台帳にも lint にも載らない。
+    const embedded = rel.endsWith('.html') ? htmlEmbeddedStyle(cwd, rel) : { blocks: 0, lines: 0 };
+    if (embedded.blocks > 0) {
+      if (!registered) {
+        details.push(
+          `HTML 埋め込み <style> が台帳外（${embedded.blocks}ブロック・約${embedded.lines}行）: ${rel}` +
+            ` — 正準配置でも中の CSS は themes / 許可リスト / legacy manifest のいずれにも載らない（#164）`,
+        );
+      } else {
+        // 台帳には載っているが、`.css` しか見ない測定経路では cap も違反数も実測できない。
+        unmeasurable.push(
+          `${rel}（${embedded.blocks}ブロック・約${embedded.lines}行）— 台帳登録済みだが測定経路が .css のみ`,
+        );
+      }
+      continue;
+    }
+    const allowed = CANONICAL_ALLOWED.some((re) => re.test(rel)) || registered;
     if (!allowed) {
       details.push(`台帳外の style ソース（themes ∪ 許可リスト ∪ legacy manifest に不在）: ${rel}`);
     }
   }
 
-  return details.length === 0 ? { state: 'green' } : { state: 'red', details };
+  if (details.length > 0) return { state: 'red', details };
+  // 🔴 不可視領域があるなら green ではなく unknown（fail-closed・G-6）。
+  // 「red が無い」を「全部見えた」と読ませない。
+  if (unmeasurable.length > 0) {
+    return {
+      state: 'unknown',
+      reason: 'not-installed',
+      details: [
+        'HTML 埋め込み <style> を実測できる走査経路が未実装のため green を返さない（#164・G-6）:',
+        ...unmeasurable,
+        '解消条件: postcss-html 経由の抽出を測定経路（init --scan / lint-baseline）に追加すること。',
+      ],
+    };
+  }
+  return { state: 'green' };
 }

--- a/packages/nene2-standards/src/index.ts
+++ b/packages/nene2-standards/src/index.ts
@@ -64,7 +64,11 @@ export {
 } from './checks/conformance.js';
 export type { ConformanceKey, ConformanceVector, KeyState } from './checks/conformance.js';
 export { checkGateIntegrity, canonicalSeverityTable } from './checks/gate-integrity.js';
-export { checkScanCoverage } from './checks/scan-coverage.js';
+export {
+  checkScanCoverage,
+  htmlEmbeddedStyle,
+  htmlEmbeddedStyleSources,
+} from './checks/scan-coverage.js';
 export { initScan, initCheck } from './checks/init-scan.js';
 export { runConformance } from './checks/run.js';
 export {

--- a/packages/nene2-standards/tests/html-embedded-style.test.ts
+++ b/packages/nene2-standards/tests/html-embedded-style.test.ts
@@ -1,0 +1,110 @@
+/**
+ * HTML 埋め込み `<style>` の不可視領域（#164）の回帰テスト。
+ *
+ * 事故形: 測定経路（`init --scan` / lint-baseline / run）は `.css` だけを見るのに、
+ * scan-coverage は `index.html` を無条件 allowed にしていた。**中の CSS は台帳にも lint にも
+ * 載らないまま green** ＝ G-6 の現物（不可視領域があるのに緑）。
+ * 実在例: concierge `public_html/admin/index.html`（52KB・`<style>` 1ブロック・fleet 実測）。
+ *
+ * 「登録されていない（red）」と「登録されているが測れない（unknown）」を分けることが本体なので、
+ * 3状態それぞれを陽性対照つきで固定する。
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { checkScanCoverage, htmlEmbeddedStyle, htmlEmbeddedStyleSources } from '../src/index.js';
+import type { RegistriesDocument } from '../src/registries/schema.js';
+
+const REPO = 'nene-probe';
+const EMPTY: RegistriesDocument = { schema: 'nene2-registries/1', entries: [] };
+
+const withManifest = (rel: string): RegistriesDocument => ({
+  schema: 'nene2-registries/1',
+  entries: [
+    {
+      kind: 'legacy-manifest',
+      id: `${REPO}-legacy-html`,
+      repo: REPO,
+      path: rel,
+      maxLines: 999,
+      maxBytes: 999_999,
+    },
+  ],
+});
+
+let root: string;
+
+function html(body: string): string {
+  return `<!doctype html>\n<html><head>${body}</head><body></body></html>\n`;
+}
+
+beforeAll(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'nene2-html-'));
+  mkdirSync(path.join(root, 'src', 'shared', 'ui', 'theme'), { recursive: true });
+  writeFileSync(path.join(root, 'src', 'shared', 'ui', 'theme', 'index.css'), '@theme {}\n');
+});
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('htmlEmbeddedStyle — 不可視領域の実測', () => {
+  it('埋め込み <style> のブロック数と行数を返す', () => {
+    const dir = mkdtempSync(path.join(root, 'a-'));
+    writeFileSync(
+      path.join(dir, 'index.html'),
+      html('<style>\n.a{color:red}\n.b{color:blue}\n</style><style>.c{}</style>'),
+    );
+    const r = htmlEmbeddedStyle(dir, 'index.html');
+    expect(r.blocks).toBe(2);
+    expect(r.lines).toBeGreaterThanOrEqual(3);
+  });
+
+  it('空の <style> は不可視領域として数えない', () => {
+    const dir = mkdtempSync(path.join(root, 'b-'));
+    writeFileSync(path.join(dir, 'index.html'), html('<style>\n\n</style>'));
+    expect(htmlEmbeddedStyle(dir, 'index.html').blocks).toBe(0);
+  });
+
+  it('埋め込みを持つ HTML だけを列挙する', () => {
+    const dir = mkdtempSync(path.join(root, 'c-'));
+    writeFileSync(path.join(dir, 'index.html'), html('<style>.a{}</style>'));
+    writeFileSync(path.join(dir, 'plain.html'), html('<link rel="stylesheet" href="a.css">'));
+    const list = htmlEmbeddedStyleSources(dir);
+    expect(list.map((e) => e.path)).toEqual(['index.html']);
+  });
+});
+
+describe('checkScanCoverage — 埋め込み <style> を持つ HTML は無条件 allowed にしない（#164）', () => {
+  it('🔴 台帳外なら red（正準配置の index.html でも）', () => {
+    const dir = mkdtempSync(path.join(root, 'd-'));
+    writeFileSync(path.join(dir, 'index.html'), html('<style>.a{color:red}</style>'));
+    const r = checkScanCoverage({ cwd: dir, repo: REPO, registries: EMPTY });
+    expect(r.state).toBe('red');
+    if (r.state === 'red') {
+      expect(r.details.some((d) => d.includes('HTML 埋め込み <style> が台帳外'))).toBe(true);
+    }
+  });
+
+  it('🔴 台帳登録済みでも「測れない」ので green ではなく unknown（G-6）', () => {
+    const dir = mkdtempSync(path.join(root, 'e-'));
+    writeFileSync(path.join(dir, 'index.html'), html('<style>.a{color:red}</style>'));
+    const r = checkScanCoverage({ cwd: dir, repo: REPO, registries: withManifest('index.html') });
+    expect(r.state).toBe('unknown');
+    if (r.state === 'unknown') {
+      expect(r.details?.some((d) => d.includes('green を返さない'))).toBe(true);
+      expect(r.details?.some((d) => d.includes('解消条件'))).toBe(true);
+    }
+  });
+
+  it('🔴 陽性対照: 埋め込みが無ければ従来どおり green（免除が壊れていない）', () => {
+    const dir = mkdtempSync(path.join(root, 'f-'));
+    writeFileSync(path.join(dir, 'index.html'), html('<link rel="stylesheet" href="a.css">'));
+    mkdirSync(path.join(dir, 'src', 'shared', 'ui', 'theme'), { recursive: true });
+    writeFileSync(path.join(dir, 'src', 'shared', 'ui', 'theme', 'index.css'), '@theme {}\n');
+    expect(checkScanCoverage({ cwd: dir, repo: REPO, registries: EMPTY }).state).toBe('green');
+  });
+});


### PR DESCRIPTION
## 事故形（G-6 の現物）

測定経路（`init --scan` / lint-baseline / `run`）は **`.css` だけを見る**（3箇所で `.endsWith('.css')`）のに、scan-coverage は `index.html` を `CANONICAL_ALLOWED` で **無条件 allowed** にしていました。結果、**埋め込み `<style>` が台帳にも lint にも載らないまま green** を返していました。

実在例（fleet 実測・読み取りのみ）: concierge `public_html/admin/index.html` = 52KB・`<style>` 1ブロック・**947行**。

## 直し方 — 「登録されていない」と「登録されているが測れない」を分ける

HTML は**埋め込み `<style>` を持つ限り無条件 allowed にしません**。

| 状態 | 返り値 | 理由 |
|---|---|---|
| 台帳外 | **red** | 既存の補集合検査の意味論そのまま（正準配置の `index.html` でも中の CSS は台帳に載らない） |
| 台帳登録済み | **unknown** | `.css` しか見ない測定経路では cap も違反数も実測できない＝**不可視領域**。fail-closed で green を返さず、解消条件を details に書く |
| 埋め込みなし | **green**（従来どおり） | 不可視領域が無い |

検出は**依存を増やさず**実装しました（`htmlEmbeddedStyle` / `htmlEmbeddedStyleSources` を export）。コメント内の `<style` を拾いうる粗さがありますが、**過検出は fail-closed 側に倒れる**ので許容しています（見落として green を返す方が G-6 違反になるため）。

## Wave 表の誤計上を fleet が独立再実測しました（#164 ②）

concierge の報告値を postcss-html で**再実測し、内訳まで完全一致**を確認しました。

| 対象 | 違反数 | 内訳 |
|---|---|---|
| `admin/app.css`（esbuild **生成物**） | **218** | `no-unlayered-css` 106 / `selector-max-specificity` 55 / `color-no-hex` 43 / `function-disallowed-list` 14 |
| `admin/index.html` の埋め込み `<style>` | **487** | `color-no-hex` 409 / `function-disallowed-list` 49 / `no-unlayered-css` 27 / `selector-max-id` 1 / `selector-max-specificity` 1 |

→ **「218」は生成物の誤計上**でした。Wave の concierge 行は **218 → 487**、W-Layer は **106 → 27**。`_work/issues.md` 項56 へ**追記で訂正**済みです（既存記述は消していません）。

🔴 **他艦も生成物 CSS を数えている可能性があります**（D-2 と同じ母集団なので、横断再点検が必要）。

## テスト6本（陽性対照つき）

ブロック数・行数の実測／空 `<style>` は数えない／埋め込みを持つ HTML だけ列挙／台帳外は red／台帳登録済みは unknown／🔴 **埋め込みが無ければ従来どおり green**（免除が壊れていない）。

## 残（#164 ③④・本 PR の射程外）

- **測定経路への HTML 抽出追加**（postcss-html + `customSyntax`）＝登録済み HTML を unknown から green にできるようにする本命。**cap の意味論**（ファイル全体の行数か `<style>` 部分だけか）に決定が要るので、hub 裁定を待ちます。
- **生成物 CSS をコミットしている艦の横断再点検**（D-2 同乗）。

## 実測

`npm run check` **exit 0** — 32 files / **462 tests** pass ／ `AM-2 release gate: PASS`。

Refs #164
