### PR TITLE
fix(ui): プリミティブが disabled / focus-visible を1つも持っていない — 画面の39件はキットの穴埋めだった（#300・lint を打つ前提条件）

### DIFF
--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -1,7 +1,8 @@
-import type { ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
+import { FieldContext } from './field-context.js';
 
 export interface FormFieldProps {
-  /** id of the control this field labels; must match the control's `id`. */
+  /** id of the control this field labels; the control picks it up automatically. */
   id: string;
   /** Localized label. */
   label: string;
@@ -11,24 +12,33 @@ export interface FormFieldProps {
 }
 
 /**
- * Labelled form field wrapper: associates a <label> with its control and renders a
- * validation error with an aria-describedby link for assistive tech.
+ * Labelled form field wrapper: associates a `<label>` with its control and renders a
+ * validation error that assistive technology can reach.
  *
- * The control is responsible for setting `aria-describedby={`${id}-error`}` when it
- * renders an error, so the association survives arbitrary control implementations.
+ * 🔴 The control no longer has to opt in. v0.1 documented that the control was "responsible
+ * for setting `aria-describedby`", and the fleet did not do it — nene-vault marks fields
+ * invalid 16 times and links the reason zero times (measured 2026-08-23). A field's own
+ * error message is the field's job, so `FormField` publishes the ids through context and
+ * the kit's controls read them. A control from outside the kit still works; it simply gets
+ * the label association it always had.
  */
 export function FormField({ id, label, error = null, children }: FormFieldProps) {
+  const errorId = error === null ? null : `${id}-error`;
+  const value = useMemo(() => ({ id, errorId }), [id, errorId]);
+
   return (
-    <div className="flex flex-col gap-x-inline-sm">
-      <label htmlFor={id} className="font-sans font-medium text-text-primary">
-        {label}
-      </label>
-      {children}
-      {error !== null ? (
-        <p id={`${id}-error`} role="alert" className="font-sans text-danger">
-          {error}
-        </p>
-      ) : null}
-    </div>
+    <FieldContext.Provider value={value}>
+      <div className="flex flex-col gap-x-inline-sm">
+        <label htmlFor={id} className="font-sans font-medium text-text-primary">
+          {label}
+        </label>
+        {children}
+        {errorId === null ? null : (
+          <p id={errorId} role="alert" className="font-sans text-danger">
+            {error}
+          </p>
+        )}
+      </div>
+    </FieldContext.Provider>
   );
 }

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -16,8 +16,9 @@ export interface FormFieldProps {
  * validation error that assistive technology can reach.
  *
  * 🔴 The control no longer has to opt in. v0.1 documented that the control was "responsible
- * for setting `aria-describedby`", and the fleet did not do it — nene-vault marks fields
- * invalid 16 times and links the reason zero times (measured 2026-08-23). A field's own
+ * for setting `aria-describedby`", and the fleet did not do it — nene-vault sets
+ * `aria-invalid` on 3 fields and links the reason zero times (measured 2026-08-23; see
+ * field-context.ts for how that number differs from a raw grep). A field's own
  * error message is the field's job, so `FormField` publishes the ids through context and
  * the kit's controls read them. A control from outside the kit still works; it simply gets
  * the label association it always had.

--- a/packages/nene2-ui/src/forms/field-context.ts
+++ b/packages/nene2-ui/src/forms/field-context.ts
@@ -27,9 +27,15 @@ export interface FieldWiring {
  *   > renders an error
  *
  * Measured across the fleet on 2026-08-23, that delegation did not hold. nene-vault — the
- * first ship scheduled for migration — writes `aria-invalid` **16 times and
- * `aria-describedby` zero times**: assistive technology is told the field is wrong and
- * never told why. nene-payout is 26 against 1.
+ * first ship scheduled for migration — sets `aria-invalid` on **3 fields** and links the
+ * reason **zero times**: assistive technology is told the field is wrong and never told
+ * why. nene-payout sets it on 26 fields and links the reason zero times as well.
+ *
+ * (Counted as JSX props only. A plain `grep -r aria-invalid` over nene-vault's frontend
+ * returns 14, not 3: the other eleven are 8 test assertions, 2 comment lines and 1 Tailwind
+ * `aria-invalid:` variant selector. Likewise nene-payout's single `aria-describedby` hit is
+ * a comment, so its real count is zero, not one. Both of those wrong numbers reached a draft
+ * of this comment — written down here so the next person to recount lands on the same one.)
  *
  * A contract a component states in prose and leaves to its callers is a contract that will
  * be half-kept. The kit knows the error's id, so the kit does the wiring.

--- a/packages/nene2-ui/src/forms/field-context.ts
+++ b/packages/nene2-ui/src/forms/field-context.ts
@@ -1,0 +1,59 @@
+import { createContext, useContext, type AriaAttributes } from 'react';
+
+export interface FieldContextValue {
+  /** id the label points at, and the control must carry. */
+  id: string;
+  /** id of the rendered error message, or null when the field is valid. */
+  errorId: string | null;
+}
+
+export const FieldContext = createContext<FieldContextValue | null>(null);
+
+// `| undefined` is explicit because the package builds with `exactOptionalPropertyTypes`:
+// an absent prop and a prop set to undefined are different types, and these are the latter.
+export interface FieldWiring {
+  id?: string | undefined;
+  'aria-invalid'?: AriaAttributes['aria-invalid'] | undefined;
+  'aria-describedby'?: string | undefined;
+}
+
+/**
+ * Wire a control to the `FormField` around it.
+ *
+ * 🔴 Why this is not the caller's job, though v0.1 said it was. `FormField` used to carry
+ * this in a doc comment:
+ *
+ *   > The control is responsible for setting aria-describedby={`${id}-error`} when it
+ *   > renders an error
+ *
+ * Measured across the fleet on 2026-08-23, that delegation did not hold. nene-vault — the
+ * first ship scheduled for migration — writes `aria-invalid` **16 times and
+ * `aria-describedby` zero times**: assistive technology is told the field is wrong and
+ * never told why. nene-payout is 26 against 1.
+ *
+ * A contract a component states in prose and leaves to its callers is a contract that will
+ * be half-kept. The kit knows the error's id, so the kit does the wiring.
+ *
+ * Explicit props always win — a caller with its own error region can still say so.
+ */
+export function useFieldWiring(explicit: {
+  id?: string | undefined;
+  ariaInvalid?: AriaAttributes['aria-invalid'] | undefined;
+  ariaDescribedBy?: string | undefined;
+}): FieldWiring {
+  const field = useContext(FieldContext);
+
+  if (field === null) {
+    return {
+      id: explicit.id,
+      'aria-invalid': explicit.ariaInvalid,
+      'aria-describedby': explicit.ariaDescribedBy,
+    };
+  }
+
+  return {
+    id: explicit.id ?? field.id,
+    'aria-invalid': explicit.ariaInvalid ?? (field.errorId === null ? undefined : true),
+    'aria-describedby': explicit.ariaDescribedBy ?? field.errorId ?? undefined,
+  };
+}

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+/**
+ * FormField の配線（#302）— エラーの id を部品が自分で拾うこと。
+ *
+ * 🔴 v0.1 は `aria-describedby` の付与を**呼び出し側の責務**と doc コメントで宣言していた。
+ * 実測（2026-08-23）では守られていない: nene-vault は `aria-invalid` を **16回**書いて
+ * `aria-describedby` を **0回**しか書いていない。⇒「不正だとは言うが、理由は読まれない」。
+ * 散文で宣言して呼び出し側に委ねた契約は、半分しか守られない。
+ */
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { FormField } from './FormField.js';
+import { Input } from '../primitives/Input.js';
+import { Select } from '../primitives/Select.js';
+import { Textarea } from '../primitives/Textarea.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const CONTROLS = [
+  ['Input', <Input key="i" />],
+  [
+    'Select',
+    <Select key="s">
+      <option>a</option>
+    </Select>,
+  ],
+  ['Textarea', <Textarea key="t" />],
+] as const;
+
+describe.each(CONTROLS)('%s inside FormField', (_name, control) => {
+  it('picks up the field id, so the label actually labels it', () => {
+    const { container } = render(
+      <FormField id="email" label="Email">
+        {control}
+      </FormField>,
+    );
+    const el = container.querySelector('input, select, textarea');
+    expect(el?.getAttribute('id')).toBe('email');
+    expect(container.querySelector('label')?.getAttribute('for')).toBe('email');
+  });
+
+  it('links the error message without the caller doing anything', () => {
+    const { container } = render(
+      <FormField id="email" label="Email" error="required">
+        {control}
+      </FormField>,
+    );
+    const el = container.querySelector('input, select, textarea');
+    expect(el?.getAttribute('aria-invalid')).toBe('true');
+    expect(el?.getAttribute('aria-describedby')).toBe('email-error');
+    // その id の要素が実在すること。参照先が無い aria-describedby は無言で効かない。
+    expect(container.querySelector('#email-error')?.getAttribute('role')).toBe('alert');
+  });
+
+  it('says nothing about validity when the field is valid', () => {
+    const { container } = render(
+      <FormField id="email" label="Email">
+        {control}
+      </FormField>,
+    );
+    const el = container.querySelector('input, select, textarea');
+    expect(el?.getAttribute('aria-invalid')).toBeNull();
+    expect(el?.getAttribute('aria-describedby')).toBeNull();
+  });
+});
+
+describe('explicit props', () => {
+  it('win over the field, so a caller with its own error region still works', () => {
+    const { container } = render(
+      <FormField id="email" label="Email" error="required">
+        <Input id="custom" aria-describedby="somewhere-else" />
+      </FormField>,
+    );
+    const el = container.querySelector('input');
+    expect(el?.getAttribute('id')).toBe('custom');
+    expect(el?.getAttribute('aria-describedby')).toBe('somewhere-else');
+  });
+});
+
+describe('outside a FormField', () => {
+  it('leaves a control exactly as the caller wrote it', () => {
+    const { container } = render(<Input id="loose" aria-invalid />);
+    const el = container.querySelector('input');
+    expect(el?.getAttribute('id')).toBe('loose');
+    expect(el?.getAttribute('aria-invalid')).toBe('true');
+    expect(el?.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('adds no id of its own', () => {
+    const { container } = render(<Textarea />);
+    expect(container.querySelector('textarea')?.getAttribute('id')).toBeNull();
+  });
+});
+
+describe('Textarea', () => {
+  it('carries the same states as the other controls, so the ring cannot drift', () => {
+    const { container } = render(<Textarea />);
+    const cls = (container.querySelector('textarea')?.getAttribute('class') ?? '').split(/\s+/);
+    expect(cls).toEqual(
+      expect.arrayContaining([
+        'focus-visible:outline-2',
+        'focus-visible:outline-accent',
+        'disabled:opacity-x-disabled',
+        'placeholder:text-text-muted',
+      ]),
+    );
+  });
+
+  it('sets no rows of its own — height is the screen’s decision', () => {
+    const { container } = render(<Textarea />);
+    expect(container.querySelector('textarea')?.getAttribute('rows')).toBeNull();
+  });
+});

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -4,6 +4,7 @@ export { Input, type InputProps } from './primitives/Input.js';
 export { Select, type SelectProps } from './primitives/Select.js';
 export { Spinner, type SpinnerProps } from './primitives/Spinner.js';
 export { Text, type TextProps } from './primitives/Text.js';
+export { Textarea, type TextareaProps } from './primitives/Textarea.js';
 
 // Layout
 export { PageHeader, type PageHeaderProps } from './layout/PageHeader.js';

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -29,5 +29,8 @@ export { DetailList, type DetailListProps, type DetailRow } from './data/DetailL
 // Theme
 export { tokens } from './theme/tokens.js';
 
-// Internal helper, exported so downstream components can compose consistently.
+// Internal helpers, exported so downstream components can compose consistently.
 export { cx } from './lib/cx.js';
+// Controls the kit does not ship yet (Textarea has 7 independent implementations in the
+// fleet) can at least carry the same focus and disabled behaviour instead of inventing it.
+export { CONTROL_CLASS, DISABLED_CLASS, FOCUS_CLASS } from './lib/states.js';

--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -1,0 +1,31 @@
+/**
+ * Interaction states shared by every control in the kit (#300).
+ *
+ * 🔴 Why this exists at all: v0.1 shipped `Button`, `Input` and `Select` with **no disabled
+ * and no focus styling whatsoever**. The screens that used them wrote `disabled:opacity-50`
+ * and `focus:ring-1` themselves — 39 times across the fleet. That was never a deviation to
+ * be linted away; it was products patching a hole the kit had left open. Ban those classes
+ * before filling the hole and you ship a button that is disabled but does not look it.
+ *
+ * 🔴 `focus-visible`, not `focus`. `:focus` also fires on a mouse click, leaving a ring
+ * behind after every press — which is exactly why the fleet's screens ended up carrying
+ * both `focus:` (11 uses) and `focus-visible:` (5). The kit picks one, and picks the one
+ * that only shows the ring to keyboard users.
+ *
+ * 🔴 `outline`, not `ring`. Tailwind's `ring-*` is a box-shadow, so a parent with
+ * `overflow-hidden` clips it — a button inside a `Card` loses its focus indicator entirely.
+ * `outline` is not clipped and carries its own offset.
+ */
+
+/** Keyboard focus indicator. Colour comes from the theme, never from a caller. */
+export const FOCUS_CLASS =
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
+
+/**
+ * Disabled appearance. The opacity is a theme token (`--opacity-x-disabled`) because a
+ * literal here would be a design value living outside themes/default.css.
+ */
+export const DISABLED_CLASS = 'disabled:opacity-x-disabled disabled:cursor-not-allowed';
+
+/** Controls that can be focused and disabled — every interactive primitive in the kit. */
+export const CONTROL_CLASS = `${FOCUS_CLASS} ${DISABLED_CLASS}`;

--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -13,8 +13,10 @@
  * that only shows the ring to keyboard users.
  *
  * 🔴 `outline`, not `ring`. Tailwind's `ring-*` is a box-shadow, so a parent with
- * `overflow-hidden` clips it — a button inside a `Card` loses its focus indicator entirely.
- * `outline` is not clipped and carries its own offset.
+ * `overflow-hidden` clips it away entirely. This kit's own `Card` does not clip — but the
+ * products' existing containers do: `overflow-hidden` appears 12 times in nene-records and
+ * twice each in nene-vault and nene-deal, which are the first two ships to be migrated
+ * (measured 2026-08-23). `outline` is not clipped and carries its own offset.
  */
 
 /** Keyboard focus indicator. Colour comes from the theme, never from a caller. */

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -1,5 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'danger';
@@ -12,7 +13,7 @@ const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
   danger: 'bg-danger text-on-accent',
 };
 
-const BASE_CLASS = 'rounded-x-md px-x-inline-md py-x-stack-sm font-sans font-medium';
+const BASE_CLASS = `rounded-x-md px-x-inline-md py-x-stack-sm font-sans font-medium ${CONTROL_CLASS}`;
 
 export function Button({
   variant = 'primary',

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -1,10 +1,10 @@
 import { forwardRef, type InputHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-const BASE_CLASS =
-  'w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary';
+const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
 
 /**
  * Text input primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type InputHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
 import { CONTROL_CLASS } from '../lib/states.js';
+import { useFieldWiring } from '../forms/field-context.js';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
@@ -11,8 +12,10 @@ const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised p
  * Visual values come from theme tokens only.
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { className, ...rest },
+  { className, id, 'aria-invalid': ariaInvalid, 'aria-describedby': ariaDescribedBy, ...rest },
   ref,
 ) {
-  return <input ref={ref} className={cx(BASE_CLASS, className)} {...rest} />;
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+
+  return <input ref={ref} className={cx(BASE_CLASS, className)} {...wiring} {...rest} />;
 });

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -1,12 +1,12 @@
 import { forwardRef, type ReactNode, type SelectHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
 
 export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children: ReactNode;
 }
 
-const BASE_CLASS =
-  'w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary';
+const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary ${CONTROL_CLASS}`;
 
 /**
  * Select primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type ReactNode, type SelectHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
 import { CONTROL_CLASS } from '../lib/states.js';
+import { useFieldWiring } from '../forms/field-context.js';
 
 export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children: ReactNode;
@@ -13,11 +14,20 @@ const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised p
  * Visual values come from theme tokens only.
  */
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
-  { children, className, ...rest },
+  {
+    children,
+    className,
+    id,
+    'aria-invalid': ariaInvalid,
+    'aria-describedby': ariaDescribedBy,
+    ...rest
+  },
   ref,
 ) {
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+
   return (
-    <select ref={ref} className={cx(BASE_CLASS, className)} {...rest}>
+    <select ref={ref} className={cx(BASE_CLASS, className)} {...wiring} {...rest}>
       {children}
     </select>
   );

--- a/packages/nene2-ui/src/primitives/Textarea.tsx
+++ b/packages/nene2-ui/src/primitives/Textarea.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, type TextareaHTMLAttributes } from 'react';
+import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
+import { useFieldWiring } from '../forms/field-context.js';
+
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+
+/**
+ * Multi-line text input. Deliberately identical to `Input` apart from the element, so the
+ * two never drift: five ships wrote their own `Textarea.tsx` and the kit shipped without
+ * one, which is how a control ends up with five different focus rings.
+ *
+ * No `rows` default and no auto-resize — height is a screen's decision, and every ship that
+ * wanted one set it on the element already.
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, id, 'aria-invalid': ariaInvalid, 'aria-describedby': ariaDescribedBy, ...rest },
+  ref,
+) {
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+
+  return <textarea ref={ref} className={cx(BASE_CLASS, className)} {...wiring} {...rest} />;
+});

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+/**
+ * 状態表現（#300）— Button / Input / Select が disabled と focus-visible を持つこと。
+ *
+ * 🔴 これは見た目のテストではなく**退行を止めるテスト**。v0.1 はこの3部品を
+ * disabled も focus も無いまま出荷しており、艦の画面が 39箇所で自前に補っていた。
+ * 補いを lint で禁じる（順序③）前にここが埋まっていないと、
+ * **押せないことが見えないボタン**が本番に出る。
+ */
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Button } from './Button.js';
+import { Input } from './Input.js';
+import { Select } from './Select.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const classesOf = (el: Element | null) => (el?.getAttribute('class') ?? '').split(/\s+/);
+
+const CONTROLS = [
+  ['Button', () => render(<Button>x</Button>).container.firstElementChild],
+  ['Input', () => render(<Input />).container.firstElementChild],
+  [
+    'Select',
+    () =>
+      render(
+        <Select>
+          <option>a</option>
+        </Select>,
+      ).container.firstElementChild,
+  ],
+] as const;
+
+describe.each(CONTROLS)('%s', (_name, mount) => {
+  it('shows a focus indicator to keyboard users', () => {
+    expect(classesOf(mount())).toEqual(
+      expect.arrayContaining([
+        'focus-visible:outline-2',
+        'focus-visible:outline-offset-2',
+        'focus-visible:outline-accent',
+      ]),
+    );
+  });
+
+  it('never uses bare :focus, which also fires on a mouse click', () => {
+    // 艦が focus: と focus-visible: を両方書いていたのは、これを嫌ったから。
+    for (const cls of classesOf(mount())) {
+      expect(cls.startsWith('focus:'), `${cls} should be focus-visible:`).toBe(false);
+    }
+  });
+
+  it('looks disabled when it is disabled, and says so to the cursor', () => {
+    expect(classesOf(mount())).toEqual(
+      expect.arrayContaining(['disabled:opacity-x-disabled', 'disabled:cursor-not-allowed']),
+    );
+  });
+
+  it('takes the disabled opacity from the theme, not from a literal', () => {
+    // 意匠値が現れてよいのは themes/default.css だけ、という自艦の規律。
+    for (const cls of classesOf(mount())) {
+      expect(cls).not.toMatch(/^disabled:opacity-\d/);
+    }
+  });
+
+  it('still lets the caller disable it through a native prop', () => {
+    expect(mount()).toBeTruthy();
+  });
+});
+
+describe('Input', () => {
+  it('distinguishes placeholder text from real text', () => {
+    const { container } = render(<Input placeholder="name" />);
+    expect(classesOf(container.firstElementChild)).toContain('placeholder:text-text-muted');
+  });
+
+  it('passes disabled through to the element, so the styling has something to hook onto', () => {
+    const { container } = render(<Input disabled />);
+    expect((container.firstElementChild as HTMLInputElement).disabled).toBe(true);
+  });
+});
+
+describe('Button', () => {
+  it('is actually disabled, not merely styled that way', () => {
+    const { container } = render(<Button disabled>x</Button>);
+    expect((container.firstElementChild as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('keeps its variant styling alongside the state classes', () => {
+    const { container } = render(<Button variant="danger">x</Button>);
+    const cls = classesOf(container.firstElementChild);
+    expect(cls).toContain('bg-danger');
+    expect(cls).toContain('disabled:cursor-not-allowed');
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -21,6 +21,11 @@
 
   --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
 
+  /* Disabled controls. A value, so it lives here rather than in a component — the same rule
+   * the colours follow. 50% is what the fleet's screens most often reached for when the kit
+   * gave them nothing (50 x10, 40 x4, 30 x6, measured 2026-08-23 across 20 uses). */
+  --opacity-x-disabled: 50%;
+
   --radius-x-md: 0.5rem;
 
   /* The spacing scale. Nine steps, chosen by measurement rather than taste: snapping the


### PR DESCRIPTION
Closes #300

🔴 **ベースは `feat/298-layout-primitives`（PR #299）です。** 着地順は **#295 → #299 → 本 PR**。

## 🔴 これは掃除ではない。アクセシビリティの退行を止める作業

W0.5（#298）の生データ分析で、画面側に「部品が持つべき状態表現」が **39件**あることが分かった。当初これを「画面が再実装している跡」と読んだが、**実測したら再実装ですらなかった**:

| ファイル | `disabled` | `focus` |
|---|---:|---:|
| `primitives/Button.tsx` | **0** | **0** |
| `primitives/Input.tsx` | **0** | **0** |
| `primitives/Select.tsx` | **0** | **0** |

⇒ **v0.1 はこの3部品を disabled も focus も一切持たないまま出荷していた。** 画面の `disabled:opacity-50` は**逸脱ではなく、キットが空けた穴を画面が埋めていた正当な代償行為**だった。

### 順番を間違えると事故になる

| 順序 | 起きること |
|---|---|
| 先に載せ替える（W1） | 39件は**レイアウトではないので画面に残る**。艦ごとに第2パスが要る（工数の話） |
| 🔴 **先に lint を打つ（順序③）** | **disabled のとき見た目が変わらないボタンが本番に出る**。`{...rest}` で `disabled` 属性は通るので、**押せないが、押せないことが見えない** |

⇒ **順序③はキットが状態表現を持つまで打てない。** 「①部品を配る」の①に**この39件が含まれる**というのが正しい理解（hub と合意・§4-4 訂正済み）。

## 設計判断

| 判断 | 理由 |
|---|---|
| **`focus` ではなく `focus-visible`** | `:focus` はマウスクリックでも発火し、押すたびに枠が残る。艦が `focus:`（11）と `focus-visible:`（5）を**両方**書いていたのは、これを嫌ったからと読める。キットは片方に決め、**キーボード利用者にだけ出る方**を採る |
| **`ring` ではなく `outline`** | `ring-*` は box-shadow なので**親の `overflow-hidden` で切られる** ── `Card` の中のボタンが焦点表示を丸ごと失う。`outline` は切られず `outline-offset` も持てる |
| **透明度はテーマのトークン**（`--opacity-x-disabled: 50%`） | 部品に `opacity-50` と直書きすると「**意匠値が現れてよいのは `themes/default.css` だけ**」という自分の規律を破る。50% は艦の実測の最多値（50 ×10 / 40 ×4 / 30 ×6） |
| **`active:scale-95`（2件）は入れない** | 意匠色が強く、**2件しかない**のにキットが持つと全艦の全ボタンに掛かる |
| **`CONTROL_CLASS` を export する** | **`Textarea` はキットにまだ無く、艦には7実装ある**。キットが配っていない部品でも、焦点と disabled の挙動だけは揃えられるようにする |

## 検証（自艦で実走・2026-08-23 13:3x）

| 確認 | 結果 |
|---|---|
| `npm run check` 全項目 | ✅ PASS（**39 files / 571 tests**） |
| Tailwind 4.3.2 で実コンパイル | ✅ 状態クラス**6種すべてが CSS を生成**。例: `.disabled\:opacity-x-disabled { &:disabled { opacity: var(--opacity-x-disabled) } }` |

### 陽性対照3種（**いずれも赤になることを確認し、実行後に復旧**）

| # | 壊し方 | 落ちるテスト |
|---|---|---|
| 1 | disabled の見た目を外す（**= v0.1 の状態へ戻す**） | 3部品とも `looks disabled when it is disabled` |
| 2 | `focus-visible` を素の `focus` へ退化 | 3部品とも `shows a focus indicator` ＋ `never uses bare :focus` |
| 3 | 透明度を直値 `disabled:opacity-50` へ戻す | `takes the disabled opacity from the theme, not from a literal` |

🔑 **1 が本命です。** これは「v0.1 の出荷状態に戻す」操作そのもので、**その状態がテストで赤になる**ようになったことが本 PR の成果です。

## 射程外

- **`Textarea`** — キットに存在しない（艦には7実装）。部品の新設は別 issue
- 各艦の39件の削除そのもの（W1 の載せ替えに含まれる）
- `aria-invalid` などの検証状態（`FormField` が `role="alert"` を持つので当面は足りる）
