### PR TITLE
feat(ui): W0.5 レイアウト部品（Stack / Grid / Box / Section / Card）— 生の値を9段スケールで吸収する（#298・陽性対照3種つき）

### DIFF
--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -7,6 +7,14 @@ export { Text, type TextProps } from './primitives/Text.js';
 
 // Layout
 export { PageHeader, type PageHeaderProps } from './layout/PageHeader.js';
+export { Stack, type StackProps } from './layout/Stack.js';
+export { Grid, type GridProps } from './layout/Grid.js';
+export { Box, type BoxProps } from './layout/Box.js';
+export { Section, type SectionProps } from './layout/Section.js';
+export { Card, type CardProps } from './layout/Card.js';
+
+// Spacing scale — the names a caller may choose from (design principle 3).
+export type { Space, Responsive } from './lib/spacing.js';
 
 // Forms
 export { FormField, type FormFieldProps } from './forms/FormField.js';

--- a/packages/nene2-ui/src/layout/Box.tsx
+++ b/packages/nene2-ui/src/layout/Box.tsx
@@ -1,0 +1,32 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { PAD, PAD_X, PAD_Y, resolve, type Responsive, type Space } from '../lib/spacing.js';
+
+export interface BoxProps extends HTMLAttributes<HTMLDivElement> {
+  /** Padding on all four sides. `padX` / `padY` win over it, the way `px-*` wins over `p-*`. */
+  pad?: Responsive<Space>;
+  padX?: Responsive<Space>;
+  padY?: Responsive<Space>;
+  children?: ReactNode;
+}
+
+/**
+ * A plain block that carries padding from the scale and nothing else.
+ *
+ * 🔴 There are deliberately no `w` / `h` props, though the fleet writes 241 sizing
+ * utilities by hand. Width is usually a fact about one screen's layout rather than a shared
+ * design decision, and the measured values say so: 241 uses spread across 76 distinct
+ * classes (`w-24`, `w-56`, `min-w-160`, `w-3.75`…). Turning that into a prop would reopen
+ * the value channel this kit exists to close, and would absorb almost nothing. Sizing stays
+ * in the caller's `className`, where it is at least visible to a linter.
+ */
+export function Box({ pad, padX, padY, children, className, ...rest }: BoxProps) {
+  return (
+    <div
+      className={cx(resolve(pad, PAD), resolve(padX, PAD_X), resolve(padY, PAD_Y), className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/layout/Card.tsx
+++ b/packages/nene2-ui/src/layout/Card.tsx
@@ -1,0 +1,34 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { GAP, PAD, resolve, type Responsive, type Space } from '../lib/spacing.js';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  pad?: Responsive<Space>;
+  gap?: Responsive<Space>;
+  /** Lift the card off the page. Off by default — a page of shadows reads as no shadows. */
+  raised?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * A bounded surface: background, hairline border, corner radius, padding.
+ *
+ * Surface, border and radius come from the theme and are not props — a card that could be
+ * given its own colour would be a `div` with extra steps.
+ */
+export function Card({ pad = 'sm', gap, raised = false, children, className, ...rest }: CardProps) {
+  return (
+    <div
+      className={cx(
+        'flex flex-col bg-surface-raised border border-border rounded-x-md',
+        raised && 'shadow-sm',
+        resolve(pad, PAD),
+        resolve(gap, GAP),
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/layout/Grid.tsx
+++ b/packages/nene2-ui/src/layout/Grid.tsx
@@ -1,0 +1,24 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { COLS, GAP, resolve, type Responsive, type Space } from '../lib/spacing.js';
+
+export interface GridProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Column count, optionally per breakpoint: `cols={{ base: 1, sm: 2 }}`.
+   *
+   * Responsive is not a nicety here. `sm:grid-cols-2` is the single most common
+   * breakpoint-qualified class in the fleet (14 uses); a `Grid` that could not express it
+   * would simply not be adopted.
+   */
+  cols?: Responsive<number>;
+  gap?: Responsive<Space>;
+  children: ReactNode;
+}
+
+export function Grid({ cols = 1, gap, children, className, ...rest }: GridProps) {
+  return (
+    <div className={cx('grid', resolve(cols, COLS), resolve(gap, GAP), className)} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/layout/Section.tsx
+++ b/packages/nene2-ui/src/layout/Section.tsx
@@ -1,0 +1,28 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { GAP, PAD, resolve, type Responsive, type Space } from '../lib/spacing.js';
+
+export interface SectionProps extends HTMLAttributes<HTMLElement> {
+  pad?: Responsive<Space>;
+  /** Rhythm between the section's own blocks. */
+  gap?: Responsive<Space>;
+  children: ReactNode;
+}
+
+/**
+ * A titled region of a page: a real `<section>` that stacks its children vertically.
+ *
+ * The defaults are the fleet's two most-written padding and gap values (`p-4` and `gap-3`
+ * measured across 749 hand-written uses), so the common case needs no props at all —
+ * which is the only way a shared component actually gets used.
+ */
+export function Section({ pad = 'sm', gap = 'xs', children, className, ...rest }: SectionProps) {
+  return (
+    <section
+      className={cx('flex flex-col', resolve(pad, PAD), resolve(gap, GAP), className)}
+      {...rest}
+    >
+      {children}
+    </section>
+  );
+}

--- a/packages/nene2-ui/src/layout/Stack.tsx
+++ b/packages/nene2-ui/src/layout/Stack.tsx
@@ -1,0 +1,71 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { GAP, resolve, type Responsive, type Space } from '../lib/spacing.js';
+
+export interface StackProps extends HTMLAttributes<HTMLDivElement> {
+  /** Main axis. Vertical by default — the common case, and the one `space-y-*` was used for. */
+  direction?: 'vertical' | 'horizontal';
+  gap?: Responsive<Space>;
+  align?: 'start' | 'center' | 'end' | 'stretch' | 'baseline';
+  justify?: 'start' | 'center' | 'end' | 'between';
+  wrap?: boolean;
+  /**
+   * Hairline between children.
+   *
+   * 🔴 This exists to absorb `last:border-b-0` / `last:pb-0` / `first:pt-0`, which the fleet
+   * writes 10 times. Those are not screen decisions — they are a list component leaking its
+   * seams into the caller. The kit owns the seams instead of taking them as props.
+   */
+  divider?: boolean;
+  children: ReactNode;
+}
+
+const ALIGN: Record<NonNullable<StackProps['align']>, string> = {
+  start: 'items-start',
+  center: 'items-center',
+  end: 'items-end',
+  stretch: 'items-stretch',
+  baseline: 'items-baseline',
+};
+
+const JUSTIFY: Record<NonNullable<StackProps['justify']>, string> = {
+  start: 'justify-start',
+  center: 'justify-center',
+  end: 'justify-end',
+  between: 'justify-between',
+};
+
+const DIVIDER: Record<NonNullable<StackProps['direction']>, string> = {
+  vertical: 'divide-y divide-border',
+  horizontal: 'divide-x divide-border',
+};
+
+export function Stack({
+  direction = 'vertical',
+  gap,
+  align,
+  justify,
+  wrap = false,
+  divider = false,
+  children,
+  className,
+  ...rest
+}: StackProps) {
+  return (
+    <div
+      className={cx(
+        'flex',
+        direction === 'vertical' ? 'flex-col' : 'flex-row',
+        resolve(gap, GAP),
+        align && ALIGN[align],
+        justify && JUSTIFY[justify],
+        wrap && 'flex-wrap',
+        divider && DIVIDER[direction],
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/layout/layout.test.tsx
+++ b/packages/nene2-ui/src/layout/layout.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+/**
+ * W0.5 レイアウト部品（#298）— Stack / Grid / Box / Section / Card。
+ *
+ * 見ているのは「意匠値が props から入らないこと」と「スケール外の値が黙って壊れないこと」。
+ * クラス文字列そのものを固定しているのは、**Tailwind が静的に拾えない形へ書き換えられたら
+ * 落ちるようにする**ため（実行時に組み立てたクラスは CSS が生成されず、間隔だけが消える）。
+ */
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Box } from './Box.js';
+import { Card } from './Card.js';
+import { Grid } from './Grid.js';
+import { Section } from './Section.js';
+import { Stack } from './Stack.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const classesOf = (el: Element | null) => (el?.getAttribute('class') ?? '').split(/\s+/);
+
+describe('Stack', () => {
+  it('stacks vertically by default and takes gap from the scale', () => {
+    const { container } = render(<Stack gap="md">x</Stack>);
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['flex', 'flex-col', 'gap-x-md']),
+    );
+  });
+
+  it('lays out horizontally when asked — direction is structure, not design', () => {
+    const { container } = render(
+      <Stack direction="horizontal" gap="2xs">
+        x
+      </Stack>,
+    );
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['flex-row', 'gap-x-2xs']),
+    );
+  });
+
+  it('owns the seams between children instead of taking them as props', () => {
+    // 画面側の last:border-b-0 / first:pt-0（実測10件）をここで吸収する。
+    const { container } = render(
+      <Stack divider>
+        <span>a</span>
+        <span>b</span>
+      </Stack>,
+    );
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['divide-y', 'divide-border']),
+    );
+  });
+
+  it('emits one class per breakpoint for a responsive gap', () => {
+    const { container } = render(<Stack gap={{ base: 'xs', sm: 'lg' }}>x</Stack>);
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['gap-x-xs', 'sm:gap-x-lg']),
+    );
+  });
+
+  it('appends the caller className last so it can override, never replace', () => {
+    const { container } = render(
+      <Stack gap="sm" className="mt-2">
+        x
+      </Stack>,
+    );
+    const cls = container.firstElementChild?.getAttribute('class') ?? '';
+    expect(cls).toContain('gap-x-sm');
+    expect(cls.trim().endsWith('mt-2')).toBe(true);
+  });
+
+  it('passes native props through', () => {
+    const { container } = render(
+      <Stack role="list" aria-label="items">
+        x
+      </Stack>,
+    );
+    expect(container.firstElementChild?.getAttribute('role')).toBe('list');
+    expect(container.firstElementChild?.getAttribute('aria-label')).toBe('items');
+  });
+});
+
+describe('Grid', () => {
+  it('is a single column until told otherwise', () => {
+    const { container } = render(<Grid>x</Grid>);
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['grid', 'grid-cols-1']),
+    );
+  });
+
+  it('expresses the fleet’s most common responsive layout', () => {
+    // sm:grid-cols-2 は breakpoint つきクラスの実測最多（14件）。ここが書けないと採用されない。
+    const { container } = render(<Grid cols={{ base: 1, sm: 2 }}>x</Grid>);
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['grid-cols-1', 'sm:grid-cols-2']),
+    );
+  });
+});
+
+describe('Box', () => {
+  it('takes padding from the scale on each axis', () => {
+    const { container } = render(
+      <Box padX="lg" padY="2xs">
+        x
+      </Box>,
+    );
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['px-x-lg', 'py-x-2xs']),
+    );
+  });
+
+  it('renders no spacing class at all when unset', () => {
+    const { container } = render(<Box>x</Box>);
+    expect(container.firstElementChild?.getAttribute('class')).toBe('');
+  });
+});
+
+describe('Section', () => {
+  it('is a real section and needs no props for the common case', () => {
+    const { container } = render(<Section>x</Section>);
+    const el = container.firstElementChild;
+    expect(el?.tagName).toBe('SECTION');
+    expect(classesOf(el)).toEqual(expect.arrayContaining(['p-x-sm', 'gap-x-xs']));
+  });
+});
+
+describe('Card', () => {
+  it('carries surface, border and radius from the theme — none of them props', () => {
+    const { container } = render(<Card>x</Card>);
+    expect(classesOf(container.firstElementChild)).toEqual(
+      expect.arrayContaining(['bg-surface-raised', 'border', 'border-border', 'rounded-x-md']),
+    );
+  });
+
+  it('is flat unless raised — a page of shadows reads as no shadows', () => {
+    const { container: flat } = render(<Card>x</Card>);
+    expect(classesOf(flat.firstElementChild)).not.toContain('shadow-sm');
+
+    const { container: lifted } = render(<Card raised>x</Card>);
+    expect(classesOf(lifted.firstElementChild)).toContain('shadow-sm');
+  });
+});
+
+describe('values that are not on the scale', () => {
+  it('are dropped rather than emitted as a class Tailwind will not generate', () => {
+    // 型では塞いであるが、JS からの呼び出しと古いビルドは実在する。
+    // ここで黙って `gap-x-4.5` を吐くと、CSS が生成されず**間隔だけが消える**。
+    const { container } = render(<Stack gap={'4.5' as never}>x</Stack>);
+    const cls = container.firstElementChild?.getAttribute('class') ?? '';
+    expect(cls).not.toMatch(/gap/);
+  });
+});

