### PR TITLE
feat(tokens): 取り残される var(--old) 参照を開示する（#132）

### DIFF
--- a/packages/nene2-tokens/src/cli.ts
+++ b/packages/nene2-tokens/src/cli.ts
@@ -12,14 +12,14 @@
  *   nene2-tokens map                                          # CODEMOD_MAP_V1 を JSON で出力
  *   nene2-tokens codemod-plan --theme <theme.css> [--map <table>]
  *                                                             # 写像表から導出した rename 計画（stdout）
- *   nene2-tokens codemod --theme <theme.css> [--map <table>] [--check] <path...>
+ *   nene2-tokens codemod --theme <theme.css> [--map <table>] [--check] [--scan-css <dir|file>[,…]] <path...>
  *                                                             # TSX/TS の class・var(--) 位置を書き換え
  *
  * 終了コード: 0 = green / 1 = 違反あり / 2 = 検査不能（fail-closed — unknown は green ではない）
  */
 
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import jscodeshift from 'jscodeshift';
 import { CONTRACT_TOKENS } from './contract.js';
 import { validateThemeSource, type ValidateOptions } from './validate.js';
@@ -36,6 +36,7 @@ import {
   CodemodError,
   buildPlan,
   buildRenameIndex,
+  danglingVarReferences,
   reentrantRenames,
   type CodemodPlan,
 } from './codemod.js';
