### PR TITLE
fix(tokens): 複合キーを拡張トークンと認識し、自分の生成物を壊さない（#134・#88）

### DIFF
--- a/packages/nene2-tokens/src/codemod-map.test.ts
+++ b/packages/nene2-tokens/src/codemod-map.test.ts
@@ -392,3 +392,34 @@ describe('FIELD_TABLE — field 語彙表正本化（C part-2・#127）', () => 
     expect(mapTokenName('--color-fg-muted-2', 'field')).toBe('--color-x-fg-muted-2');
   });
 });
+
+describe('classifyTokenName — 自分の生成物を壊さない（#134 / #88）', () => {
+  const nameOf = (r: ReturnType<typeof classifyTokenName>): string | null =>
+    r.kind === 'reject' ? null : r.name;
+
+  it('x- 送り済みの複合キーは no-op（再送りで double-x にしない）', () => {
+    const r = classifyTokenName('--text-x-body--line-height');
+    expect(r.kind).not.toBe('reject');
+    expect(nameOf(r)).toBe('--text-x-body--line-height');
+  });
+
+  it('複合キーの x- 送りは 2巡目で不動（冪等）', () => {
+    const first = nameOf(classifyTokenName('--text-lg--line-height'));
+    expect(first).toBe('--text-x-lg--line-height');
+    expect(nameOf(classifyTokenName(first as string))).toBe(first);
+  });
+
+  it('🔴 x- 送りの結果が不正な名前になるなら reject（発明せず止める）', () => {
+    const r = classifyTokenName('--text-x-body---line-height');
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') {
+      expect(r.reason).toContain('not a valid extension token name');
+    }
+  });
+
+  it('🔴 陽性対照: 未知 namespace は従来どおり reject（#92 の (i)reject が生きている）', () => {
+    for (const t of ['--space-x-nav-w', '--r-x-base']) {
+      expect(classifyTokenName(t).kind).toBe('reject');
+    }
+  });
+});

--- a/packages/nene2-tokens/src/codemod-map.ts
+++ b/packages/nene2-tokens/src/codemod-map.ts
@@ -497,7 +497,25 @@ export function classifyTokenName(
     const key = name.slice(`--${ns}-`.length);
     // キーが空（`--font-` のような末尾ハイフン名）は写像を発明せず reject へ落とす。
     // 旧実装の `(.+)` が担っていた非空要件をここで保つ（fail-closed の維持）。
-    if (key !== '') return { kind: 'rename', name: `--${ns}-x-${key}` };
+    if (key !== '') {
+      const renamed = `--${ns}-x-${key}`;
+      // 🔴 **自分の検査器が拒否する名前を出さない**（#134 / #88 同族の一般形）。
+      // x- 送りの結果が拡張トークン名として不正なら、そのまま出すと
+      // ①generate / validate がその名前を refuse する（extract と generate の自己矛盾）
+      // ②再実行で更に x- が積まれる（double-x・非冪等）
+      // のどちらかになる。実測（2026-07-30）: `--text-x-body---line-height` のような不正キーは
+      // 旧実装で `--text-x-x-body---line-height` を生成していた。発明せず reject へ落とす。
+      if (!isExtensionTokenName(renamed)) {
+        return {
+          kind: 'reject',
+          reason:
+            `cannot x-send ${name} — the result ${renamed} is not a valid extension token name ` +
+            `(key must be [a-z0-9-] segments with at most one '--' compound separator; ` +
+            `no invented names: the codemod must not emit a name its own checker rejects)`,
+        };
+      }
+      return { kind: 'rename', name: renamed };
+    }
   }
 
   // 7. 未知 namespace・単一セグメント等の未知名 — 発明せず reject（(i)reject・C part-1 #92）

--- a/packages/nene2-tokens/src/contract.test.ts
+++ b/packages/nene2-tokens/src/contract.test.ts
@@ -114,3 +114,25 @@ describe('#49 — 生成側の出力を検査側が受理する（道具が自�
     }
   });
 });
+
+describe('isExtensionTokenName — 複合キー（#134 / #88 同族）', () => {
+  it('x- 送り済みの複合キーを拡張トークンとして受理する（道具が自分の生成物を認識する）', () => {
+    expect(isExtensionTokenName('--text-x-body--line-height')).toBe(true);
+    expect(isExtensionTokenName('--text-x-body--letter-spacing')).toBe(true);
+  });
+
+  it('単純キーは従来どおり受理する（回帰なし）', () => {
+    expect(isExtensionTokenName('--text-x-body')).toBe(true);
+    expect(isExtensionTokenName('--font-weight-x-medium')).toBe(true);
+  });
+
+  it('🔴 区切りを発明しない: `---` / 末尾 `--` / 2回以上の複合は受理しない', () => {
+    expect(isExtensionTokenName('--text-x-body---line-height')).toBe(false);
+    expect(isExtensionTokenName('--text-x-body--')).toBe(false);
+    expect(isExtensionTokenName('--text-x-a--b--c')).toBe(false);
+  });
+
+  it('🔴 namespace は表の実在名のみ（複合キーでも緩めない）', () => {
+    expect(isExtensionTokenName('--space-x-nav--w')).toBe(false);
+  });
+});

