### PR TITLE
fix(check): lock 同期ゲートを check の先頭に足す — 「ローカル緑・CI 赤」を構造的に潰す（#296・陽性対照2種つき）

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "format:check": "prettier --check \"packages/**/*.{ts,tsx,json,css}\"",
     "test": "vitest run",
     "build": "tsc --build packages/*",
+    "check:lock": "node scripts/check-lock-sync.mjs",
     "check:cli": "node packages/nene2-tokens/dist/cli.js validate packages/nene2-tokens/themes/reference.css",
-    "check": "npm run type-check && npm run lint && npm run format:check && npm run test && npm run check:cli && npm run check:nene2-check && npm run check:am2-gate",
+    "check": "npm run check:lock && npm run type-check && npm run lint && npm run format:check && npm run test && npm run check:cli && npm run check:nene2-check && npm run check:am2-gate",
     "check:nene2-check": "cd packages/nene2-standards/tests/fixtures/check-app && node ../../../dist/checks/cli.js conformance --repo nene-check-smoke",
     "check:am2-gate": "node scripts/am2-release-gate.mjs",
     "audit": "audit-ci --config audit-ci.jsonc"

--- a/scripts/check-lock-sync.mjs
+++ b/scripts/check-lock-sync.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * lock 同期ゲート（#296）— `npm run check` の先頭で走る。
+ *
+ * 何を防ぐか: `package.json` と `package-lock.json` の食い違いを、CI へ着くより前に落とす。
+ *
+ * 🔴 なぜ必要か（2026-08-23・PR #295 で実踏）:
+ * `packages/nene2-ui` を足した PR の CI が `npm ci` で赤になったが、その直前に
+ * `npm run check` は全7項目 PASS していた。node_modules に既にワークスペースが
+ * 張られている環境では lock の欠落が見えず、check の各項目はどれも lock を読まない。
+ * ⇒ **ワークスペースを1本足すと必ず「ローカル緑・CI 赤」になる**構造だった。
+ *
+ * 🔴 なぜ `--offline` か:
+ * check は手元で回すループ（Stop hook パイロットの対象でもある）なので、ここへ
+ * ネットワーク依存の検査を混ぜると回線都合の赤が「無視してよい赤」として定着する。
+ * この既決は .github/workflows/check.yml が `npm run audit` を check に入れない理由として
+ * 明文で書いている。同じ理由でネットワークを断つ。実測 1.0 秒（#296）。
+ *
+ * 🔴 なぜ `--dry-run` か: node_modules を書き換えないため。手元のループを壊さない。
+ *
+ * 失敗コードが2種類あるのは `--offline` の副作用で、どちらも「lock が package.json を
+ * 覆っていない」ことを指す。素の npm の文言だけだと2つ目が回線障害に見えるので、
+ * ここで意味を言い直している（それをしないと「無視してよい赤」に化ける）。
+ */
+import { spawnSync } from 'node:child_process';
+
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const r = spawnSync(npm, ['ci', '--dry-run', '--ignore-scripts', '--offline'], {
+  encoding: 'utf8',
+});
+
+if (r.error) {
+  console.error('check:lock: npm の起動に失敗 — fail-closed で赤にする');
+  console.error(String(r.error));
+  process.exit(1);
+}
+
+if (r.status === 0) {
+  console.log('check:lock: package.json と package-lock.json は同期している');
+  process.exit(0);
+}
+
+const out = `${r.stdout ?? ''}${r.stderr ?? ''}`;
+
+// EUSAGE   = lock にエントリが無い（ワークスペースの追加漏れなど）
+// ENOTCACHED = 宣言された依存が lock 経由でキャッシュに解決できない
+//              （--offline なので取りに行かない。新規依存を足して lock を更新していない形）
+const cause = out.includes('ENOTCACHED')
+  ? 'package.json が宣言している依存を lock が覆っていない（--offline なので取得は試みていない。回線の問題ではない）'
+  : 'package.json と package-lock.json が同期していない';
+
+console.error(out.trimEnd());
+console.error('');
+console.error(`🔴 check:lock: ${cause}`);
+console.error('');
+console.error('   直し方: npm install --package-lock-only --ignore-scripts');
+console.error('   🔴 npm audit fix は使わない（版を勝手に上げ下げする）。');
+console.error('   🔴 直したら lock の差分を全量で読む（版の上げ下げが混ざっていないこと）。');
+process.exit(1);


### PR DESCRIPTION
Closes #296

## 何が壊れていたか

2026-08-23、PR #295（`packages/nene2-ui` の追加）の CI が **`npm ci` で赤**になった。

```
npm error Missing: @hideyukimori/nene2-ui@0.1.0 from lock file
```

🔴 **その直前、`npm run check` は hub 側でも自艦でも全7項目 PASS していた。**