@@ -51,7 +52,14 @@ function parseArgs(argv: string[]): Parsed {
   const [command = 'help', ...rest] = argv;
   const flags = new Map<string, string | true>();
   const files: string[] = [];
-  const valued = new Set(['--parent', '--map', '--container-selector', '--theme', '--ext']);
+  const valued = new Set([
+    '--parent',
+    '--map',
+    '--container-selector',
+    '--theme',
+    '--ext',
+    '--scan-css',
+  ]);
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i]!;
     if (a.startsWith('--')) {
@@ -245,6 +253,44 @@ function main(): void {
       }
       for (const u of plan.unmapped) {
         console.log(`WARN  no class rename derived for ${u.from} → ${u.to}: ${u.reason}`);
+      }
+
+      // #132: この codemod は既定で .ts/.tsx しか書き換えないので、CSS に残った var(--old) は
+      // 未定義参照になる。CSS はエラーを出さず宣言ごと破棄するため型検査も lint も通る。
+      // 開示のみ（fail しない）— 手当は製品側。
+      const scanCssFlag = flags.get('--scan-css');
+      if (typeof scanCssFlag === 'string') {
+        const cssSources: { file: string; text: string }[] = [];
+        const themePath = resolve(String(flags.get('--theme')));
+        for (const root of scanCssFlag.split(',')) {
+          for (const file of walkSources(root, ['.css'])) {
+            // テーマ自身は codemod-generate 経路で移行されるので dangle ではない
+            if (resolve(file) === themePath) continue;
+            cssSources.push({ file, text: read(file) });
+          }
+        }
+        if (cssSources.length === 0) {
+          console.log(`NOTE  --scan-css '${scanCssFlag}' matched no .css file — nothing scanned.`);
+        } else {
+          const dangling = danglingVarReferences(index, cssSources);
+          for (const d of dangling) {
+            const kind = d.hasFallback ? 'silently falls back' : 'drops the declaration';
+            console.log(
+              `WARN  ${d.file}:${d.line} var(${d.token}) → ${d.to} is renamed but this file is not rewritten (${kind}).`,
+            );
+          }
+          console.log(
+            `scan-css — ${cssSources.length} file(s), ${dangling.length} dangling var() reference(s)`,
+          );
+        }
+      } else {
+        // 沈黙を「CSS は健全」と読ませない（G-6）
+        console.log(
+          'NOTE  CSS was NOT scanned. var(--old) left in CSS becomes an undefined reference and no gate catches it.',
+        );
+        console.log(
+          '      Pass --scan-css <dir|file>[,…] to have them disclosed (fleet-tooling#132).',
+        );
       }
       if (index.size === 0) {
         console.log('codemod — nothing to rename (theme is already on contract vocabulary)');

--- a/packages/nene2-tokens/src/codemod.test.ts
+++ b/packages/nene2-tokens/src/codemod.test.ts
@@ -11,6 +11,7 @@ import {
   buildRenameIndex,
   buildRenameRegex,
   collectDeclaredTokenNames,
+  danglingVarReferences,
   deriveClassRenames,
   namespaceOf,
   reentrantRenames,
@@ -294,6 +295,63 @@ describe('reentrantRenames — 2 回撃つと壊れる対の開示（#17 の字�
 
   it('reports nothing re-entrant when no target is itself a source', () => {
     expect(reentrantRenames(new Map([['a', 'b']]))).toEqual([]);
+  });
+});
+
+describe('danglingVarReferences — apply が触らない CSS に残る var(--old) の開示（#132）', () => {
+  const index = buildRenameIndex(buildPlan(payoutMappable, 'common'));
+  // 索引に実在する token rename を1本、テストの前提として固定する（前提が崩れたら気づけるように）
+  const [sampleToken, sampleTo] = [...index.entries()].find(([k]) => k.startsWith('--'))!;
+
+  it('reports a fallback-less var(--old) left in a file the codemod does not rewrite', () => {
+    const found = danglingVarReferences(index, [
+      { file: 'src/index.css', text: `.a { color: var(${sampleToken}); }` },
+    ]);
+    expect(found).toEqual([
+      { file: 'src/index.css', line: 1, token: sampleToken, to: sampleTo, hasFallback: false },
+    ]);
+  });
+
+  it('reports var(--old, fallback) too, flagged — it silently switches to the fallback', () => {
+    const found = danglingVarReferences(index, [
+      { file: 'a.css', text: `.a { color: var(${sampleToken}, red); }` },
+    ]);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.hasFallback).toBe(true);
+  });
+
+  it('reports the 1-based line and finds multiple refs on one line', () => {
+    const text = `/* head */\n.a { color: var(${sampleToken}); border-color: var(${sampleToken}); }`;
+    const found = danglingVarReferences(index, [{ file: 'a.css', text }]);
+    expect(found).toHaveLength(2);
+    expect(found.every((d) => d.line === 2)).toBe(true);
+  });
+
+  it('ignores var() references to tokens that are not being renamed（誤報しない）', () => {
+    const found = danglingVarReferences(index, [
+      { file: 'a.css', text: '.a { color: var(--not-in-the-plan-at-all); }' },
+    ]);
+    expect(found).toEqual([]);
+  });
+
+  it('ignores class-rename keys — only `--` token keys are var() referable', () => {
+    // 索引には class rename（`gap-inline-sm` 等）も入っている。var(gap-inline-sm) は CSS として
+    // 無効なので拾ってはいけない（VAR_REF_RE が `--` 始まりだけを見ることの固定）。
+    const classKey = [...index.keys()].find((k) => !k.startsWith('--'))!;
+    expect(
+      danglingVarReferences(index, [{ file: 'a.css', text: `.a { x: var(${classKey}); }` }]),
+    ).toEqual([]);
+  });
+
+  it('refuses an empty scan — 走査対象ゼロで「dangle なし」を返さない（G-6）', () => {
+    expect(() => danglingVarReferences(index, [])).toThrow(CodemodError);
+  });
+
+  it('故意 fail: 検出器が生きていることの陽性対照（索引が空なら何も出ない）', () => {
+    // 索引を空にすると同じ入力で 0 件になる＝上の検出は索引に依存している（空虚合格の防止）
+    const text = `.a { color: var(${sampleToken}); }`;
+    expect(danglingVarReferences(new Map(), [{ file: 'a.css', text }])).toEqual([]);
+    expect(danglingVarReferences(index, [{ file: 'a.css', text }])).toHaveLength(1);
   });
 });
 

--- a/packages/nene2-tokens/src/codemod.ts
+++ b/packages/nene2-tokens/src/codemod.ts
@@ -333,6 +333,72 @@ export function reentrantRenames(index: ReadonlyMap<string, string>): readonly R
   return out;
 }
 