--- a/packages/nene2-tokens/src/contract.ts
+++ b/packages/nene2-tokens/src/contract.ts
@@ -146,9 +146,19 @@ export function tailwindNamespaceOf(token: string): string | null {
  * 手書きの正規表現に戻さないこと: #49 まで cat 部を `[a-z][a-z0-9]*` と独自に決めていたため
  * multi-segment namespace（`font-weight`）を弾き、**#35 が是正した生成側の出力 `--font-weight-x-medium`
  * を検査側が拒否していた**（道具が自分の生成物を拒否する）。表から導出すれば構造的に追随する。
+ *
+ * 🔴 **複合キー**（Tailwind v4 の `--text-<key>--line-height` 形）も受理する（#134 / #88 同族）。
+ * 受理していなかったため、**x- 送り済みの複合キーが「拡張トークンではない」と判定され、
+ * codemod が x- を再挿入して double-x に壊していた**（実測 2026-07-30）:
+ *   `--text-x-body--line-height` → isExtensionTokenName=false → `--text-x-x-body--line-height`
+ * その名前は当然どこにも属さないので generate が refuse する ＝ **extract と generate の自己矛盾**
+ * （#134 の症状）として現れていた。根は「道具が自分の生成物を認識できない」＝#49/#35 と同型。
+ *
+ * 区切りは `--`（2連ハイフン）ちょうど1回まで。`---` や末尾 `--` は受理しない（発明しない）。
  */
+const EXT_KEY = String.raw`[a-z0-9]+(?:-[a-z0-9]+)*`;
 export const EXTENSION_TOKEN_PATTERN = new RegExp(
-  `^--(${TAILWIND_V4_NAMESPACES.join('|')})-x-([a-z0-9]+(?:-[a-z0-9]+)*)$`,
+  `^--(${TAILWIND_V4_NAMESPACES.join('|')})-x-(${EXT_KEY}(?:--${EXT_KEY})?)$`,
 );
 
 /**


### PR DESCRIPTION
## 実測した因果 — #134 の「extract と generate の自己矛盾」は #88 と同じ根でした

`EXTENSION_TOKEN_PATTERN` が Tailwind v4 の**複合キー**（`--text-<key>--line-height` 形）を受理していませんでした。そのため:

1. `isExtensionTokenName('--text-x-body--line-height')` = **false**（x- 送り済みなのに未知扱い）
2. → step 6 が x- を**再挿入**して `--text-x-x-body--line-height`（**double-x**・非冪等）
3. → その名前はどこにも属さないので `generate` が refuse ＝ **extract が出したものを generate が拒否する**（#134 の症状）

つまり **#134 は #88（double-x で自分の生成物を壊す）と同一の根**でした。#49 / #35 の「道具が自分の生成物を拒否する」の3例目です。

## 直したこと

**1. `EXTENSION_TOKEN_PATTERN` が複合キーを受理する。** 区切りは `--` **ちょうど1回まで**（`---` / 末尾 `--` / 2回以上は受理しない＝発明しない）。namespace は従来どおり**表の実在名のみ**です。

**2. step 6 に「自分の検査器が拒否する名前を出さない」不変条件を追加。** x- 送りの結果が拡張トークン名として不正なら **reject**（発明せず止める）。旧実装は不正キーに対しても double-x 名を黙って生成していました。

## 実測（before → after）

| 入力 | before | after |
|---|---|---|
| `--text-x-body--line-height` | rename → `--text-x-x-body--line-height`（double-x） | **no-op**（冪等） |
| `--text-lg--line-height` を2巡 | 2巡目で double-x | 1巡目 `--text-x-lg--line-height`・**2巡目 不動** |
| `--text-x-body---line-height` | rename → double-x | **reject**（理由つき） |
| #134 の round-trip（`extract` → `generate`） | 🔴 refuse | 🟢 **generate OK** |
| `--space-x-nav-w` / `--r-x-base`（#88 の実測ケース） | — | **reject 維持** |

## #88 / #92 の現況について（棚卸し）

#88 が根治として求めていた「step 6 の x- 送りは v4 表に実在する namespace に限定し、表に無い未知名は reject」は、**すでに実装されていました**（`tailwindNamespaceOf` は未知で `null`・step 7 で reject）。#88 の実測ケース（`--space-x-nav-w` / `--r-x-base`）を測って確認しました。

ただし **#88 の本体（double-x で自分の生成物を壊す）は複合キー経路に残っていた**ので、本 PR がそれを閉じます。回帰テストも #88 のケースを陽性対照として入れました（`#92` の (i)reject が生きていることをテストで固定）。

→ **#92（(i)reject 実装本体）は実装済みと見えます**が、受入条件の確認は別途必要なので本 PR では触っていません（open 維持）。

## テスト9本（陽性対照つき）

`contract.test.ts` 4本（複合キー受理／単純キー回帰なし／区切りを発明しない／namespace は表のみ）＋ `codemod-map.test.ts` 5本（no-op／2巡目不動＝冪等／不正なら reject／**未知 namespace の reject 維持**）。

## 実測

`npm run check` **exit 0** — 31 files / **464 tests** pass ／ `AM-2 release gate: PASS`。**契約キー集合は不変**（凍結記録と一致）。

Closes #134
Closes #88
