### PR TITLE
ci(check): if は !cancelled() を使う＋concurrency group の前置を捨てる（#258・hub レビュー是正／正本を無改変で貼れる形へ）

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,8 +22,12 @@ on:
 # 🔴 group に `github.event_name` を含めるのが要点: 含めないと schedule / workflow_dispatch の run が
 # main への push と同じ group に入り、**push に cancel される**。
 # 「設定したのに走らない」という最も質の悪い失敗になる（origin が実装時に踏んだ罠）。
+#
+# group に前置（`check-` / `ci-`）は付けない。`github.workflow` が既に workflow を一意にするので
+# 冗長であるうえ、正本スニペットとして配るときに**艦ごとに違う値を書く余地**が生まれる。
+# 前置を持たない形なら、どの艦でも1文字も変えずに貼れる（#258）。
 concurrency:
-  group: check-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -43,13 +47,24 @@ jobs:
       - run: npm run check:cli
       # 依存脆弱性ゲート（#255）。設定・例外の作法は `audit-ci.jsonc` の冒頭に書いてある。
       #
-      # `if: always()` は意図的: コードが赤い日でも advisory の信号は独立に見たい。
-      # ここを既定の挙動（前ステップが赤なら skip）にすると、型エラーが1件あるだけで
-      # 「世界が動いたか」の検査が止まり、定期再検査の目的そのものが失われる。
+      # 🔴 `if` を既定の挙動（前ステップが赤なら skip）にしない理由 —— この行は理由ごと残すこと。
+      # 理由の無い設定は次の人に元へ戻される。
+      # advisory は**我々のコミットではなく向こう側の時計で公開される**。既定の挙動だと、
+      # 型エラーが1件あるだけで「世界が動いたか」の検査が止まり、定期再検査の目的が失われる。
+      # だからコードの赤とは独立に、この信号だけは出したい。
+      #
+      # 🔴 ただし `always()` ではなく `!cancelled()` を使う（#258）。
+      # `always()` は **cancelled のときも true** になり、上の `cancel-in-progress: true` により
+      # cancel は日常的に起きる。その run で audit だけが走って落ちると
+      # 「キャンセルされた run の赤」という**無意味な信号**が出て、
+      # 「無視してよい赤」としてゲートが鈍る（records の Stop hook 観測 = 実欠陥検出 S/N 0 と同じ壊れ方）。
+      # `!cancelled()` なら success / failure では走り、cancel では走らない。上の意図はそのまま保たれる。
       #
       # 🔴 `npm run check` には含めていない。check は手元で回すループ（Stop hook パイロットの
       # 対象でもある）で、そこへネットワーク依存の検査を混ぜると、回線都合の赤が
       # 「無視してよい赤」として定着する。ゲートは CI に置く。
+      # ※ 正本として配るときはここが2ケースに割れる:
+      #   Stop hook を持つ艦 = CI に置く／持たない艦 = `check` に入れてよい。
       - name: Audit (fail on high/critical)
-        if: always()
+        if: ${{ !cancelled() }}
         run: npm run audit


### PR DESCRIPTION
Closes #258

hub レビュー（#257 検収 PASS と同時に出た改善提案2点）の反映。
**どちらも #257 の挙動が壊れていたのではなく、18艦へ配る正本として不適切だった点。**

## 1. 🔴 `if: always()` → `if: ${{ !cancelled() }}`

`always()` は **cancelled のときも true**。
そして #257 は同じ PR で `cancel-in-progress: true` を入れたので、**cancel は例外ではなく常態**になる。

その run では audit ステップだけが走り、落ちれば赤が出る＝
**「キャンセルされた run の赤」という無意味な信号**。これは
records の Stop hook 観測（6日・ブロック4回・**実欠陥検出 S/N 0**）で踏んだのと同じ壊れ方で、
ゲートを鈍らせる最短経路。

`!cancelled()` なら **success / failure では走り、cancel では走らない**。
当初の意図（**コードの赤と独立に advisory の信号を見る**）はそのまま保たれる。

**私の見落とし**: `always()` を選んだとき、`cancel-in-progress` を同じ PR で入れた以上
cancel が常態になる、という接続を見ていなかった。

## 2. 🔴 `concurrency` group の前置 `check-` を削除

```diff
-  group: check-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
```

`${{ github.workflow }}` が既に workflow を一意にするので冗長。
そして正本スニペットとして見ると前置は**害**になる —— **艦ごとに違う値を書く余地**が生まれる。
前置を持たない形なら **どの艦でも1文字も変えずに貼れる**。

#257 のレビュー依頼で出した懸念（「origin は `ci-`、こちらは `check-`。正本ではどう決めるか」）への
答えが「**前置という概念を持たない**」だった。

## 3. `if` の理由をコメントに残した

hub 裁定: **「理由が無い設定は元に戻される」**。挙動だけ配ると、次の人が
「前ステップが赤なら skip でいいのでは」と戻す。
`always()` を避ける理由と、`!cancelled()` を選ぶ理由の両方を workflow 内に書いた。

正本が **2ケースに割れる**点も注記した（**Stop hook を持つ艦 = CI に置く／持たない艦 = `check` に入れてよい**）。

## 検証

| | 結果 |
|---|---|
| YAML パース | triggers = push / pull_request / **schedule** / **workflow_dispatch** |
| group | `${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}` |
| audit step の `if` | `${{ !cancelled() }}` |
| CI | この PR の check で確認 |

⚠️ **この PR で新たに実測したことはありません。** 変更は workflow の式のみで、
`npm run check` / `npm run audit` の結果は #257 から変わらない（依存も src も触っていない）。
**回した数字を再掲しないため**、ここには書かない。

## 📌 #257 のマージ後に取れた実測（#255 にコメント済み）

正本起草の前提にしていた「**schedule が push に cancel されないこと**」の測定が、
マージ直後に**偶然そろいました**〔実測〕:

| run | event | started | ended | conclusion |
|---|---|---|---|---|
| `31310232441` | **push**（#257 のマージ） | 11:12:50Z | **11:13:36Z** | **success** |
| `31310254576` | **workflow_dispatch** | **11:13:26Z** | 11:14:16Z | **success** |

**同じ `refs/heads/main` 上で約10秒重なり、どちらも cancel されなかった。**
`cancel-in-progress: true` の下では新しい run が同じ group の古い run を cancel するので、
group が衝突していれば push run は cancelled で終わったはず。**success で完走した**＝
**group 文字列が実際に分離している証明**。

⚠️ 観測したのは「**dispatch が push を cancel しなかった**」であって、その逆ではない。
分離は group キーが純粋な文字列関数である以上どちらの向きにも成立するが、
**観測と推論を混ぜないため**に分けて書く。`cron` の実発火は **08-10（月）** まで未観測。

## 📌 報告の書き方の是正（コードではないが記録）

#257 本文の「**`package.json` 無変更**」は、hub 検証で**主張の中身は真**（依存バージョンの制約は
1つも変えていない）だったが、**PR 全体では package.json は変わっている**
（`audit` script ＋ `audit-ci` devDep）。**誤読を招く書き方だった。**
次からは「**5件の是正は lockfile のみ／`package.json` の変更は audit ゲート自身の追加だけ**」と分ける。

## 次

マージ後、**正本スニペット＋適用手順の起草**へ（2ケース書き分け:
`concurrency` 既存なし＝丸ごと貼る／既存あり〔NeNe / nene2-js / nene2-python〕＝
既存 group の末尾に `-${{ github.event_name }}` を足す）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
