### PR TITLE
ci(check): 週次の定期再検査と依存脆弱性ゲートを自艦へ導入（#255・玉1の素振り／lockfile のみで high 4・moderate 1 を全閉）

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,27 @@ on:
   push:
     branches: [main]
   pull_request:
+  # 定期再検査（#255）。push 契機だけだと「誰も触らない週は何も検査されない」状態になり、
+  # 艦の健全性が「最近誰かが作業したか」に依存してしまう。advisory は我々のコミットではなく
+  # 向こう側の時計で公開されるので、`main` がまだ緑かどうかを push から切り離す必要がある。
+  #
+  # 実測（2026-08-09・hub）: 週次 schedule を持つのはフリート25リポ中 origin 1つだけだった。
+  # このリポ自身も持っておらず、しかも走査の述語（`nene-*`）にマッチしないため
+  # **その1艦のカウントにも入っていなかった**。
+  #
+  # 月曜 00:00 UTC = 09:00 JST（稼働週の頭）。参照実装 = nene-origin #412。
+  schedule:
+    - cron: '0 0 * * 1'
+  # schedule を待たずに手で叩くための口。これが無いと「配ったこと自体を検証できない」。
+  workflow_dispatch:
+
+# 同じ ref への連続 push で古い run を畳む。
+# 🔴 group に `github.event_name` を含めるのが要点: 含めないと schedule / workflow_dispatch の run が
+# main への push と同じ group に入り、**push に cancel される**。
+# 「設定したのに走らない」という最も質の悪い失敗になる（origin が実装時に踏んだ罠）。
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   check:
@@ -20,3 +41,15 @@ jobs:
       - run: npm run format:check
       - run: npm run test
       - run: npm run check:cli
+      # 依存脆弱性ゲート（#255）。設定・例外の作法は `audit-ci.jsonc` の冒頭に書いてある。
+      #
+      # `if: always()` は意図的: コードが赤い日でも advisory の信号は独立に見たい。
+      # ここを既定の挙動（前ステップが赤なら skip）にすると、型エラーが1件あるだけで
+      # 「世界が動いたか」の検査が止まり、定期再検査の目的そのものが失われる。
+      #
+      # 🔴 `npm run check` には含めていない。check は手元で回すループ（Stop hook パイロットの
+      # 対象でもある）で、そこへネットワーク依存の検査を混ぜると、回線都合の赤が
+      # 「無視してよい赤」として定着する。ゲートは CI に置く。
+      - name: Audit (fail on high/critical)
+        if: always()
+        run: npm run audit

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,31 @@
+{
+  // 依存脆弱性ゲート（CI）。素の `npm audit --audit-level=high` を置き換える形は
+  // フリートの参照実装（nene-origin `frontend/audit-ci.jsonc`）に合わせてある。
+  // 素の npm audit には「理由のある例外」を記録する場所が無い、というのが置き換えの理由。
+  //
+  // ゲートは鈍らせない: 下に挙がっていない high/critical は必ずビルドを落とす。
+  // `allowlist` は **advisory 単位（GHSA id）** であって severity 単位ではない。閾値は下げない。
+  //
+  // 🔴 エントリを足すときは、このファイルの中に4点そろえること（EX-9）:
+  //   (1) advisory id
+  //   (2) **このコードベースに当てはまらない理由を、執筆時点で実測して**書く（仮定を書かない）
+  //   (3) 失効日
+  //   (4) 何が起きればこの例外が不要になるか
+  // 失効したエントリは「更新するもの」ではなく **タスク**。反射的に延長せず、測り直す。
+  //
+  // 🔴 このリポは配布元である、という固有の事情:
+  // ここは npm 3パッケージ（tokens / standards / i18n）を艦隊へ配る。
+  // `@hideyukimori/nene2-standards` は `postcss` を **runtime dependencies** で宣言しており、
+  // ここの依存ツリーは各艦の install 経路の一部になる（#255）。
+  // したがって **ここでの例外は自艦だけの話で終わらない**。
+  // 「dev でしか使わないから」を理由にする前に、その依存が published package の
+  // `dependencies` 側に居ないことを実測すること。
+  "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
+  "moderate": false,
+  "high": true,
+  "critical": true,
+  // 2026-08-09 時点で **空**。#255 の導入時、`npm audit fix --package-lock-only` だけで
+  // 当時の5件（high 4 / moderate 1）が全て閉じ、例外を1件も必要としなかった〔実測〕。
+  // 逃げ道ゼロで始まっている状態を、そのまま維持したい。
+  "allowlist": [],
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^22.20.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "audit-ci": "^7.1.0",
         "eslint": "^9.30.0",
         "jsdom": "^25.0.1",
         "prettier": "3.6.2",
@@ -577,7 +578,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2088,7 +2089,7 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2109,7 +2110,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -2120,7 +2121,7 @@
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
       "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -2158,7 +2159,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -2422,15 +2423,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3161,6 +3162,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/audit-ci": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/audit-ci/-/audit-ci-7.1.0.tgz",
+      "integrity": "sha512-PjjEejlST57S/aDbeWLic0glJ8CNl/ekY3kfGFPMrPkmuaYaDKcMH0F9x9yS9Vp6URhuefSCubl/G0Y2r6oP0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "escape-string-regexp": "^4.0.0",
+        "event-stream": "4.0.1",
+        "jju": "^1.4.0",
+        "jsonstream-next": "^3.0.0",
+        "readline-transform": "1.0.0",
+        "semver": "^7.0.0",
+        "tslib": "^2.0.0",
+        "yargs": "^17.0.0"
+      },
+      "bin": {
+        "audit-ci": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3213,9 +3238,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3424,6 +3449,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clone-deep": {
@@ -3782,7 +3822,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3806,7 +3846,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
     },
