### PR TITLE
fix(seam): 型検査テストに明示 timeout — 既定 5000ms は余裕2倍で負荷下に溢れる（#156）

### DIFF
--- a/docs/seam/recover-auth-v1.test.ts
+++ b/docs/seam/recover-auth-v1.test.ts
@@ -16,20 +16,36 @@ function extractTsBlocks(md: string): string[] {
   return [...md.matchAll(/```ts\n([\s\S]*?)```/g)].map((m) => m[1] ?? '');
 }
 
+const fileName = '/virtual/spec.ts';
+
+// モジュールスコープの定数。lib SourceFile キャッシュのキーが name+target だけで足りるのは、
+// 全 typecheck() 呼び出しがこの同一 options を使うため（options を可変にするならキーも見直すこと）。
+const options: ts.CompilerOptions = {
+  strict: true,
+  noEmit: true,
+  target: ts.ScriptTarget.ES2022,
+  types: [],
+};
+
+// typecheck() の所要はほぼ全部が lib d.ts の読み込み（#156 実測: createProgram 1回あたり
+// 約 0.8〜1.0 秒）。仮想ファイル以外は呼び出しをまたいで同一なので SourceFile を使い回す。
+const libSourceFiles = new Map<string, ts.SourceFile | undefined>();
+
 function typecheck(source: string): string[] {
-  const fileName = '/virtual/spec.ts';
-  const options: ts.CompilerOptions = {
-    strict: true,
-    noEmit: true,
-    target: ts.ScriptTarget.ES2022,
-    types: [],
-  };
   const host = ts.createCompilerHost(options);
   const getSourceFile = host.getSourceFile.bind(host);
-  host.getSourceFile = (name, languageVersion, ...rest) =>
-    name === fileName
-      ? ts.createSourceFile(name, source, ts.ScriptTarget.ES2022, true)
-      : getSourceFile(name, languageVersion, ...rest);
+  host.getSourceFile = (name, languageVersion, ...rest) => {
+    if (name === fileName) {
+      return ts.createSourceFile(name, source, ts.ScriptTarget.ES2022, true);
+    }
+    const target =
+      typeof languageVersion === 'object' ? languageVersion.languageVersion : languageVersion;
+    const key = `${name}::${target}`;
+    if (!libSourceFiles.has(key)) {
+      libSourceFiles.set(key, getSourceFile(name, languageVersion, ...rest));
+    }
+    return libSourceFiles.get(key);
+  };
   const fileExists = host.fileExists.bind(host);
   host.fileExists = (name) => name === fileName || fileExists(name);
   const program = ts.createProgram([fileName], options, host);
@@ -38,8 +54,14 @@ function typecheck(source: string): string[] {
     .map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'));
 }
 
+// TypeScript コンパイラをテストプロセス内で起動するため、vitest 既定の 5000ms では
+// 負荷下（npm run check の直列実行で type-check→lint→format:check の後に回る）に落ちる。
+// #156 実測: 単体 1.8 秒 / check 経由で 4回中2回タイムアウト。上限は明示的に与える
+// （リポ全体の testTimeout 引き上げは本物のハングを見逃すので採らない）。
+const TYPECHECK_TIMEOUT_MS = 30_000;
+
 describe('seam 仕様 v1（recoverAuth）— 仕様書の機械検査', () => {
-  it('§1 interface 定義ブロックが型検査を通る', () => {
+  it('§1 interface 定義ブロックが型検査を通る', { timeout: TYPECHECK_TIMEOUT_MS }, () => {
     const blocks = extractTsBlocks(spec);
     expect(blocks.length).toBeGreaterThanOrEqual(1);
     for (const block of blocks) {
@@ -47,9 +69,13 @@ describe('seam 仕様 v1（recoverAuth）— 仕様書の機械検査', () => {
     }
   });
 
-  it('故意 fail: 壊れた TS は検査器が検知する（検査器の空虚合格防止）', () => {
-    expect(typecheck('export type Broken = (x: Missing) => Nope;').length).toBeGreaterThan(0);
-  });
+  it(
+    '故意 fail: 壊れた TS は検査器が検知する（検査器の空虚合格防止）',
+    { timeout: TYPECHECK_TIMEOUT_MS },
+    () => {
+      expect(typecheck('export type Broken = (x: Missing) => Nope;').length).toBeGreaterThan(0);
+    },
+  );
 
   it('config キーは recoverAuth 1個のみ・経路除外 config の不在が明文', () => {
     expect(spec).toContain('config キーは **`recoverAuth` 1個のみ**');


### PR DESCRIPTION
## なぜ

`docs/seam/recover-auth-v1.test.ts` の型検査テストが、`npm run check` 経由（＝負荷下）で vitest 既定の 5000ms を超えて落ちる。#156 の実測で **4回中2回・50% 再現**（`npm test` 単体では 4回中0回）。

テスト側の書き方の問題ではなく、**テストプロセス内で TypeScript コンパイラを起動しているのに上限が既定の 5000ms のまま**という設計上の問題（#156 本文）。

## 何をしたか

### ① 明示 timeout（30秒）— これがフレークを止める本体

`typecheck()` を呼ぶ2本に `{ timeout: 30_000 }` を付けた。`vitest.config.ts` の `testTimeout` をリポ全体で引き上げる案は**採らない**（#156 の指摘どおり、本物のハングを見逃す方向に効く）。

### ② lib SourceFile のモジュールスコープ・キャッシュ

`ts.createCompilerHost()` は呼び出しのたびに lib d.ts を読み直す。仮想ファイル以外は全呼び出しで同一なので `SourceFile` を使い回す。

## 🔴 #156 の提案3は前提が成り立たなかった（[実測コメント](https://github.com/hideyukiMORI/nene2-fleet-tooling/issues/156#issuecomment-5139861117)）

提案3「program 生成を describe 単位で1回に集約」は**採れない**。実測で:

- 仕様書の ts ブロックは **1個**（`grep -c '^```ts$'` = 1）＝ §1 テストのループは1周しかせず、まとめる対象が無い。
- `typecheck()` を呼ぶ2本は **有効な TS と壊れた TS**を検査する。後者は検査器の空虚合格を防ぐ**陽性対照**なので、program をまとめると対照が消える。
- 共有できる本体は program ではなく **lib d.ts の読み込み**だった → ②へ読み替えて採用。

## 実測

### キャッシュの効果（同一マシン・変更前後3回ずつ・`tests` 時間）

| | 1 | 2 | 3 | 中央値 |
| --- | --- | --- | --- | --- |
| 変更前 | 2.24s | 1.83s | 1.85s | **1.85s** |
| 変更後 | 1.55s | 1.68s | 1.65s | **1.65s** |

**約 11% 短縮**にとどまる。個別では 故意 fail テストが 791ms → 524ms（キャッシュが温まった2本目に効く）。**劇的ではない — フレークを止めているのは ① であって ② ではない。**

### 負荷下の実測（`npm run check` 経由・§1 テストの所要）

| 経路 | §1 の所要 |
| --- | --- |
| 単体（`npx vitest run <file>`） | **0.98s** |
| `npm run check` 経由 4回 | **2.25s / 2.27s / 2.25s / 2.39s** |

負荷で **2.3倍に伸びる**ことを実測で確認（#156 の原因分析どおり）。既定 5000ms に対する余裕は **2.2倍**しかなく、これが 07-29 に 50% で溢れた。30秒なら余裕 **13倍**。

### 🔴 「修正後4回 green」は再発しない証明になっていない（陰性対照つき）

修正後 `npm run check` **4回すべて exit 0 / 517 tests passed**。ただしこれだけでは意味がないので、**main 版（未修正）でも同じ4回**を回した:

| 版 | check 4回の結果 | §1 の所要 |
| --- | --- | --- |
| **修正後**（本 PR） | 4/4 exit 0・517 tests passed | 2247 / 2270 / 2254 / 2394 ms |
| **main 版（未修正・陰性対照）** | **4/4 exit 0** | 2398 / 2469 / 2017 / 2149 ms |

🔴 **未修正版も今日は4回とも通った。**＝ 今日のこのマシンの負荷条件では 07-29 の失敗が再現せず、**「修正後4回 green」は判別力を持っていない**（修正の有無で結果が変わらないので、green は修正の効果の証拠になっていない）。

**この PR の根拠は 4回 green ではなく余裕の量**である:

| | 上限 | 負荷下の実測 | 余裕 |
| --- | --- | --- | --- |
| 変更前 | 5,000ms | 2.0〜2.5s | **2.0〜2.5倍** |
| 変更後 | 30,000ms | 2.0〜2.4s | **12〜15倍** |

07-29 は同じ 2.0〜2.5倍の余裕で 50% 溢れた。上限を上げた分だけ確実に余裕が増える、というのが主張のすべてで、それ以上は今日のデータからは言えない。

## 変更していないもの

- `vitest.config.ts` 無変更・`packages/*` 無変更（配布物に影響なし＝**publish 不要**）。
- 陽性対照は**既存の「故意 fail」テストをそのまま使う**（新規に足していない）。これはキャッシュが温まった状態で走り、壊れた TS に診断が出ることを要求するので、**キャッシュが診断を殺していれば必ず落ちる**。

## クローズ条件（#156 本文の作法）

> フレークを直したら、直後の1回ではなく**その後の実 CI 実行**で再発を監視する。「ローカル N 回 green」は必要条件であって十分条件ではない。

🔴 **意図的に `Closes` キーワードを使っていない**（hub 裁定 (a)・2026-07-31）。closing keyword ＋ issue 番号を本文に書くとマージ時に自動クローズされ、**観測する前に閉じてしまう**ため。#160（closing keyword で Issue が閉じ残る判例）を扱っている当のリポで、逆向きに「観測前に閉じる」のは筋が通らない。

（本文と commit message のどちらにも closing keyword ＋ 番号を置いていない。squash マージでは commit message も merge commit の本文に入るので、**両方から外さないと自動クローズは止まらない**。）

**手順**: この PR がマージされた後、main の CI 実行を**複数回観測**し、再発が無いことを確認してから **#156 を手動クローズ**する（観測結果を #156 にコメントで残す）。

Refs #156