`node_modules` に既にワークスペースが張られている環境では lock の欠落が見えず、check の7項目（type-check / lint / format:check / test / check:cli / conformance / am2-gate）は**どれも lock を読まない**。検出するのは CI の `npm ci` だけだった。

⇒ 🔑 **モノレポにワークスペースを1本足すと、必ず「ローカル緑・CI 赤」になる構造。**

## 直し方

`scripts/check-lock-sync.mjs` を新設し、`check` の**先頭**で走らせる（依存が食い違ったまま後続を走らせない）。中身は `npm ci --dry-run --ignore-scripts --offline` 1本。

| フラグ | 理由 |
|---|---|
| `--offline` | check は**手元で回すループ**（Stop hook パイロットの対象でもある）。ネットワーク依存の検査を混ぜると回線都合の赤が「無視してよい赤」として定着する。**この既決は `check.yml` が `npm run audit` を check に入れない理由として明文で書いている**ので、それに従った |
| `--dry-run` | `node_modules` を書き換えない（手元のループを壊さない） |
| `--ignore-scripts` | ライフサイクルスクリプトを走らせない |

**所要 1.0 秒**（check 全体 14.3 秒に対して無視できる）。

### 条件付きにしなかった理由

hub から「`check` を重くすると誰も回さなくなる。**ワークスペース／依存を触った時だけ**の条件付きが筋だが、**無条件で軽く回る形があるならそちらが上**」という指摘をもらった。実測が **1.0 秒**だったので**無条件**を採った。条件判定を持つと**判定器自体が壊れたときに元の木阿弥**になる。

### なぜ素の npm を直接呼ばずラッパを噛ませたか

`--offline` の副作用で**失敗コードが2種類に割れる**:

| コード | 実際の意味 | 素の文言だとどう見えるか |
|---|---|---|
| `EUSAGE` | lock にエントリが無い | 正しく読める |
| `ENOTCACHED` | 宣言された依存を lock が覆っていない | 🔴 **回線障害に見える** |

**言い直さないと「無視してよい赤」に化ける**（records の Stop hook 観測＝実欠陥検出 S/N 0 と同じ壊れ方）。直し方もその場に出す:

```
🔴 check:lock: package.json が宣言している依存を lock が覆っていない（--offline なので取得は試みていない。回線の問題ではない）

   直し方: npm install --package-lock-only --ignore-scripts
   🔴 npm audit fix は使わない（版を勝手に上げ下げする）。
   🔴 直したら lock の差分を全量で読む（版の上げ下げが混ざっていないこと）。
```

## 検証（自艦で実走・2026-08-23 13:0x）

### 陰性対照

| 確認 | 結果 |
|---|---|
| 正常な lock | ✅ `check:lock: package.json と package-lock.json は同期している` |
| `npm run check` 全8項目 | ✅ PASS（**35 files / 524 tests**・**14.3 秒**） |
| `node_modules` | ✅ 不変（`--dry-run`） |

### 陽性対照2種（**どちらも赤になることを実測し、実行後に復旧**）

| # | 壊し方 | 出た文言 |
|---|---|---|
| 1 | lock からワークスペース登録を削る（**#295 で実際に起きた形**） | `🔴 check:lock: package.json と package-lock.json が同期していない` |
| 2 | `package.json` に lock に無い依存を宣言する | `🔴 check:lock: package.json が宣言している依存を lock が覆っていない（--offline なので取得は試みていない。回線の問題ではない）` |

🔴 **陽性対照を取らない緑は「必要条件すら満たしているか不明」**（#206）。この PR ではその作法に従い、**壊して・検出させて・復旧するまでを1本の記録**にしてある。

## 射程

この欠陥は**自艦固有ではない** — モノレポ構成の艦すべてに同じ穴がある。ただし**配布の判断は hub と施主へ**（板の順序2 の整理と衝突しないよう、まず自艦で形を作る）。

**#238（条文が前提にする装置が実在するか）と同じ層の逆方向**にあたる。条文ではなく検査器の側で、**「緑」が保証している範囲が名乗りより狭い**ケース。

⇒ 順序2 (b)（機械強制できる条文だけ残す）の判定は**2段**が要る（hub 採用済み）:

1. その条文に**検査器が在るか** … #238
2. その検査器が**名乗った範囲を実際に覆っているか** … 本 PR

一般則としては `_work/advice.md` 冒頭に hub が収載済み（2026-08-23 エントリ）。

## 着地の順序

**#293 → #295 → 本 PR**。本 PR は `origin/main` 起点なので #295 とは独立に着地できるが、#295 が先に入ると `check` に `nene2-ui` が乗った状態でこのゲートを通ることになり、**実運用の初回実行が #295 の内容に対して走る**ので望ましい。
