### PR TITLE
feat(ui): @hideyukimori/nene2-ui v0.1 を追加 — 意匠を「検査で揃える」から「部品で揃わせる」へ（#294・hub 実装／fleet-tooling 検証・PR化）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,6 +1554,10 @@
       "resolved": "packages/nene2-tokens",
       "link": true
     },
+    "node_modules/@hideyukimori/nene2-ui": {
+      "resolved": "packages/nene2-ui",
+      "link": true
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -6864,7 +6868,6 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8916,6 +8919,15 @@
       },
       "devDependencies": {
         "@types/jscodeshift": "^17.3.0"
+      }
+    },
+    "packages/nene2-ui": {
+      "name": "@hideyukimori/nene2-ui",
+      "version": "0.1.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=19",
+        "tailwindcss": ">=4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "type-check": "tsc --build packages/*",
     "lint": "eslint .",
-    "format:check": "prettier --check \"packages/**/*.{ts,json,css}\"",
+    "format:check": "prettier --check \"packages/**/*.{ts,tsx,json,css}\"",
     "test": "vitest run",
     "build": "tsc --build packages/*",
     "check:cli": "node packages/nene2-tokens/dist/cli.js validate packages/nene2-tokens/themes/reference.css",

--- a/packages/nene2-standards/tests/fixtures/styling-entry/src/features/panel/panel.tsx
+++ b/packages/nene2-standards/tests/fixtures/styling-entry/src/features/panel/panel.tsx
@@ -4,8 +4,6 @@
 // they are recognised — 0 false positives.
 export function Panel() {
   return (
-    <div className="bg-surface border-border px-inline-md py-stack-sm gap-inline-sm">
-      panel
-    </div>
+    <div className="bg-surface border-border px-inline-md py-stack-sm gap-inline-sm">panel</div>
   );
 }

--- a/packages/nene2-ui/LICENSE
+++ b/packages/nene2-ui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 HideyukiMORI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -1,0 +1,147 @@
+# @hideyukimori/nene2-ui
+
+Shared React UI kit for the NeNe fleet. **Components carry no design of their own — themes do.**
+
+## Why this exists
+
+The fleet already had design **tokens** (`@hideyukimori/nene2-tokens`) and a **conformance
+checker** (`@hideyukimori/nene2-standards`) — but no box to ship the actual parts in. So every
+product wrote its own, and consistency was chased afterwards by counting violations.
+
+Measured across the 13 product frontends on 2026-08-23:
+
+| Component    | Independent implementations |
+| ------------ | --------------------------: |
+| `Button`     |                      **20** |
+| `Input`      |                          17 |
+| `Select`     |                          16 |
+| `EmptyState` |                          15 |
+| `Text`       |                          14 |
+| `Stack`      |                          12 |
+
+Of the **266** files in the fleet's `shared/ui` directories, **74% share a name with at least one
+other product**. The designs had already converged — only the execution was scattered N ways.
+
+🔑 **Enforcing consistency by inspection scales with the number of deviations, which has no upper
+bound. Providing the parts scales with the number of screens, which is finite.**
+
+## Design principles
+
+1. **Pass native props through.** Every primitive extends its element's HTML attributes, so there
+   is nothing new to learn and nothing that quietly breaks accessibility.
+2. **`className` composes, never replaces.** Caller classes are appended last via `cx`, so
+   Tailwind's later-wins cascade makes them an escape hatch rather than a footgun.
+3. **No colour, spacing or radius props.** `<Button color="#f00">` does not exist. If a variant
+   cannot express it, add a variant — for everyone. _This is the principle that matters:_ the
+   13,021 style violations the fleet is currently remediating exist because values could be
+   written inline. Make them unwritable and there is nothing to inspect.
+4. **No strings.** The kit ships no user-visible text. `Spinner` takes `label`, `ErrorState` takes
+   `retryLabel`. Localisation stays with the product (`@hideyukimori/nene2-i18n`), so a wording
+   change never becomes a kit release.
+5. **The three states ship together.** `LoadingState` / `EmptyState` / `ErrorState` exist as a set
+   so a screen that handles only the happy path is visibly incomplete.
+
+## Install
+
+```bash
+npm i @hideyukimori/nene2-ui
+```
+
+Peer dependencies: `react >= 19`, `tailwindcss >= 4`.
+
+## Use
+
+```css
+/* src/shared/ui/theme/index.css */
+@import 'tailwindcss';
+@import '@hideyukimori/nene2-ui/themes/default.css';
+```
+
+```tsx
+import { PageHeader, Button, FormField, Input, EmptyState } from '@hideyukimori/nene2-ui';
+
+export function InvoiceListPage({ t, invoices }) {
+  return (
+    <>
+      <PageHeader title={t('invoices.title')} actions={<Button>{t('invoices.new')}</Button>} />
+      {invoices.length === 0 ? (
+        <EmptyState message={t('invoices.empty')} />
+      ) : (
+        <InvoiceTable rows={invoices} />
+      )}
+    </>
+  );
+}
+```
+
+## Theming
+
+Components reference Tailwind utilities derived from `@theme` custom properties. A theme is one
+CSS file of ~20 lines, and it is the **only** place a design value may appear.
+
+```
+tokens contract ──themegen──▶ themes/<name>.css  (@theme block)
+                                    │
+                     product's active.css imports exactly one
+```
+
+To rebrand, replace the theme file. **Never edit a component.** This is what makes adopting the
+kit reversible: the look is 20 lines away from being something else.
+
+Regenerate a theme from the token contract with:
+
+```bash
+npx @hideyukimori/nene2-tokens themegen
+```
+
+## What is in scope
+
+**In:** admin console and business-screen UI, page layout scaffolding, form field structure, the
+loading/empty/error state set, read-only detail displays.
+
+**Out:** end-user-facing themes that are a _product feature_ (NeNe Records ships 30 of them —
+`aurora`, `newsprint`, `noir`, `japandi`, …), public marketing and brand surfaces, domain-specific
+screens (invoice previews, kanban boards, reports), and anything in the `model/` layer — data
+fetching and state are governed by `@hideyukimori/nene2-standards`, not by this kit.
+
+## Components (v0.1)
+
+Promoted verbatim from `nene-payout`, the fleet's only conformance-violation-free product, with
+one correctness fix: `className` now composes instead of replacing.
+
+| Group        | Components                                                  |
+| ------------ | ----------------------------------------------------------- |
+| `primitives` | `Button` `Input` `Select` `Spinner` `Text`                  |
+| `layout`     | `PageHeader`                                                |
+| `forms`      | `FormField`                                                 |
+| `states`     | `EmptyState` `ErrorState`                                   |
+| `data`       | `DetailList`                                                |
+| `theme`      | `tokens` (read-only `var()` accessors for canvas/chart use) |
+
+`Input` and `Select` use `forwardRef`, so they drop straight into `react-hook-form`'s `register`.
+
+### Not yet here
+
+`Modal` `ConfirmDialog` `Toast` `Badge` `Card` `Stack` `DataTable` `Pagination` `Textarea`
+`Checkbox` `Alert` `LoadingState` — all measured as recurring across ≥3 products. They land as
+migrating products contribute their implementation upward, rather than being designed up front.
+
+## Contributing a component
+
+The kit grows by **promotion, not invention**. If a screen needs something the kit lacks:
+
+1. Build it in that product's `shared/ui` first, against tokens only.
+2. When a second product needs the same thing, promote it here — the second use is the evidence.
+3. Open an issue if a variant is missing. **Do not special-case it in the screen**; one exception
+   granted is the moment the kit stops meaning anything.
+
+## Development
+
+```bash
+npm ci
+npm run check    # type-check + format:check + test
+```
+
+## License
+
+MIT © hideyuki MORI

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@hideyukimori/nene2-ui",
+  "version": "0.1.0",
+  "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
+  "type": "module",
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./themes/default.css": "./themes/default.css",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "themes"
+  ],
+  "sideEffects": [
+    "*.css"
+  ],
+  "scripts": {
+    "build": "tsc --build",
+    "prepack": "tsc --build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hideyukiMORI/nene2-fleet-tooling.git",
+    "directory": "packages/nene2-ui"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "react": ">=19",
+    "tailwindcss": ">=4"
+  }
+}

