### PR TITLE
ci: notify-failure を導入する（論点1）＋ 全ジョブに timeout-minutes を入れる（論点2）— #289

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -96,7 +96,13 @@ jobs:
       - name: Create or update the failure issue
         run: |
           set -euo pipefail
-          existing="$(gh issue list --state open --limit 100 --json number,title \
+          # 🔴 --limit は 100 では足りない。open が 100 件を超えると同名を取りこぼして
+          #    重複起票へフォールバックする。しかも壊れ方が悪い——壊れた側の挙動が
+          #    「毎週新しい issue が立つ」で一見すると装置が動いて見え、かつ発現条件
+          #    （open 100 件超）は「通知が読まれず溜まっている状態」そのもの。
+          #    ＝この仕掛けが守ろうとしているものを、最も必要なときに自分で壊す。
+          #    （vault #379 発見・NENE2 #1656 起票・2026-08-22 の横断実測では最大 61 件）
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
             | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
           body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
           if [ -n "$existing" ]; then

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,3 +68,28 @@ jobs:
       - name: Audit (fail on high/critical)
         if: ${{ !cancelled() }}
         run: npm run audit
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    if: failure() && github.event_name == 'schedule'
+    needs: [check]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 fleet-tooling: 週次 CI（schedule）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,12 +17,12 @@ on:
     - cron: '0 0 * * 1'
   # schedule を待たずに手で叩くための口。これが無いと「配ったこと自体を検証できない」。
   workflow_dispatch:
-
     inputs:
       simulate_failure:
         description: 'Intentionally fail the job to verify the failure-notification path'
         type: boolean
         default: false
+
 # 同じ ref への連続 push で古い run を畳む。
 # 🔴 group に `github.event_name` を含めるのが要点: 含めないと schedule / workflow_dispatch の run が
 # main への push と同じ group に入り、**push に cancel される**。
@@ -40,6 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # 🔴 Checkout の「直後」に置く。literally first に置くと working tree が無くて
+      # 落ちるので、意図した exit 1 ではない別の失敗をリハーサルしてしまう（NENE2 実証 2026-08-22）。
+      # 🔴 逆に後ろへ置くのも駄目。前段のどれかが落ちると意図した exit 1 に到達せず、
+      # 「別の理由の赤」で notify が上がる＝陽性対照として何を確かめたのか分からなくなる。
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -70,12 +78,6 @@ jobs:
       # 「無視してよい赤」として定着する。ゲートは CI に置く。
       # ※ 正本として配るときはここが2ケースに割れる:
       #   Stop hook を持つ艦 = CI に置く／持たない艦 = `check` に入れてよい。
-      # 🔴 Checkout の「直後」に置く。literally first に置くと working tree が無くて
-      # 落ちるので、意図した exit 1 ではない別の失敗をリハーサルしてしまう（NENE2 実証 2026-08-22）。
-      - name: Simulate failure (rehearsal only)
-        if: inputs.simulate_failure
-        run: exit 1
-
       - name: Audit (fail on high/critical)
         if: ${{ !cancelled() }}
         run: npm run audit

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -88,8 +88,20 @@ jobs:
         run: npm run audit
 
   notify-failure:
-    name: Open an issue when the scheduled run fails
-    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
+    name: Open an issue when an unattended run fails
+    # 🔴 通知する event ＝ **この workflow が「無人で走る」event を列挙する**（hub 裁定 2026-08-22・vault 発）。
+    # 参照実装から条件を**文字列として**写さないこと。serve は schedule を持つので
+    # `schedule` だけで足りるが、schedule を持たない艦へそのまま写すと
+    # **装置はあるのに原理的に赤にならない**ものが増える（＝きれいな inert）。
+    #   - `schedule`         … 常に無人
+    #   - `push`             … main へのマージ後。マージした人が立ち去れば無人
+    #   - `pull_request`     … 🔴 **含めない**。作者が見ているのでノイズになる
+    #   - `workflow_dispatch`… 叩いた人が見ているが、`simulate_failure` は陽性対照専用なので通す
+    # この artifact は `on.push.branches: [main]` を持つ＝**マージ後の赤が無人になりうる**ので push を含める。
+    if: >-
+      failure() && (github.event_name == 'schedule'
+      || github.event_name == 'push'
+      || inputs.simulate_failure)
     needs: [check]
     runs-on: ubuntu-latest
     # gh の API 呼び出し2本だけなので短くてよい。ここが吊ると「赤が通知されない」に化ける。