+/** apply が触らない CSS に取り残される `var(--old)` 参照（rename 後に未定義参照になる）。 */
+export interface DanglingVarRef {
+  /** 呼び出し側が付けた出所ラベル（ファイルパス等）。 */
+  readonly file: string;
+  /** 1 始まりの行番号。 */
+  readonly line: number;
+  /** 参照されている改名元トークン（`--font-sans`）。 */
+  readonly token: string;
+  /** 改名先（`--font-x-sans`）。 */
+  readonly to: string;
+  /**
+   * `var(--old, fallback)` の形か。
+   *
+   * **fallback 付きも報告する**（除外しない）。無い場合は宣言ごと破棄されて壊れ方が目に見えるが、
+   * **有る場合は黙って fallback 値へ切り替わる**（＝壊れたことが見えない）。開示の価値はむしろ後者が高い。
+   */
+  readonly hasFallback: boolean;
+}
+
+/** `var(` の直後のトークン名と、その次の非空白1文字（`,` なら fallback あり）。 */
+const VAR_REF_RE = /var\(\s*(--[A-Za-z0-9_-]+)\s*([,)])/g;
+
+/**
+ * **取り残される `var(--old)` 参照**を洗い出す（`reentrantRenames` と同型の開示関数）。
+ *
+ * トークンを x- 化すると、テーマ側は codemod が書き換えるが、**apply の対象外にある CSS に残った
+ * `var(--old)` は未定義参照（dangle）になる**。CSS は未定義の `var()` でエラーを出さず、宣言ごと
+ * 破棄して継承値で描画するため、型検査・lint・テストのいずれも通る（field W1 実測: `index.css` の
+ * `var(--font-sans)` 1 件が dangle し、grep で見つけて手当した — fleet-tooling#132）。
+ *
+ * **fail ではなく開示**である（#132 の指定）: 手当は製品側の仕事で、codemod は「どこが外れるか」を
+ * 見せる責任だけを負う。呼び出し側は結果を warning として出す。
+ *
+ * @param index    `buildRenameIndex(plan)` の索引。`--` 始まりのキー（token rename）だけを見る。
+ * @param sources  **apply が書き換えないファイル**を呼び出し側が選んで渡す。テーマ自身や、
+ *                 apply 対象に含めた CSS を渡すと「これから直る参照」を dangle として誤報する。
+ * @throws CodemodError `sources` が空のとき（G-6: 走査対象ゼロで「dangle なし」を返さない）。
+ */
+export function danglingVarReferences(
+  index: ReadonlyMap<string, string>,
+  sources: readonly { readonly file: string; readonly text: string }[],
+): readonly DanglingVarRef[] {
+  if (sources.length === 0) {
+    throw new CodemodError(
+      'no sources to scan — refusing to report "no dangling refs" from an empty scan ' +
+        '(G-6: 検査不能は green ではない)',
+    );
+  }
+  const out: DanglingVarRef[] = [];
+  for (const { file, text } of sources) {
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!;
+      VAR_REF_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = VAR_REF_RE.exec(line)) !== null) {
+        const token = m[1]!;
+        const to = index.get(token);
+        if (to === undefined) continue;
+        out.push({ file, line: i + 1, token, to, hasFallback: m[2] === ',' });
+      }
+    }
+  }
+  return out;
+}
+
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/packages/nene2-tokens/src/index.ts
+++ b/packages/nene2-tokens/src/index.ts
@@ -73,6 +73,7 @@ export {
   buildRenameIndex,
   buildRenameRegex,
   collectDeclaredTokenNames,
+  danglingVarReferences,
   deriveClassRenames,
   namespaceOf,
   reentrantRenames,
@@ -81,6 +82,7 @@ export type {
   ApplyResult,
   ClassRenameResult,
   CodemodPlan,
+  DanglingVarRef,
   Rename,
   UnmappedRename,
 } from './codemod.js';


### PR DESCRIPTION
## なぜ

トークンを x- 化（`--font-sans` → `--font-x-sans`）すると、テーマ側は codemod が書き換えます。しかし **codemod は既定で `.ts` / `.tsx` しか触らない**ので、**CSS に残った `var(--font-sans)` は未定義参照（dangle）になります**。

CSS は未定義の `var()` でエラーを出さず、**宣言ごと破棄して継承値で描画する**ため、**型検査も lint もテストも通ります**。field W1 の実走で `index.css` の `var(--font-sans)` 1件が dangle し、grep で見つけて手当したのが #132 です。

＝ **「導入 ≠ 実行」ガード族（#161）の tokens 版**: codemod は「改名した」ことは保証しますが、「参照が解決する」ことは検査していませんでした。serve 由来の **EX-1（TC-x・トークン参照の解決性）が製品側で言っていることを、道具の側で言った形**です。

## 何をしたか

### ① `danglingVarReferences(index, sources)` — `reentrantRenames` と同型の開示用純関数

#132 の提案（「reentrantRenames の開示と同型」）どおりの形にしました。**fail ではなく warning で開示**し、手当は製品側（issue の指定）。

```ts
export function danglingVarReferences(
  index: ReadonlyMap<string, string>,
  sources: readonly { readonly file: string; readonly text: string }[],
): readonly DanglingVarRef[]
```

### ② 🔴 `var(--old, fallback)` も報告する（除外しない）

判断が要ったところなので明記します。

| | 起きること | 見え方 |
|---|---|---|
| `var(--old)` | 宣言ごと破棄され継承値で描画 | 壊れ方が**目に見える** |
| **`var(--old, red)`** | **黙って fallback 値へ切り替わる** | **壊れたことが見えない** |

**開示の価値はむしろ後者が高い**ので、除外せず `hasFallback` で区別して両方出します。

⚠️ **serve 由来の TC-x（#161）は fallback 付き参照を「対象外」としています**が、**問いが違います**。TC-x は「**未宣言**のトークンを参照していないか」で、fallback がその契約になっている設計（`var(--pct, 0%)` を実行時にインライン供給する等）を弾かないための除外です。本件は「**存在していたトークンが改名される**」ので、fallback 付きは**黙って値が変わる**側になります。条文が矛盾して見えないよう、この差はコメントに書いてあります。

### ③ 空走査の拒否（G-6）

`sources` が空なら `CodemodError`。**走査対象ゼロで「dangle なし」を返しません**（`collectDeclaredTokenNames` の既存ガードと同じ形）。

### ④ CLI `--scan-css <dir|file>[,…]`

テーマ自身は `extract → generate` 経路で移行されるので**除外**します（誤報防止）。

🔴 **`--scan-css` を渡さなかった場合は「CSS は走査していない」と明示します。** 沈黙を「CSS は健全」と読ませないためで、これは #164（不可視領域があるのに green を返す）で踏んだのと同じ型です。

## 実測

### end-to-end（ビルド済み CLI で実行）

改名対象 `--color-accent-contrast → --color-on-accent` に対し、`src/index.css` に3種類の参照を置いて実行:

```
WARN  …/src/index.css:1 var(--color-accent-contrast) → --color-on-accent is renamed but this file is not rewritten (drops the declaration).
WARN  …/src/index.css:2 var(--color-accent-contrast) → --color-on-accent is renamed but this file is not rewritten (silently falls back).
scan-css — 1 file(s), 2 dangling var() reference(s)
```

- fallback の有無を**撃ち分けている**
- 3行目に置いた `var(--never-renamed)` は**報告されない**（誤報なし）

`--scan-css` 無しの場合:
```
NOTE  CSS was NOT scanned. var(--old) left in CSS becomes an undefined reference and no gate catches it.
      Pass --scan-css <dir|file>[,…] to have them disclosed (fleet-tooling#132).
```

### テスト

**7本追加**（`npm run check` exit 0・**35 files / 524 tests**・AM-2 PASS）。うち1本は**陽性対照**です:

> 索引を空にすると同じ入力で 0 件になる ＝ 上の検出が索引に依存していることの固定（空虚合格の防止）

class rename キー（`gap-inline-sm` 等）を `var()` で拾わないことも固定しました（`var(gap-inline-sm)` は CSS として無効なので、拾ったら誤報になります）。

## 配布

**tokens 1.3.0 便**（レーン1・standards とは別便＝hub 裁定済み）。**本 PR では版を上げていません** — bump / publish は施主の縫い目なので、#133 と揃えてから一度で出す想定です。

Closes #132