--- a/packages/nene2-ui/src/data/DetailList.tsx
+++ b/packages/nene2-ui/src/data/DetailList.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+export interface DetailRow {
+  /** Localized row label. */
+  label: string;
+  value: ReactNode;
+}
+
+export interface DetailListProps {
+  rows: DetailRow[];
+}
+
+/**
+ * Read-only key/value display for detail screens. Uses a description list so the
+ * label/value relationship is conveyed to assistive technology.
+ */
+export function DetailList({ rows }: DetailListProps) {
+  return (
+    <dl className="flex flex-col gap-x-stack-sm">
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          className="flex flex-col gap-x-inline-sm border-b border-border py-x-stack-sm"
+        >
+          <dt className="font-sans font-medium text-text-muted">{row.label}</dt>
+          <dd className="font-sans text-text-primary">{row.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+export interface FormFieldProps {
+  /** id of the control this field labels; must match the control's `id`. */
+  id: string;
+  /** Localized label. */
+  label: string;
+  /** Localized error message, or null when valid. */
+  error?: string | null;
+  children: ReactNode;
+}
+
+/**
+ * Labelled form field wrapper: associates a <label> with its control and renders a
+ * validation error with an aria-describedby link for assistive tech.
+ *
+ * The control is responsible for setting `aria-describedby={`${id}-error`}` when it
+ * renders an error, so the association survives arbitrary control implementations.
+ */
+export function FormField({ id, label, error = null, children }: FormFieldProps) {
+  return (
+    <div className="flex flex-col gap-x-inline-sm">
+      <label htmlFor={id} className="font-sans font-medium text-text-primary">
+        {label}
+      </label>
+      {children}
+      {error !== null ? (
+        <p id={`${id}-error`} role="alert" className="font-sans text-danger">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -1,0 +1,25 @@
+// Primitives
+export { Button, type ButtonProps } from './primitives/Button.js';
+export { Input, type InputProps } from './primitives/Input.js';
+export { Select, type SelectProps } from './primitives/Select.js';
+export { Spinner, type SpinnerProps } from './primitives/Spinner.js';
+export { Text, type TextProps } from './primitives/Text.js';
+
+// Layout
+export { PageHeader, type PageHeaderProps } from './layout/PageHeader.js';
+
+// Forms
+export { FormField, type FormFieldProps } from './forms/FormField.js';
+
+// States
+export { EmptyState, type EmptyStateProps } from './states/EmptyState.js';
+export { ErrorState, type ErrorStateProps } from './states/ErrorState.js';
+
+// Data
+export { DetailList, type DetailListProps, type DetailRow } from './data/DetailList.js';
+
+// Theme
+export { tokens } from './theme/tokens.js';
+
+// Internal helper, exported so downstream components can compose consistently.
+export { cx } from './lib/cx.js';

--- a/packages/nene2-ui/src/layout/PageHeader.tsx
+++ b/packages/nene2-ui/src/layout/PageHeader.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+export interface PageHeaderProps {
+  /** Localized page title. */
+  title: string;
+  actions?: ReactNode;
+}
+
+export function PageHeader({ title, actions }: PageHeaderProps) {
+  return (
+    <header className="flex items-center justify-between py-x-stack-md">
+      <h1 className="font-sans font-medium text-text-primary">{title}</h1>
+      {actions}
+    </header>
+  );
+}

--- a/packages/nene2-ui/src/lib/cx.test.ts
+++ b/packages/nene2-ui/src/lib/cx.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { cx } from './cx.js';
+
+describe('cx', () => {
+  it('joins the parts it is given', () => {
+    expect(cx('a', 'b')).toBe('a b');
+  });
+
+  it('drops falsy parts so conditional classes are safe', () => {
+    expect(cx('a', false, null, undefined, '', 'b')).toBe('a b');
+  });
+
+  it('puts the caller class last so it can override the kit (escape hatch)', () => {
+    // 🔴 This is the regression this helper exists for: before `cx`, spreading
+    // `{...rest}` after `className` made a caller's class REPLACE the kit's styling.
+    expect(cx('bg-accent', 'bg-surface')).toBe('bg-accent bg-surface');
+  });
+});

--- a/packages/nene2-ui/src/lib/cx.ts
+++ b/packages/nene2-ui/src/lib/cx.ts
@@ -1,0 +1,14 @@
+/**
+ * Merge the kit's own classes with a caller-supplied `className`.
+ *
+ * 🔴 Why this exists: spreading `{...rest}` after setting `className` lets a caller's
+ * className *replace* the component's styling entirely, silently un-theming the element.
+ * Every component in this kit must compose through `cx` instead.
+ *
+ * The caller's classes come last so Tailwind's later-wins cascade lets them override,
+ * which is the intended escape hatch (design principle 2). What is not allowed is
+ * accepting colour/spacing/radius as *props* — see README "Design principles".
+ */
+export function cx(...parts: (string | false | null | undefined)[]): string {
+  return parts.filter((p): p is string => typeof p === 'string' && p.length > 0).join(' ');
+}

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -1,0 +1,29 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger';
+  children: ReactNode;
+}
+
+const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
+  primary: 'bg-accent text-on-accent',
+  secondary: 'bg-surface-raised text-text-primary border border-border',
+  danger: 'bg-danger text-on-accent',
+};
+
+const BASE_CLASS = 'rounded-x-md px-x-inline-md py-x-stack-sm font-sans font-medium';
+
+export function Button({
+  variant = 'primary',
+  children,
+  type = 'button',
+  className,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button type={type} className={cx(BASE_CLASS, VARIANT_CLASS[variant], className)} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -1,0 +1,18 @@
+import { forwardRef, type InputHTMLAttributes } from 'react';
+import { cx } from '../lib/cx.js';
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+const BASE_CLASS =
+  'w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary';
+
+/**
+ * Text input primitive. forwardRef so it works directly with react-hook-form `register`.
+ * Visual values come from theme tokens only.
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, ...rest },
+  ref,
+) {
+  return <input ref={ref} className={cx(BASE_CLASS, className)} {...rest} />;
+});

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -1,0 +1,24 @@
+import { forwardRef, type ReactNode, type SelectHTMLAttributes } from 'react';
+import { cx } from '../lib/cx.js';
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  children: ReactNode;
+}
+
+const BASE_CLASS =
+  'w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary';
+
+/**
+ * Select primitive. forwardRef so it works directly with react-hook-form `register`.
+ * Visual values come from theme tokens only.
+ */
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { children, className, ...rest },
+  ref,
+) {
+  return (
+    <select ref={ref} className={cx(BASE_CLASS, className)} {...rest}>
+      {children}
+    </select>
+  );
+});

--- a/packages/nene2-ui/src/primitives/Spinner.tsx
+++ b/packages/nene2-ui/src/primitives/Spinner.tsx
@@ -1,0 +1,12 @@
+export interface SpinnerProps {
+  /** Localized loading text. The kit never ships strings — see README. */
+  label: string;
+}
+
+export function Spinner({ label }: SpinnerProps) {
+  return (
+    <output className="font-sans text-text-muted" aria-live="polite">
+      {label}
+    </output>
+  );
+}

--- a/packages/nene2-ui/src/primitives/Text.tsx
+++ b/packages/nene2-ui/src/primitives/Text.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+export interface TextProps {
+  as?: 'p' | 'span';
+  tone?: 'primary' | 'muted';
+  children: ReactNode;
+}
+
+export function Text({ as = 'p', tone = 'primary', children }: TextProps) {
+  const className = `font-sans ${tone === 'muted' ? 'text-text-muted' : 'text-text-primary'}`;
+
+  return as === 'span' ? (
+    <span className={className}>{children}</span>
+  ) : (
+    <p className={className}>{children}</p>
+  );
+}

--- a/packages/nene2-ui/src/states/EmptyState.tsx
+++ b/packages/nene2-ui/src/states/EmptyState.tsx
@@ -1,0 +1,12 @@
+export interface EmptyStateProps {
+  /** Localized message. The kit never ships strings — see README. */
+  message: string;
+}
+
+export function EmptyState({ message }: EmptyStateProps) {
+  return (
+    <div className="py-x-stack-lg font-sans text-text-muted" role="status">
+      {message}
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/states/ErrorState.tsx
+++ b/packages/nene2-ui/src/states/ErrorState.tsx
@@ -1,0 +1,22 @@
+import { Button } from '../primitives/Button.js';
+
+export interface ErrorStateProps {
+  /** Localized message. */
+  message: string;
+  /** Localized label for the retry control. */
+  retryLabel: string;
+  onRetry: () => void;
+}
+
+export function ErrorState({ message, retryLabel, onRetry }: ErrorStateProps) {
+  return (
+    <div className="py-x-stack-lg" role="alert">
+      <p className="font-sans text-danger">{message}</p>
+      <div className="py-x-stack-sm">
+        <Button variant="secondary" onClick={onRetry}>
+          {retryLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/theme/tokens.ts
+++ b/packages/nene2-ui/src/theme/tokens.ts
@@ -1,0 +1,19 @@
+/**
+ * Read-only TS accessors for theme tokens, for programmatic use such as charts where a
+ * CSS class cannot be applied.
+ *
+ * 🔴 These are `var()` references, never literal values — the CSS `@theme` block stays
+ * the single source of truth. Adding a literal here creates a second source that drifts.
+ */
+export const tokens = {
+  color: {
+    accent: 'var(--color-accent)',
+    danger: 'var(--color-danger)',
+    surface: 'var(--color-surface)',
+    surfaceRaised: 'var(--color-surface-raised)',
+    border: 'var(--color-border)',
+    textPrimary: 'var(--color-text-primary)',
+    textMuted: 'var(--color-text-muted)',
+    onAccent: 'var(--color-on-accent)',
+  },
+} as const;

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -1,0 +1,31 @@
+/* @nene2-contract 1.0 @themegen 1.0.0
+ *
+ * The kit's default theme. Promoted verbatim from nene-payout — the fleet's only
+ * conformance-violation-free product as of 2026-08-23.
+ *
+ * 🔴 This file is the ONLY place a design value may appear. Components reference these
+ * through Tailwind utilities (bg-accent, rounded-x-md, px-x-inline-md). To rebrand,
+ * replace this file — never edit a component.
+ *
+ * Regenerate with: npx @hideyukimori/nene2-tokens themegen
+ */
+@theme {
+  --color-surface: oklch(99% 0.004 260);
+  --color-surface-raised: oklch(100% 0 0);
+  --color-text-primary: oklch(25% 0.02 260);
+  --color-text-muted: oklch(55% 0.02 260);
+  --color-border: oklch(90% 0.01 260);
+  --color-accent: oklch(55% 0.15 250);
+  --color-on-accent: oklch(99% 0 0);
+  --color-danger: oklch(55% 0.2 25);
+
+  --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
+
+  --radius-x-md: 0.5rem;
+
+  --spacing-x-inline-sm: 0.5rem;
+  --spacing-x-inline-md: 1rem;
+  --spacing-x-stack-sm: 0.75rem;
+  --spacing-x-stack-md: 1.25rem;
+  --spacing-x-stack-lg: 2rem;
+}

--- a/packages/nene2-ui/tsconfig.json
+++ b/packages/nene2-ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    // The first React package in this monorepo: the shared base targets Node, so the DOM
+    // libs and the JSX transform are added here rather than widening the base for everyone.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
+}


### PR DESCRIPTION
Closes #294

## これは何か

フリート共有 React UI キット **`@hideyukimori/nene2-ui` v0.1.0** を配布物として追加する。

**実装者は hub（統合リナ）**。本 PR は fleet-tooling レーンが**受け取って PR 化した**もの（板 行115 の②「fleet-tooling レーンへ引き渡し」）。**自艦は実装していない** — 検証と PR 化のみ担当。

## なぜ（診断・hub 実測 2026-08-23）

トークン（`nene2-tokens` 138変数）と検査器（`nene2-standards` eslint 22ルール）はあるのに、**部品を配る箱が無い**。だから各艦が独自に書き、あとから違反を数えて揃えにいっている。

| 部品 | 独立実装の数 |
|---|---:|
| `Button` | **20** |
| `Input` | 17 |
| `Select` | 16 |
| `EmptyState` | 15 |

`shared/ui` 総ファイル **266本**のうち **74% が他艦と同名**。`nene-payout` と `nene-invoice` の `Button` は独立に書かれて**ほぼ同型**。

🔑 **統一の設計は既に終わっている。実行だけが N 回に散っている。** ⇒ 仕事量が「逸脱の数」で決まる形をやめ、「画面の数」で決まる形へ移す。

## 中身

**新規設計はゼロ。** `nene-payout`（違反0の唯一の艦）の `shared/ui` から10部品を昇格させたもの。

`src/index.ts` の export（実測）= Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList ＋ `tokens` ＋ `cx`。

唯一の実装追加は **`cx()`** — `className` が variant クラスを丸ごと上書きしてしまう欠陥の是正＋回帰テスト3本。

## コミットを2本に分けている理由

| SHA | 中身 |
|---|---|
| `a5944a3` | `chore(format): format:check の glob に .tsx を足す（#294）` |
| `671a2e9` | `feat(ui): @hideyukimori/nene2-ui v0.1 を追加（#294）` — 19ファイル |

root の `format:check` が `packages/**/*.{ts,json,css}` で **`.tsx` を含んでいなかった**ため、キットのコンポーネントだけ整形ゲートを素通りする状態だった。**パッケージを足す前に glob 側を先に塞ぐ**順序にしてある。

その副作用で既存フィクスチャ `packages/nene2-standards/tests/fixtures/styling-entry/src/features/panel/panel.tsx` が未整形として露出したので整形した。🔴 **自艦で diff を実測**したが、prettier が触ったのは **JSX の改行のみで `className` 文字列は不変**（`bg-surface border-border px-inline-md py-stack-sm gap-inline-sm`）。当該フィクスチャは「トークン化ユーティリティが誤検知0で認識されること」を見るものなので、アサーションに影響しない。

## 検証（**自艦で実走**・2026-08-23 12:5x）

`npm run check` **全7項目 PASS・exit 0**:

| 項目 | 結果 |
|---|---|
| `type-check`（`tsc --build packages/*`・glob なので nene2-ui も対象） | ✅ |
| `lint`（`eslint .`） | ✅ |
| `format:check` | ✅ All matched files use Prettier code style! |
| `test` | ✅ **36 files / 527 tests** |
| `check:cli` | ✅ 1 file(s), 0 error(s), 0 warning(s) |
| `check:nene2-check`（conformance） | ✅ |
| `check:am2-gate` | ✅ PASS — contract 1.0 (color 28 + shadow 4) は凍結記録と一致 |

`vitest.config.ts` の include が `packages/*/src/**/*.test.ts` なので、**`nene2-ui/src/lib/cx.test.ts` も実際に走っている**（cx の回帰3本が空振りしていないことを確認済み）。

`dist/` と `*.tsbuildinfo` は `.gitignore` で除外されており、**diff に入っていない**〔自艦で実測〕。

## README にバッジを貼らない

初版には npm バッジと license バッジがあったが、**2本とも削除済み**。理由:

- 未 publish なので npm バッジのリンク先が **404**
- 🔴 それ以前に、**兄弟3パッケージ（i18n / standards / tokens）と root は元からバッジ0本**〔`grep -c shields.io` = 0/0/0/0・自艦で実測〕

⇒ #55 / #152 の「**README に版・進捗を書かない**」は既にリポの実装として現れていた。**恒久的に貼らない**で確定（hub 判断・自艦同意）。

## 🏁 施主決定（2026-08-23・hub 経由）

| 問い | 決定 |
|---|---|
| 管理コンソール面の「見た目保存の縛り」を解くか | **解く。ただし本番デプロイ前に施主の目視確認を義務化** |
| 本 PR のコミット | **GO** |

⇒ **各艦への載せ替えの DoD が5段になる**:

1. import を差し替える（`shared/ui/primitives/X` → `@hideyukimori/nene2-ui`）
2. 旧 `X.tsx` / `X.stories.tsx` を消す
3. variant で表せない意匠は**キットへ issue**（画面側で特例を作らない）
4. `npm run check` 緑
5. 🔴 **施主の目視確認**（新設・**本番デプロイ前**・艦ごと／波ごと）

⚠️ 5 は「**デプロイ前**」であって「PR 前」ではない。PR ごとに施主を呼ぶとレーンが止まる（08-22 に判断待ち20件が滞留した型）。**波の単位でまとめて1回。** 目視の材料の出し方は未決で、W1（vault → deal）で形を作る。

## 🔴 着地の順序

**#293 → #286 クローズ → 本 PR**。

#293 は `docs/todo/current.md` 冒頭の「いま自艦の手番にあるものは無い」が偽である点（#288）を是正する。**マージされるまでリポ上は偽のまま**で、他艦が読みに来て止まる型（同じ週に `nene-records` が**3日間停止**した実績・板 行103）。

## 射程外・次

- `nene-records` の30テーマは製品機能であり本キットの射程外
- `fleet-baseline.json` への `@hideyukimori/nene2-ui` 登録と npm publish は**施主承認後**（`docs/publish.md`・AM-2 gate）

正本: `_work/reports/2026-08-23-nene2-ui-design.md`（§9 = 施主決定 / §10 = 着地の順序表）／討議: `_work/discussion-log/2026-08-23.md`