@@ -3823,6 +3863,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.392",
@@ -4294,15 +4341,15 @@
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
@@ -4481,6 +4528,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -4540,9 +4603,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "devOptional": true,
       "funding": [
         {
@@ -4719,6 +4782,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4791,6 +4861,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5193,6 +5273,13 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -5655,6 +5742,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -5663,9 +5757,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -5814,6 +5908,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/jsonstream-next": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonstream-next/-/jsonstream-next-3.0.0.tgz",
+      "integrity": "sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "jsonparse": "^1.2.0",
+        "through2": "^4.0.2"
+      },
+      "bin": {
+        "jsonstream-next": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -5940,7 +6061,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -5978,6 +6099,13 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -6105,9 +6233,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -6414,6 +6542,19 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6533,9 +6674,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6552,7 +6693,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6643,7 +6784,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6659,7 +6800,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -6723,7 +6864,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6733,7 +6874,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -6746,9 +6887,34 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readline-transform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readline-transform/-/readline-transform-1.0.0.tgz",
+      "integrity": "sha512-7KA6+N9IGat52d83dvxnApAWN+MtVb1MiVuMR/cf1O4kYsJG+g/Aav0AHcHKsb6StinayfPLne0+fMX2sOzAKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/recast": {
       "version": "0.23.12",
@@ -6806,6 +6972,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -6942,6 +7118,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -6999,7 +7196,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -7240,6 +7437,19 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stable-hash-x": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
@@ -7274,6 +7484,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -7658,6 +7889,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
       }
     },
     "node_modules/tiny-invariant": {
@@ -8442,6 +8690,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
@@ -8494,11 +8760,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -8514,12 +8819,28 @@
     },
     "packages/nene2-i18n": {
       "name": "@hideyukimori/nene2-i18n",
-      "version": "0.2.0",
-      "license": "MIT"
+      "version": "0.3.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "@testing-library/react": "^16.0.0",
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@testing-library/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "packages/nene2-standards": {
       "name": "@hideyukimori/nene2-standards",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:cli": "node packages/nene2-tokens/dist/cli.js validate packages/nene2-tokens/themes/reference.css",
     "check": "npm run type-check && npm run lint && npm run format:check && npm run test && npm run check:cli && npm run check:nene2-check && npm run check:am2-gate",
     "check:nene2-check": "cd packages/nene2-standards/tests/fixtures/check-app && node ../../../dist/checks/cli.js conformance --repo nene-check-smoke",
-    "check:am2-gate": "node scripts/am2-release-gate.mjs"
+    "check:am2-gate": "node scripts/am2-release-gate.mjs",
+    "audit": "audit-ci --config audit-ci.jsonc"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.0",
@@ -24,6 +25,7 @@
     "@types/node": "^22.20.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "audit-ci": "^7.1.0",
     "eslint": "^9.30.0",
     "jsdom": "^25.0.1",
     "prettier": "3.6.2",


### PR DESCRIPTION
Closes #255（自艦適用の部分）

hub 裁定（08-09）で **#255 は玉1・玉2 の射程へ編入**され、配布形は
「fleet が18艦へ直接 PR を出す」ではなく **「自艦で実証 → 正本スニペット → 各艦が自艦で測って適用」**
と決まった。**本 PR はその1段目（自艦での実証）**。

## なぜ自艦が素振り台なのか

hub 実測で既存 `concurrency` の有無が**2種類に割れている**（あり = NeNe / nene2-js / nene2-python ／
無し = fleet-tooling / nene2-node / sakura）。参照実装の origin は**既存 group からの改修**なので、
`concurrency` を持たない多数派とは初期条件が違う。
**自艦は「無い状態から入れる」側**なので、配布先の多数派と同じ初期条件で踏める。

## 入れたもの

| | 内容 |
|---|---|
| `schedule` | `cron: '0 0 * * 1'` = 月曜 09:00 JST（参照実装 origin #412 と同値） |
| `workflow_dispatch` | 併設。**これが無いと「配ったこと自体を検証できない」** |
| `concurrency` | 🔴 group に **`github.event_name` を含める**。無いと schedule の run が main への push と同じ group に入り **cancel される**＝「設定したのに走らない」 |
| audit ゲート | `audit-ci` + `audit-ci.jsonc`（フリート参照実装 = origin `frontend/audit-ci.jsonc` と同形） |

### 設計判断を2つ、理由つきで

**① `if: always()` を audit ステップに付けた。**
既定（前ステップが赤なら skip）だと、型エラーが1件あるだけで「世界が動いたか」の検査が止まる。
定期再検査の目的は **advisory は我々のコミットではなく向こう側の時計で公開される**ことへの備えなので、
コードの赤と独立に信号が出る必要がある。

**② `npm run check` には audit を含めなかった。**
`check` は手元で回すループで、**Stop hook パイロットの対象でもある**。
そこへネットワーク依存の検査を混ぜると、回線都合の赤が「無視してよい赤」として定着する。
records の観測報告（6日・ブロック4回・実欠陥検出 **S/N 0**）と同じ壊れ方を作らないため、ゲートは CI に置いた。

## 依存の是正 — **lockfile のみ**で5件すべて閉じた

`npm audit fix --package-lock-only` のみ。**`package.json` は無変更**〔実測〕。

| package | before | after |
|---|---|---|
| brace-expansion | 1.1.16 / 5.0.7 (x2) | **1.1.18 / 5.0.9 (x2)** |
| fast-uri | 3.1.3 | 3.1.5 |
| js-yaml | 4.3.0 | 4.3.1 |
| **nanoid** | **3.3.16**（floor 3.3.17 未満） | **3.3.18** |
| postcss | 8.5.19 | 8.5.26 |

これは玉3（allowlist ゼロ化）が react-router で見ている形と同じ「**lockfile bump だけで閉じる**」。

🔴 `brace-expansion 1.1.16 → 1.1.18` は **`GHSA-rgw5-rvv9-x895`**（mh99 の緩和を**回避する**後続・
published 2026-08-03・floor が `<1.1.17` → `<1.1.18` へ移動）を閉じたもの。
**#229 の13艦は mh99 基準の射程**なので、hub が別途起票する再測の玉に繋がる。

## 🔴 対照実験（消す前に取った）

「Passed」だけでは検査器が最初から死んでいた可能性を排除できないので、両方向を実測した:

| lockfile | `npm run audit` |
|---|---|
| **修正前**（`HEAD` の lock に差し替え） | **exit 1** — mh99 / rgw5 / v2hh / 7p8r … を名指しして落ちる |
| **修正後**（本 PR） | **exit 0** — `Passed npm security audit.` |

つまりこのゲートは**現に鳴る**。空虚合格ではない。

## 副産物: lockfile のワークスペース版が実体に遅れていた

`npm audit fix` が一緒に直した〔実測〕:
`packages/nene2-i18n: 0.2.0 → 0.3.0` ／ `packages/nene2-standards: 2.1.0 → 2.2.0`

版上げのコミット時に lock が再生成されていなかった。
**この PR の主題ではないが、隠さず記録する**（配布物の再現性の話なので無視できない）。

## 検証

| | 結果 |
|---|---|
| `npm run check` | **exit 0**（`$?` を直接取得） |
| tests | **35 files / 524 tests** 全 pass |
| AM-2 release gate | **PASS** |
| conformance | red 0 / unknown 14 / green 0（本 PR の射程外・W0a skeleton のまま） |
| `npm run audit` | **exit 0** |

## 🔴 この PR で**検証できていないこと**（誠実性ガード）

- **`schedule` が push に cancel されないことの実測は、まだ出来ていない。**
  `workflow_dispatch` も `schedule` も **default branch 上の workflow 定義でしか発火しない**ため、
  マージ後でないと叩けない。**マージ後に `workflow_dispatch` で1回叩いて実測し、#255 に結果を貼る。**
  それを確認してから正本スニペットを起草する（未実測のまま18艦へ配らない）。
- `cron` が実際に月曜に発火するかは、次の月曜（**2026-08-10**）まで観測できない。
- 各艦の lockfile での nanoid 解決経路は**測っていない**。本リポ内のみの実測。

## 次

1. マージ（**施主 GO 待ち**）
2. `workflow_dispatch` で実走 → cancel されないことを実測 → #255 へ結果
3. **正本スニペット＋適用手順の起草**（`concurrency` 既存あり／無しの**2ケースを書き分ける**）
4. 玉2 の棚卸し（線引きは hub 裁定で「frontend の有無」→ **「外に配る依存ツリーを持つか」**へ変更済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
