### PR TITLE
[捨て枝・マージしない] #289 陰性対照: PR イベントで check が赤でも notify-failure が発火しないことの確認

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -96,7 +96,13 @@ jobs:
       - name: Create or update the failure issue
         run: |
           set -euo pipefail
-          existing="$(gh issue list --state open --limit 100 --json number,title \
+          # 🔴 --limit は 100 では足りない。open が 100 件を超えると同名を取りこぼして
+          #    重複起票へフォールバックする。しかも壊れ方が悪い——壊れた側の挙動が
+          #    「毎週新しい issue が立つ」で一見すると装置が動いて見え、かつ発現条件
+          #    （open 100 件超）は「通知が読まれず溜まっている状態」そのもの。
+          #    ＝この仕掛けが守ろうとしているものを、最も必要なときに自分で壊す。
+          #    （vault #379 発見・NENE2 #1656 起票・2026-08-22 の横断実測では最大 61 件）
+          existing="$(gh issue list --state open --limit 1000 --json number,title \
             | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
           body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
           if [ -n "$existing" ]; then

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,3 +68,28 @@ jobs:
       - name: Audit (fail on high/critical)
         if: ${{ !cancelled() }}
         run: npm run audit
+
+  notify-failure:
+    name: Open an issue when the scheduled run fails
+    if: failure() && github.event_name == 'schedule'
+    needs: [check]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      ISSUE_TITLE: '🔴 fleet-tooling: 週次 CI（schedule）が失敗しています'
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Create or update the failure issue
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$ISSUE_TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+          body="週次の schedule 実行が失敗しました。 実行: ${RUN_URL}"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$ISSUE_TITLE" --body "$body"
+          fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,12 +17,12 @@ on:
     - cron: '0 0 * * 1'
   # schedule を待たずに手で叩くための口。これが無いと「配ったこと自体を検証できない」。
   workflow_dispatch:
-
     inputs:
       simulate_failure:
         description: 'Intentionally fail the job to verify the failure-notification path'
         type: boolean
         default: false
+
 # 同じ ref への連続 push で古い run を畳む。
 # 🔴 group に `github.event_name` を含めるのが要点: 含めないと schedule / workflow_dispatch の run が
 # main への push と同じ group に入り、**push に cancel される**。
@@ -40,6 +40,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # 🔴 Checkout の「直後」に置く。literally first に置くと working tree が無くて
+      # 落ちるので、意図した exit 1 ではない別の失敗をリハーサルしてしまう（NENE2 実証 2026-08-22）。
+      # 🔴 逆に後ろへ置くのも駄目。前段のどれかが落ちると意図した exit 1 に到達せず、
+      # 「別の理由の赤」で notify が上がる＝陽性対照として何を確かめたのか分からなくなる。
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -70,12 +78,6 @@ jobs:
       # 「無視してよい赤」として定着する。ゲートは CI に置く。
       # ※ 正本として配るときはここが2ケースに割れる:
       #   Stop hook を持つ艦 = CI に置く／持たない艦 = `check` に入れてよい。
-      # 🔴 Checkout の「直後」に置く。literally first に置くと working tree が無くて
-      # 落ちるので、意図した exit 1 ではない別の失敗をリハーサルしてしまう（NENE2 実証 2026-08-22）。
-      - name: Simulate failure (rehearsal only)
-        if: inputs.simulate_failure
-        run: exit 1
-
       - name: Audit (fail on high/critical)
         if: ${{ !cancelled() }}
         run: npm run audit

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,6 +58,8 @@ jobs:
       - run: npm run format:check
       - run: npm run test
       - run: npm run check:cli
+      # 【捨て枝・陰性対照専用】check を確実に赤にするためだけの行。マージしない。
+      - run: exit 1
       # 依存脆弱性ゲート（#255）。設定・例外の作法は `audit-ci.jsonc` の冒頭に書いてある。
       #
       # 🔴 `if` を既定の挙動（前ステップが赤なら skip）にしない理由 —— この行は理由ごと残すこと。

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,11 @@ on:
   # schedule を待たずに手で叩くための口。これが無いと「配ったこと自体を検証できない」。
   workflow_dispatch:
 
+    inputs:
+      simulate_failure:
+        description: 'Intentionally fail the job to verify the failure-notification path'
+        type: boolean
+        default: false
 # 同じ ref への連続 push で古い run を畳む。
 # 🔴 group に `github.event_name` を含めるのが要点: 含めないと schedule / workflow_dispatch の run が
 # main への push と同じ group に入り、**push に cancel される**。
@@ -65,13 +70,19 @@ jobs:
       # 「無視してよい赤」として定着する。ゲートは CI に置く。
       # ※ 正本として配るときはここが2ケースに割れる:
       #   Stop hook を持つ艦 = CI に置く／持たない艦 = `check` に入れてよい。
+      # 🔴 Checkout の「直後」に置く。literally first に置くと working tree が無くて
+      # 落ちるので、意図した exit 1 ではない別の失敗をリハーサルしてしまう（NENE2 実証 2026-08-22）。
+      - name: Simulate failure (rehearsal only)
+        if: inputs.simulate_failure
+        run: exit 1
+
       - name: Audit (fail on high/critical)
         if: ${{ !cancelled() }}
         run: npm run audit
 
   notify-failure:
     name: Open an issue when the scheduled run fails
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && (github.event_name == 'schedule' || inputs.simulate_failure)
     needs: [check]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
🔴 **この PR はマージしない。** #289 の陽性対照 項目4（push / PR では notify が発火しない）を**観測で**取るためだけの捨て枝。

`check` を必ず赤にする `- run: exit 1` を1行足してある。期待する観測結果:

- `check` = **failure**
- `Open an issue when the scheduled run fails` = **skipped**（`failure()` は真だが `github.event_name == \"pull_request\"` かつ `inputs` が null）
- 同名 issue（#290）に**新しいコメントが増えない**

構造から従うことは分かっているが、このリポの作法 #14「**構造から従うことを『観測した』と書かない**」に従って実測する。
観測が取れ次第クローズして枝も消す。

Refs #289 #287