--- a/packages/nene2-ui/src/lib/spacing.test.ts
+++ b/packages/nene2-ui/src/lib/spacing.test.ts
@@ -1,0 +1,118 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { COLS, GAP, PAD, PAD_X, PAD_Y, resolve, type Space } from './spacing.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const themeCss = readFileSync(path.join(here, '../../themes/default.css'), 'utf8');
+
+const SPACES: Space[] = ['none', '3xs', '2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'];
+const TABLES = { GAP, PAD, PAD_X, PAD_Y };
+
+describe('spacing scale', () => {
+  it('covers every step in every table, at every breakpoint', () => {
+    for (const [name, table] of Object.entries(TABLES)) {
+      for (const space of SPACES) {
+        const set = table[space];
+        expect(set, `${name}.${space}`).toBeDefined();
+        for (const bp of ['base', 'sm', 'md', 'lg'] as const) {
+          expect(set[bp], `${name}.${space}.${bp}`).toBeTruthy();
+        }
+      }
+    }
+  });
+
+  it('names no step numerically — `gap-x-2` is Tailwind’s own column-gap utility', () => {
+    // A step called `2` would produce `gap-x-2`, which Tailwind resolves to column-gap
+    // rather than to our token. The styling would look almost right, which is worse.
+    for (const space of SPACES) {
+      expect(Number.isNaN(Number(space)), `step "${space}" must not parse as a number`).toBe(true);
+    }
+  });
+
+  it('every token a class refers to is actually defined in the theme', () => {
+    // 🔴 Fail-closed: a class naming a token the theme does not define produces no CSS at
+    // all, and the component silently renders unspaced. This is the check that would have
+    // caught it.
+    const referenced = new Set<string>();
+    for (const table of Object.values(TABLES)) {
+      for (const set of Object.values(table)) {
+        for (const cls of Object.values(set)) {
+          const token = cls
+            .replace(/^[a-z-]+:/, '')
+            .match(/^p[xy]?-(x-[a-z0-9-]+)$|^gap-(x-[a-z0-9-]+)$/);
+          if (token) referenced.add(token[1] ?? token[2]!);
+        }
+      }
+    }
+    expect(referenced.size).toBeGreaterThan(0);
+    for (const token of referenced) {
+      expect(themeCss, `--spacing-${token} missing from themes/default.css`).toContain(
+        `--spacing-${token}:`,
+      );
+    }
+  });
+
+  it('spells every class out, because Tailwind only finds what it can read', () => {
+    // 🔴 This is the one failure the render tests cannot see. Rewriting a table entry as
+    // `gap-x-${size}` keeps every unit test green — the component still emits the right
+    // string at runtime — while Tailwind's scanner stops finding the class and generates no
+    // CSS for it. The spacing silently disappears in the product, not in CI.
+    // Measured (2026-08-23): degrading one of the nine gap rows to template literals drops
+    // the statically visible class count from 192 to 188, with all tests still passing.
+    const source = readFileSync(path.join(here, 'spacing.ts'), 'utf8');
+    const tables = source
+      .slice(source.indexOf('export const GAP'))
+      // Comments legitimately quote class names with backticks; the tables must not.
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+
+    expect(tables.length).toBeGreaterThan(1000);
+    expect(tables, 'a table value is built at runtime — Tailwind will not see it').not.toMatch(
+      /[`$]/,
+    );
+  });
+
+  it('keeps the v0.1 semantic names as aliases, never as second values', () => {
+    // Two names holding the same literal is the drift this kit exists to prevent, so the
+    // primitives that shipped in v0.1 must read their spacing through the scale.
+    for (const legacy of ['x-inline-sm', 'x-inline-md', 'x-stack-sm', 'x-stack-md', 'x-stack-lg']) {
+      expect(themeCss).toMatch(
+        new RegExp(`--spacing-${legacy}:\\s*var\\(--spacing-x-[a-z0-9]+\\)`),
+      );
+    }
+  });
+});
+
+describe('resolve', () => {
+  it('returns nothing for an unset prop, so the class list stays clean', () => {
+    expect(resolve(undefined, GAP)).toBe('');
+  });
+
+  it('takes a bare value as the base breakpoint', () => {
+    expect(resolve('md', GAP)).toBe('gap-x-md');
+    expect(resolve('none', PAD)).toBe('p-0');
+  });
+
+  it('emits one class per breakpoint given an object, in cascade order', () => {
+    expect(resolve({ base: 'xs', sm: 'md', lg: 'xl' }, GAP)).toBe(
+      'gap-x-xs sm:gap-x-md lg:gap-x-xl',
+    );
+  });
+
+  it('skips breakpoints that are not given', () => {
+    expect(resolve({ sm: 'sm' }, GAP)).toBe('sm:gap-x-sm');
+  });
+
+  it('resolves numeric column counts, including responsive ones', () => {
+    expect(resolve(1, COLS)).toBe('grid-cols-1');
+    expect(resolve({ base: 1, sm: 2 }, COLS)).toBe('grid-cols-1 sm:grid-cols-2');
+  });
+
+  it('ignores a value that is not on the scale rather than emitting a broken class', () => {
+    // Callers are typed, but JS callers and stale builds exist.
+    expect(resolve('4.5' as unknown as Space, GAP)).toBe('');
+    expect(resolve({ base: 99 }, COLS)).toBe('');
+  });
+});

--- a/packages/nene2-ui/src/lib/spacing.ts
+++ b/packages/nene2-ui/src/lib/spacing.ts
@@ -1,0 +1,117 @@
+/**
+ * The kit's spacing scale — the single set of spacing values a caller may choose from.
+ *
+ * 🔴 Design principle 3: components take no spacing *values*, only names from this scale.
+ * `<Stack gap={4.5}>` does not exist, on purpose. Once a number can be written, it will be
+ * nudged, and the fleet is back to counting deviations.
+ *
+ * Why nine steps, and why these nine — measured, not guessed (2026-08-23, #298):
+ * across 944 spacing utilities written by hand in the fleet's screens, snapping every one
+ * onto this scale moves 98.2% of them by 2px or less, and 99.7% by 4px or less.
+ * The fleet currently writes those 944 uses with 153 distinct classes; this is nine.
+ *
+ * 🔴 Every class below is written out in full. Tailwind finds utilities by scanning source
+ * text, so a class assembled at runtime (`gap-x-${size}`) is never generated. Do not
+ * "simplify" these tables into template literals — the styles would silently disappear.
+ *
+ * 🔴 Do not name a step something numeric (`x-2`). `gap-x-2` is Tailwind's own column-gap
+ * utility and would win; `gap-x-2xs` is unambiguous because `2xs` is not a number
+ * (verified against tailwindcss 4.3.2).
+ */
+export type Space = 'none' | '3xs' | '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+/** Breakpoint-keyed value. Mobile-first: `base` applies until the next key takes over. */
+export type Responsive<T> = T | { base?: T; sm?: T; md?: T; lg?: T };
+
+type ClassSet = { base: string; sm: string; md: string; lg: string };
+
+/**
+ * Resolve a responsive prop against one of the tables below.
+ * Returns a class string; an undefined value contributes nothing.
+ */
+export function resolve<T extends string | number>(
+  value: Responsive<T> | undefined,
+  table: Record<string, ClassSet>,
+): string {
+  if (value === undefined) return '';
+  if (typeof value !== 'object') return table[String(value)]?.base ?? '';
+  return (['base', 'sm', 'md', 'lg'] as const)
+    .map((bp) => {
+      const v = value[bp];
+      return v === undefined ? '' : (table[String(v)]?.[bp] ?? '');
+    })
+    .filter(Boolean)
+    .join(' ');
+}
+
+/** `gap` on a flex or grid container. */
+export const GAP: Record<Space, ClassSet> = {
+  none: { base: 'gap-0', sm: 'sm:gap-0', md: 'md:gap-0', lg: 'lg:gap-0' },
+  '3xs': { base: 'gap-x-3xs', sm: 'sm:gap-x-3xs', md: 'md:gap-x-3xs', lg: 'lg:gap-x-3xs' },
+  '2xs': { base: 'gap-x-2xs', sm: 'sm:gap-x-2xs', md: 'md:gap-x-2xs', lg: 'lg:gap-x-2xs' },
+  xs: { base: 'gap-x-xs', sm: 'sm:gap-x-xs', md: 'md:gap-x-xs', lg: 'lg:gap-x-xs' },
+  sm: { base: 'gap-x-sm', sm: 'sm:gap-x-sm', md: 'md:gap-x-sm', lg: 'lg:gap-x-sm' },
+  md: { base: 'gap-x-md', sm: 'sm:gap-x-md', md: 'md:gap-x-md', lg: 'lg:gap-x-md' },
+  lg: { base: 'gap-x-lg', sm: 'sm:gap-x-lg', md: 'md:gap-x-lg', lg: 'lg:gap-x-lg' },
+  xl: { base: 'gap-x-xl', sm: 'sm:gap-x-xl', md: 'md:gap-x-xl', lg: 'lg:gap-x-xl' },
+  '2xl': { base: 'gap-x-2xl', sm: 'sm:gap-x-2xl', md: 'md:gap-x-2xl', lg: 'lg:gap-x-2xl' },
+};
+
+/** Padding on all four sides. */
+export const PAD: Record<Space, ClassSet> = {
+  none: { base: 'p-0', sm: 'sm:p-0', md: 'md:p-0', lg: 'lg:p-0' },
+  '3xs': { base: 'p-x-3xs', sm: 'sm:p-x-3xs', md: 'md:p-x-3xs', lg: 'lg:p-x-3xs' },
+  '2xs': { base: 'p-x-2xs', sm: 'sm:p-x-2xs', md: 'md:p-x-2xs', lg: 'lg:p-x-2xs' },
+  xs: { base: 'p-x-xs', sm: 'sm:p-x-xs', md: 'md:p-x-xs', lg: 'lg:p-x-xs' },
+  sm: { base: 'p-x-sm', sm: 'sm:p-x-sm', md: 'md:p-x-sm', lg: 'lg:p-x-sm' },
+  md: { base: 'p-x-md', sm: 'sm:p-x-md', md: 'md:p-x-md', lg: 'lg:p-x-md' },
+  lg: { base: 'p-x-lg', sm: 'sm:p-x-lg', md: 'md:p-x-lg', lg: 'lg:p-x-lg' },
+  xl: { base: 'p-x-xl', sm: 'sm:p-x-xl', md: 'md:p-x-xl', lg: 'lg:p-x-xl' },
+  '2xl': { base: 'p-x-2xl', sm: 'sm:p-x-2xl', md: 'md:p-x-2xl', lg: 'lg:p-x-2xl' },
+};
+
+/** Inline (left/right) padding. */
+export const PAD_X: Record<Space, ClassSet> = {
+  none: { base: 'px-0', sm: 'sm:px-0', md: 'md:px-0', lg: 'lg:px-0' },
+  '3xs': { base: 'px-x-3xs', sm: 'sm:px-x-3xs', md: 'md:px-x-3xs', lg: 'lg:px-x-3xs' },
+  '2xs': { base: 'px-x-2xs', sm: 'sm:px-x-2xs', md: 'md:px-x-2xs', lg: 'lg:px-x-2xs' },
+  xs: { base: 'px-x-xs', sm: 'sm:px-x-xs', md: 'md:px-x-xs', lg: 'lg:px-x-xs' },
+  sm: { base: 'px-x-sm', sm: 'sm:px-x-sm', md: 'md:px-x-sm', lg: 'lg:px-x-sm' },
+  md: { base: 'px-x-md', sm: 'sm:px-x-md', md: 'md:px-x-md', lg: 'lg:px-x-md' },
+  lg: { base: 'px-x-lg', sm: 'sm:px-x-lg', md: 'md:px-x-lg', lg: 'lg:px-x-lg' },
+  xl: { base: 'px-x-xl', sm: 'sm:px-x-xl', md: 'md:px-x-xl', lg: 'lg:px-x-xl' },
+  '2xl': { base: 'px-x-2xl', sm: 'sm:px-x-2xl', md: 'md:px-x-2xl', lg: 'lg:px-x-2xl' },
+};
+
+/** Block (top/bottom) padding. */
+export const PAD_Y: Record<Space, ClassSet> = {
+  none: { base: 'py-0', sm: 'sm:py-0', md: 'md:py-0', lg: 'lg:py-0' },
+  '3xs': { base: 'py-x-3xs', sm: 'sm:py-x-3xs', md: 'md:py-x-3xs', lg: 'lg:py-x-3xs' },
+  '2xs': { base: 'py-x-2xs', sm: 'sm:py-x-2xs', md: 'md:py-x-2xs', lg: 'lg:py-x-2xs' },
+  xs: { base: 'py-x-xs', sm: 'sm:py-x-xs', md: 'md:py-x-xs', lg: 'lg:py-x-xs' },
+  sm: { base: 'py-x-sm', sm: 'sm:py-x-sm', md: 'md:py-x-sm', lg: 'lg:py-x-sm' },
+  md: { base: 'py-x-md', sm: 'sm:py-x-md', md: 'md:py-x-md', lg: 'lg:py-x-md' },
+  lg: { base: 'py-x-lg', sm: 'sm:py-x-lg', md: 'md:py-x-lg', lg: 'lg:py-x-lg' },
+  xl: { base: 'py-x-xl', sm: 'sm:py-x-xl', md: 'md:py-x-xl', lg: 'lg:py-x-xl' },
+  '2xl': { base: 'py-x-2xl', sm: 'sm:py-x-2xl', md: 'md:py-x-2xl', lg: 'lg:py-x-2xl' },
+};
+
+/**
+ * Grid column counts. 1–12 rather than only the six the fleet currently uses
+ * (1, 2, 3, 4, 5, 7), because a column count is a structural fact about a layout,
+ * not a design value — capping it would only push callers back to `grid-cols-*`.
+ */
+export const COLS: Record<number, ClassSet> = {
+  1: { base: 'grid-cols-1', sm: 'sm:grid-cols-1', md: 'md:grid-cols-1', lg: 'lg:grid-cols-1' },
+  2: { base: 'grid-cols-2', sm: 'sm:grid-cols-2', md: 'md:grid-cols-2', lg: 'lg:grid-cols-2' },
+  3: { base: 'grid-cols-3', sm: 'sm:grid-cols-3', md: 'md:grid-cols-3', lg: 'lg:grid-cols-3' },
+  4: { base: 'grid-cols-4', sm: 'sm:grid-cols-4', md: 'md:grid-cols-4', lg: 'lg:grid-cols-4' },
+  5: { base: 'grid-cols-5', sm: 'sm:grid-cols-5', md: 'md:grid-cols-5', lg: 'lg:grid-cols-5' },
+  6: { base: 'grid-cols-6', sm: 'sm:grid-cols-6', md: 'md:grid-cols-6', lg: 'lg:grid-cols-6' },
+  7: { base: 'grid-cols-7', sm: 'sm:grid-cols-7', md: 'md:grid-cols-7', lg: 'lg:grid-cols-7' },
+  8: { base: 'grid-cols-8', sm: 'sm:grid-cols-8', md: 'md:grid-cols-8', lg: 'lg:grid-cols-8' },
+  9: { base: 'grid-cols-9', sm: 'sm:grid-cols-9', md: 'md:grid-cols-9', lg: 'lg:grid-cols-9' },
+  10: { base: 'grid-cols-10', sm: 'sm:grid-cols-10', md: 'md:grid-cols-10', lg: 'lg:grid-cols-10' },
+  11: { base: 'grid-cols-11', sm: 'sm:grid-cols-11', md: 'md:grid-cols-11', lg: 'lg:grid-cols-11' },
+  12: { base: 'grid-cols-12', sm: 'sm:grid-cols-12', md: 'md:grid-cols-12', lg: 'lg:grid-cols-12' },
+};

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -23,9 +23,27 @@
 
   --radius-x-md: 0.5rem;
 
-  --spacing-x-inline-sm: 0.5rem;
-  --spacing-x-inline-md: 1rem;
-  --spacing-x-stack-sm: 0.75rem;
-  --spacing-x-stack-md: 1.25rem;
-  --spacing-x-stack-lg: 2rem;
+  /* The spacing scale. Nine steps, chosen by measurement rather than taste: snapping the
+   * 944 spacing utilities the fleet writes by hand onto these nine moves 98.2% of them by
+   * 2px or less (2026-08-23, #298). See src/lib/spacing.ts.
+   *
+   * 🔴 No step may be named numerically (`x-2`) — `gap-x-2` is Tailwind's own column-gap
+   * utility and would take precedence. */
+  --spacing-x-3xs: 0.25rem;
+  --spacing-x-2xs: 0.5rem;
+  --spacing-x-xs: 0.75rem;
+  --spacing-x-sm: 1rem;
+  --spacing-x-md: 1.25rem;
+  --spacing-x-lg: 1.5rem;
+  --spacing-x-xl: 2rem;
+  --spacing-x-2xl: 3rem;
+
+  /* Semantic names used by the primitives that shipped in v0.1. They are aliases, never
+   * second values — two names holding the same literal is exactly the drift this file
+   * exists to prevent. Rebranding still means editing the scale above, once. */
+  --spacing-x-inline-sm: var(--spacing-x-2xs);
+  --spacing-x-inline-md: var(--spacing-x-sm);
+  --spacing-x-stack-sm: var(--spacing-x-xs);
+  --spacing-x-stack-md: var(--spacing-x-md);
+  --spacing-x-stack-lg: var(--spacing-x-xl);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,17 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['packages/*/src/**/*.test.ts', 'packages/*/tests/**/*.test.ts', 'docs/**/*.test.ts'],
+    // 🔴 .tsx を書き落とすと、テストは「無い」のではなく「**在るのに走らない**」状態になる。
+    // 2026-08-23 に実際に踏んだ（#298 のレイアウト部品のレンダテスト12本が黙って0件扱いだった）。
+    // 同じ日、prettier の format:check glob にも同じ .tsx 欠落があった（#294）。
+    // .tsx を持つパッケージが1つも無い間は、どちらの穴も見えない。
+    include: [
+      'packages/*/src/**/*.test.ts',
+      'packages/*/src/**/*.test.tsx',
+      'packages/*/tests/**/*.test.ts',
+      'packages/*/tests/**/*.test.tsx',
+      'docs/**/*.test.ts',
+    ],
     environment: 'node',
   },
 });


### PR DESCRIPTION
Closes #298

🔴 **ベースは `main` ではなく `feat/nene2-ui`（PR #295）です。** #295 が着地してから本 PR を見てください。

## 何を足したか

`Stack` / `Grid` / `Box` / `Section` / `Card` と、その土台になる**9段のスペーシングスケール**（`src/lib/spacing.ts` ＋ `themes/default.css`）。

## なぜ

W0 のキットは**部品の内側**しか縛らない。**部品を並べる画面側は `className` に生の値を書ける**ので、同じ `shared/ui` を使っていても生の値は `field 424 / vault 138 / deal 87 / payout 0` と割れる。施主方針は「**基本完全準拠**」なので、**①部品を配る → ②tsx 層を計測 → ③lint で落とす** の①を先に置く。

生データ = `_work/reports/2026-08-23-w05-layout-primitives-rawdata.md`（hub 納品・射程ラベルつき）。

## 🔴 スケールが9段である理由 — 計算した

原則3（色・間隔・角丸を props で受けない）があるので `<Stack gap={4.5}>` は存在できない。⇒ 決めるのは**段数だけ**。944件（gap/padding/margin/space）を候補へスナップしたときのズレ:

| 候補 | ズレ≤2px | ズレ≤4px | 最大ズレ |
|---|---:|---:|---:|
| 7段 | 92.1% | 97.7% | 32px |
| 8段 | 96.3% | 99.7% | 16px |
| **9段 `[0,1,2,3,4,5,6,8,12]`** | **98.2%** | **99.7%** | 16px（`py-16`・1件） |
| 10段 | 98.3% | 99.8% | 8px |

10段目は 0.1pt しか買えない。

🔑 **勝ち筋は「段数を減らすこと」ではなく「異なりを潰すこと」。** 艦はこの944件を **153種**の異なりクラスで書いている。それが **9段**になる。

`.5` 刻みは**設計ではなく漂流の証拠**と読んだ。密度が根拠 — **padding は 421件を 87種＝1種あたり 4.8件**、`size` は 241件を 76種＝**3.2件**。さらに hub の追加実測で、**`.5` は `--spacing-x-*` を使わない6艦に集中し、使う2艦（payout / serve）は0件**。

## トークンの置き方（hub の stop 指摘を反映）

`--spacing-x-*` の名前空間に入れた。`nene2-tokens/src/contract.ts` の AM-3 scope 宣言が「typography/radius/spacing は `x-` 拡張」と明文で、実測ではフリートが **`x-` あり2艦・なし6艦**に割れている。**外すとキットが7艦目の逸脱になる。**

既存5本（`x-inline-*` / `x-stack-*`）は **`var()` 別名として残した**:

```css
--spacing-x-inline-md: var(--spacing-x-sm);   /* 1rem — 値は1文字も変えていない */
```

⇒ **v0.1 の部品の見た目は不変**（5本とも旧値と同値であることを実測）、かつ**フリートの 58箇所の remap を段階的にできる**。二重の源は作らない。

🟢 AM-2 の凍結は **color 28 + shadow 4 のみ**なので spacing は射程外＝**stop-the-line ADR 不要**（hub が `contract-freeze.json` と `am2-release-gate.mjs` を実読して確認）。

## API の判断

| 判断 | 理由 |
|---|---|
| variant は**レスポンシブだけ**受ける（`sm`/`md`/`lg`）。**状態は受けない** | `disabled:`/`focus:`/`active:` を props にすると、**逃げ道を塞ぐつもりで逃げ道を新設**することになる。`sm:grid-cols-2` は breakpoint つき最多（14件）なので `cols` の responsive は必須 |
| `last:pb-0` / `first:pt-0`（10件）は props ではなく `Stack` の **`divider`** | あれは画面の決定ではなく、**リスト部品が継ぎ目を呼び出し側へ漏らしている跡** |
| **`w`/`h` の props は作らない** | 241件が **76種**に散っている（`w-24` `w-56` `min-w-160` `w-3.75`…）。値の口を再び開けるだけで**ほとんど吸収しない**。寸法は caller の `className` に残す（そこなら lint から見える） |

## 🔴 ついでに見つかった穴 — `vitest.config.ts` の include に `.tsx` が無い

レンダテストを12本書いたのに **1本も走らなかった**。テストは「無い」のではなく「**在るのに走らない**」。

🔑 **同じ日、prettier の `format:check` glob にも同じ `.tsx` 欠落があった**（#294 で修正済み）。**`.tsx` を持つパッケージが1つも無い間は、どちらの穴も見えない。** 今日3つ目の同族です（1つ目 = `format:check` の glob、2つ目 = `check` に `npm ci` が無い〔#296 / PR #297〕、3つ目 = これ）。

## 検証（自艦で実走・2026-08-23 13:2x）

| 確認 | 結果 |
|---|---|
| `npm run check` 全項目 | ✅ PASS（**38 files / 552 tests**） |
| Tailwind 4.3.2 で実コンパイル | ✅ **`spacing.ts` が吐く 192 クラス全部が CSS を生成**（生成されなかったもの **0**） |
| 別名5本の実効値 | ✅ 旧値と**全て同値**（`inline-sm` 0.5 / `inline-md` 1 / `stack-sm` 0.75 / `stack-md` 1.25 / `stack-lg` 2 rem） |

### 陽性対照3種（**いずれも赤になることを確認し、実行後に復旧**）

| # | 壊し方 | 落ちるテスト |
|---|---|---|
| 1 | テーマからトークンを1本消す | `every token a class refers to is actually defined in the theme` |
| 2 | 別名を実値へ戻す（二重の源を作る） | `keeps the v0.1 semantic names as aliases, never as second values` |
| 3 | テーブルをテンプレートリテラルへ退化させる | `spells every class out, because Tailwind only finds what it can read` |

🔴 **3 が本命です。レンダテストでは検出できません。** 実行時のクラス文字列は正しいままなので**14本のレンダテストは全部緑のまま**で、Tailwind の走査だけが取りこぼす。実測で**静的に見えるクラスが 192 → 188 に減り、CSS が生成されず間隔だけが製品から消える**。この形を落とすテストを1本置いてあります。

## 射程外

- 各艦への載せ替え（W1）。🔴 **施主の目視確認が本番デプロイ前に要る**（波の単位で1回・PR ごとではない）
- **第3のバケツ39件**（`disabled:opacity` 20 / `focus:ring` 11 / `focus-visible:` 5 / `active:scale` 2 / `placeholder:` 1）＝**画面が部品の状態表現を再実装している**類。レイアウト部品では吸収できないので、W1 の前に既存プリミティブ側で拾う
- 既存 `inline`/`stack` **58箇所の remap**（別名で当面動くので移行計画へ）