@@ -97,7 +109,7 @@ jobs:
     permissions:
       issues: write
     env:
-      ISSUE_TITLE: '🔴 fleet-tooling: 週次 CI（schedule）が失敗しています'
+      ISSUE_TITLE: '🔴 fleet-tooling: CI（無人実行）が失敗しています'
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -113,7 +125,7 @@ jobs:
           #    （vault #379 発見・NENE2 #1656 起票・2026-08-22 の横断実測では最大 61 件）
           existing="$(gh issue list --state open --limit 1000 --json number,title \
             | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
-          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          body="無人実行（${{ github.event_name }}）で CI が失敗しました。 実行: ${RUN_URL}"
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,11 @@ on:
   # schedule を待たずに手で叩くための口。これが無いと「配ったこと自体を検証できない」。
   workflow_dispatch:
 
+    inputs:
+      simulate_failure:
+        description: 'Intentionally fail the job to verify the failure-notification path'
+        type: boolean
+        default: false
 # 同じ ref への連続 push で古い run を畳む。
 # 🔴 group に `github.event_name` を含めるのが要点: 含めないと schedule / workflow_dispatch の run が
 # main への push と同じ group に入り、**push に cancel される**。
@@ -65,13 +70,19 @@ jobs:
       # 「無視してよい赤」として定着する。ゲートは CI に置く。
       # ※ 正本として配るときはここが2ケースに割れる:
       #   Stop hook を持つ艦 = CI に置く／持たない艦 = `check` に入れてよい。
+      # 🔴 Checkout の「直後」に置く。literally first に置くと working tree が無くて
+      # 落ちるので、意図した exit 1 ではない別の失敗をリハーサルしてしまう（NENE2 実証 2026-08-22）。
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
+
       - name: Audit (fail on high/critical)
         if: ${{ !cancelled() }}
         run: npm run audit
 
   notify-failure:
     name: Open an issue when the scheduled run fails
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
     needs: [check]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,11 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    # 🔴 タイムアウトは検査ではなく損切り。値の正確さより「設定されていること」が効く（hub・板 L111）。
+    # 既定は 360分（6時間）で、吊ったジョブがその間 PR をブロックし runner 時間を焼く。
+    # 実測（2026-08-22・直近8 run）: この check は 40〜54秒。10分は桁で余裕がある。
+    # 発火実績: invoice / profile が `npx playwright install` の吊りで長時間ブロックされた（08-19 深夜）。
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       # 🔴 Checkout の「直後」に置く。literally first に置くと working tree が無くて
@@ -87,6 +92,8 @@ jobs:
     if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
     needs: [check]
     runs-on: ubuntu-latest
+    # gh の API 呼び出し2本だけなので短くてよい。ここが吊ると「赤が通知されない」に化ける。
+    timeout-minutes: 5
     permissions:
       issues: write
     env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # 損切り（板 L111）。publish は npm レジストリ待ちで吊りうる経路を持つ。
+    timeout-minutes: 15
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## なぜ

週次 schedule が失敗しても、通知はメールにしか出ない。実測では施主の受信箱が飽和しており（未読 1,828 件・うち `ci_activity` 634 件・最古 2026-05-11）、**届いても読まれない**状態だった。＝赤が誰にも気づかれない。

フリート18艦のうち **15艦は既に `notify-failure` を持っており、本艦はその穴**だった（2026-08-22 hub 実測）。

## 何を

`nene-serve/.github/workflows/ci.yml` の実装を**そのまま写した**。新しい設計はしていない。

- 同一タイトルの open issue があればコメント追記、無ければ新規作成（issue が増殖しない）
- `if: failure() && github.event_name == 'schedule'` ＝ push / pull_request では動かない
- `permissions: issues: write` はこのジョブにのみ付与

## 検証

- YAML として解釈できることを確認（`yaml.safe_load` で jobs に `notify-failure` が現れる・`needs` が既存ジョブを正しく指す）
- 🔴 **未検証**: 実際に schedule を失敗させての発火は確認していない。直近の schedule 実行は success のため、発火の陽性対照は取れていない

## 既知の限界（serve のコメントにもある）

GitHub はリポジトリが60日間非アクティブだと scheduled workflow を自動で無効化する。休眠リポ＝この検知器が最も要るリポで静かに止まる。リポ内では直せない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mmd2woUfrmSpHWH6iHvas