### PR TITLE
feat(ui): W0.6 — 三状態の欠けた1本（LoadingState）と重複実装の多いフィードバック部品（Modal 8 / ConfirmDialog 5 / Badge 5 / InlineAlert 6）（#304・陽性対照4種）

### DIFF
--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -104,27 +104,35 @@ loading/empty/error state set, read-only detail displays.
 screens (invoice previews, kanban boards, reports), and anything in the `model/` layer — data
 fetching and state are governed by `@hideyukimori/nene2-standards`, not by this kit.
 
-## Components (v0.1)
+## Components
 
-Promoted verbatim from `nene-payout`, the fleet's only conformance-violation-free product, with
-one correctness fix: `className` now composes instead of replacing.
+🔴 **This table is generated from `src/index.ts`.** Regenerate it when you add a component —
+a component list that lags the code is how a product ends up writing a part that already exists.
 
 | Group        | Components                                                  |
 | ------------ | ----------------------------------------------------------- |
-| `primitives` | `Button` `Input` `Select` `Spinner` `Text`                  |
-| `layout`     | `PageHeader`                                                |
+| `primitives` | `Button` `Input` `Select` `Spinner` `Text` `Textarea`       |
+| `layout`     | `PageHeader` `Stack` `Grid` `Box` `Section` `Card`          |
 | `forms`      | `FormField`                                                 |
-| `states`     | `EmptyState` `ErrorState`                                   |
+| `states`     | `LoadingState` `EmptyState` `ErrorState`                    |
+| `overlay`    | `Modal` `ConfirmDialog`                                     |
+| `feedback`   | `Badge` `InlineAlert`                                       |
 | `data`       | `DetailList`                                                |
 | `theme`      | `tokens` (read-only `var()` accessors for canvas/chart use) |
 
-`Input` and `Select` use `forwardRef`, so they drop straight into `react-hook-form`'s `register`.
+`Input`, `Select` and `Textarea` use `forwardRef`, so they drop straight into
+`react-hook-form`'s `register`, and pick up their `id` / `aria-describedby` from the
+`FormField` around them.
 
 ### Not yet here
 
-`Modal` `ConfirmDialog` `Toast` `Badge` `Card` `Stack` `DataTable` `Pagination` `Textarea`
-`Checkbox` `Alert` `LoadingState` — all measured as recurring across ≥3 products. They land as
-migrating products contribute their implementation upward, rather than being designed up front.
+`Toast` `DataTable` `Pagination` `Checkbox` `Radio` `Switch` `Icon` — all measured as recurring
+across ≥3 products. They land as migrating products contribute their implementation upward,
+rather than being designed up front.
+
+Until one lands, a product writing its own control can import `CONTROL_CLASS` so that at least
+the focus ring and the disabled treatment match the rest of the kit. **What each product imports
+it for is the measured list of what the kit is still missing.**
 
 ## Contributing a component
 

--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+
+export interface BadgeProps {
+  /** What the badge means, not what colour it is. */
+  tone?: 'neutral' | 'accent' | 'danger';
+  children: ReactNode;
+}
+
+const TONE_CLASS: Record<NonNullable<BadgeProps['tone']>, string> = {
+  neutral: 'bg-surface text-text-muted border-border',
+  accent: 'bg-accent text-on-accent border-accent',
+  danger: 'bg-danger text-on-accent border-danger',
+};
+
+/**
+ * A small status marker.
+ *
+ * 🔴 `tone` names a meaning, never a colour. `<Badge tone="danger">` survives a rebrand;
+ * `<Badge color="red">` becomes a lie the moment the theme changes, and there is no way to
+ * find every such lie afterwards except by reading every screen.
+ */
+export function Badge({ tone = 'neutral', children }: BadgeProps) {
+  return (
+    <span
+      className={cx(
+        'inline-flex items-center rounded-x-md border px-x-2xs py-x-3xs font-sans',
+        TONE_CLASS[tone],
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/nene2-ui/src/feedback/InlineAlert.tsx
+++ b/packages/nene2-ui/src/feedback/InlineAlert.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+
+export interface InlineAlertProps {
+  /** What the message means. `danger` is announced assertively; `info` politely. */
+  tone?: 'info' | 'danger';
+  children: ReactNode;
+}
+
+const TONE_CLASS: Record<NonNullable<InlineAlertProps['tone']>, string> = {
+  info: 'bg-surface text-text-primary border-border',
+  danger: 'bg-surface text-danger border-danger',
+};
+
+/**
+ * A message attached to the thing it is about, rather than to the page.
+ *
+ * 🔴 The tone decides the ARIA role, not just the colour. `danger` becomes `role="alert"`,
+ * which interrupts a screen reader; `info` becomes `role="status"`, which waits its turn.
+ * Six ships wrote this component (three as `InlineAlert`, three as `Alert`) and the choice
+ * of role is precisely the part that is easy to get wrong and invisible when you do.
+ */
+export function InlineAlert({ tone = 'info', children }: InlineAlertProps) {
+  return (
+    <div
+      role={tone === 'danger' ? 'alert' : 'status'}
+      className={cx('rounded-x-md border p-x-2xs font-sans', TONE_CLASS[tone])}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+/**
+ * W0.6（#304）— LoadingState / Modal / ConfirmDialog / Badge / InlineAlert。
+ *
+ * 見ているのは意匠ではなく**意味の割り当て**（role / aria / 焦点の順序）。
+ * 艦が別々に書いたとき最初にズレるのがここで、しかも**ズレても画面は正しく見える**。
+ */
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Badge } from './Badge.js';
+import { InlineAlert } from './InlineAlert.js';
+import { ConfirmDialog } from '../overlay/ConfirmDialog.js';
+import { Modal } from '../overlay/Modal.js';
+import { LoadingState } from '../states/LoadingState.js';
+import { EmptyState } from '../states/EmptyState.js';
+import { ErrorState } from '../states/ErrorState.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('the three states', () => {
+  it('all exist — the README promises them as a set', async () => {
+    // v0.1 は LoadingState を欠いたまま「set として出荷する」と書いていた。
+    const kit = await import('../index.js');
+    for (const name of ['LoadingState', 'EmptyState', 'ErrorState'] as const) {
+      expect(kit[name], `${name} must be exported`).toBeTypeOf('function');
+    }
+  });
+
+  it('each announces itself, and none of them announces twice', () => {
+    const loading = render(<LoadingState label="loading" />).container;
+    // Spinner が <output aria-live> なので、包む側は live region を重ねない。
+    expect(loading.firstElementChild?.getAttribute('aria-busy')).toBe('true');
+    expect(loading.firstElementChild?.getAttribute('role')).toBeNull();
+    expect(loading.querySelector('output')?.getAttribute('aria-live')).toBe('polite');
+
+    expect(
+      render(<EmptyState message="none" />).container.firstElementChild?.getAttribute('role'),
+    ).toBe('status');
+    expect(
+      render(
+        <ErrorState message="bad" retryLabel="retry" onRetry={() => {}} />,
+      ).container.firstElementChild?.getAttribute('role'),
+    ).toBe('alert');
+  });
+});
+
+describe('Modal', () => {
+  it('is a real dialog, named by its title', () => {
+    const { container } = render(
+      <Modal open title="Settings" onClose={() => {}}>
+        body
+      </Modal>,
+    );
+    const el = container.querySelector('dialog');
+    expect(el).toBeTruthy();
+    expect(el?.getAttribute('aria-label')).toBe('Settings');
+  });
+
+  it('opens through showModal when the browser has it — only that puts it in the top layer', () => {
+    const showModal = vi.fn(function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    });
+    // jsdom 25.0.1 does not implement showModal at all, so the test supplies it.
+    Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+      value: showModal,
+      configurable: true,
+      writable: true,
+    });
+
+    render(
+      <Modal open title="t" onClose={() => {}}>
+        b
+      </Modal>,
+    );
+    expect(showModal).toHaveBeenCalledTimes(1);
+
+    Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal');
+  });
+
+  it('still shows itself where showModal does not exist, rather than vanishing', () => {
+    // 🔴 これが無いと、jsdom と古いブラウザでは「開かない modal」になる。
+    expect(HTMLDialogElement.prototype.showModal).toBeUndefined();
+    const { container } = render(
+      <Modal open title="t" onClose={() => {}}>
+        b
+      </Modal>,
+    );
+    expect(container.querySelector('dialog')?.hasAttribute('open')).toBe(true);
+  });
+
+  it('is closed when it is not open', () => {
+    const { container } = render(
+      <Modal open={false} title="t" onClose={() => {}}>
+        b
+      </Modal>,
+    );
+    expect(container.querySelector('dialog')?.hasAttribute('open')).toBe(false);
+  });
+});
+
+describe('ConfirmDialog', () => {
+  const props = {
+    open: true,
+    title: 'Delete',
+    message: 'Sure?',
+    confirmLabel: 'Delete',
+    cancelLabel: 'Cancel',
+  };
+
+  it('puts the safe choice first, so keyboard order reaches it first', () => {
+    const { container } = render(
+      <ConfirmDialog {...props} onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    const labels = [...container.querySelectorAll('button')].map((b) => b.textContent);
+    expect(labels).toEqual(['Cancel', 'Delete']);
+  });
+
+  it('marks a destructive confirmation as destructive', () => {
+    const { container } = render(
+      <ConfirmDialog {...props} tone="danger" onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    const confirm = [...container.querySelectorAll('button')].at(-1);
+    expect(confirm?.getAttribute('class')).toContain('bg-danger');
+  });
+
+  it('is not destructive-looking by default', () => {
+    const { container } = render(
+      <ConfirmDialog {...props} onConfirm={() => {}} onCancel={() => {}} />,
+    );
+    const confirm = [...container.querySelectorAll('button')].at(-1);
+    expect(confirm?.getAttribute('class')).toContain('bg-accent');
+  });
+
+  it('routes a dismissal to onCancel, never to onConfirm', () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    const { container } = render(
+      <ConfirmDialog {...props} onConfirm={onConfirm} onCancel={onCancel} />,
+    );
+    container.querySelector('dialog')?.dispatchEvent(new Event('close'));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('Badge', () => {
+  it('takes a meaning, and reads its colour from the theme', () => {
+    const { container } = render(<Badge tone="danger">x</Badge>);
+    const cls = container.firstElementChild?.getAttribute('class') ?? '';
+    expect(cls).toContain('bg-danger');
+    expect(cls).not.toMatch(/#|rgb|\[/);
+  });
+
+  it('is neutral unless told otherwise', () => {
+    const { container } = render(<Badge>x</Badge>);
+    expect(container.firstElementChild?.getAttribute('class')).toContain('text-text-muted');
+  });
+});
+
+describe('InlineAlert', () => {
+  it('interrupts for danger and waits its turn for info', () => {
+    // 🔴 tone が決めるのは色だけではない。role が変わる。
+    expect(
+      render(<InlineAlert tone="danger">x</InlineAlert>).container.firstElementChild?.getAttribute(
+        'role',
+      ),
+    ).toBe('alert');
+    expect(
+      render(<InlineAlert>x</InlineAlert>).container.firstElementChild?.getAttribute('role'),
+    ).toBe('status');
+  });
+});

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -20,9 +20,19 @@ export type { Space, Responsive } from './lib/spacing.js';
 // Forms
 export { FormField, type FormFieldProps } from './forms/FormField.js';
 
-// States
+// States — the three ship together (design principle 5). Adding a fourth screen state
+// means adding it here, or the set stops being a set.
+export { LoadingState, type LoadingStateProps } from './states/LoadingState.js';
 export { EmptyState, type EmptyStateProps } from './states/EmptyState.js';
 export { ErrorState, type ErrorStateProps } from './states/ErrorState.js';
+
+// Overlay
+export { Modal, type ModalProps } from './overlay/Modal.js';
+export { ConfirmDialog, type ConfirmDialogProps } from './overlay/ConfirmDialog.js';
+
+// Feedback
+export { Badge, type BadgeProps } from './feedback/Badge.js';
+export { InlineAlert, type InlineAlertProps } from './feedback/InlineAlert.js';
 
 // Data
 export { DetailList, type DetailListProps, type DetailRow } from './data/DetailList.js';

--- a/packages/nene2-ui/src/overlay/ConfirmDialog.tsx
+++ b/packages/nene2-ui/src/overlay/ConfirmDialog.tsx
@@ -1,0 +1,55 @@
+import { Button } from '../primitives/Button.js';
+import { Stack } from '../layout/Stack.js';
+import { Text } from '../primitives/Text.js';
+import { Modal } from './Modal.js';
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  /** Localized title. */
+  title: string;
+  /** Localized body. */
+  message: string;
+  /** Localized label for the affirmative control. */
+  confirmLabel: string;
+  /** Localized label for the dismissive control. */
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** `danger` for destructive confirmations. Chooses a variant, never a colour. */
+  tone?: 'default' | 'danger';
+}
+
+/**
+ * "Are you sure?" — the same dialog five ships wrote separately.
+ *
+ * 🔴 Cancel comes first in the DOM. It is the safe choice, so it is the one that should be
+ * reached first by keyboard and the one focus lands on when the dialog opens. A destructive
+ * confirmation whose dangerous button is the default is a footgun, and it is exactly the
+ * kind of detail that differs between five independent implementations.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+  tone = 'default',
+}: ConfirmDialogProps) {
+  return (
+    <Modal open={open} onClose={onCancel} title={title}>
+      <Stack gap="xs">
+        <Text>{message}</Text>
+        <Stack direction="horizontal" gap="2xs" justify="end">
+          <Button variant="secondary" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+          <Button variant={tone === 'danger' ? 'danger' : 'primary'} onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </Stack>
+      </Stack>
+    </Modal>
+  );
+}

--- a/packages/nene2-ui/src/overlay/Modal.tsx
+++ b/packages/nene2-ui/src/overlay/Modal.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+
+export interface ModalProps {
+  open: boolean;
+  /** Called for every dismissal the browser owns: Esc, the close control, the backdrop. */
+  onClose: () => void;
+  /** Localized title. Also names the dialog for assistive tech. */
+  title: string;
+  children: ReactNode;
+}
+
+/**
+ * A modal dialog built on the native `<dialog>` element.
+ *
+ * 🔴 Why native. Focus trapping, Esc-to-dismiss, the backdrop, and rendering above every
+ * stacking context are all things the browser already does correctly. Eight ships wrote
+ * their own modal, which means the fleet currently maintains eight focus traps — the single
+ * hardest piece of interaction code to get right, reimplemented per product.
+ *
+ * 🔴 `showModal()` is called imperatively rather than through the `open` attribute, because
+ * only `showModal()` puts the dialog in the top layer and traps focus; setting `open`
+ * renders it inline and non-modal. jsdom 25.0.1 does not implement `showModal` at all
+ * (measured 2026-08-23), and neither do browsers older than the feature, so the fallback
+ * sets `open` — degraded but visible, rather than a dialog that never appears.
+ */
+export function Modal({ open, onClose, title, children }: ModalProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el === null) return;
+
+    if (open) {
+      if (typeof el.showModal === 'function') {
+        if (!el.open) el.showModal();
+      } else {
+        el.setAttribute('open', '');
+      }
+      return;
+    }
+
+    if (typeof el.close === 'function') {
+      if (el.open) el.close();
+    } else {
+      el.removeAttribute('open');
+    }
+  }, [open]);
+
+  return (
+    <dialog
+      ref={ref}
+      aria-label={title}
+      // The browser fires `close` for Esc as well as for close(); routing both through the
+      // caller keeps `open` from drifting out of sync with what is on screen.
+      onClose={onClose}
+      onCancel={onClose}
+      className={cx(
+        'bg-surface-raised text-text-primary border border-border rounded-x-md',
+        'p-x-sm font-sans backdrop:bg-text-primary/50',
+      )}
+    >
+      {children}
+    </dialog>
+  );
+}

--- a/packages/nene2-ui/src/states/LoadingState.tsx
+++ b/packages/nene2-ui/src/states/LoadingState.tsx
@@ -1,0 +1,27 @@
+import { Spinner } from '../primitives/Spinner.js';
+
+export interface LoadingStateProps {
+  /** Localized message announced while the work is in flight. */
+  label: string;
+}
+
+/**
+ * The third of the three states.
+ *
+ * 🔴 The kit's own README says these ship as a set — "so a screen that handles only the
+ * happy path is visibly incomplete" — and then v0.1 shipped `EmptyState` and `ErrorState`
+ * without this one. Five ships wrote their own. A set documented as a set and delivered
+ * short is worse than no set: every screen author reads the principle, looks for the part,
+ * and writes their own.
+ *
+ * 🔴 The wrapper carries no `role="status"`. `Spinner` renders an `<output aria-live>`,
+ * and a live region wrapped in another live region is announced twice. `aria-busy` marks
+ * the region as in-flight without adding a second announcer.
+ */
+export function LoadingState({ label }: LoadingStateProps) {
+  return (
+    <div className="py-x-stack-lg" aria-busy="true">
+      <Spinner label={label} />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #304

🔴 **ベースは `fix/300-primitive-states`（PR #301）です。** 着地順 = **#295 → #299 → #301 → 本 PR**。

## 🔴 1. `LoadingState` — キット自身の仕様違反だった

`README.md` の設計原則5:

> **The three states ship together.** `LoadingState` / `EmptyState` / `ErrorState` exist as a set so a screen that handles only the happy path is visibly incomplete.

**そう書いてあるのに、v0.1 は `EmptyState` と `ErrorState` だけを出荷していました。** 艦の独立実装は **5本**。

🔑 **set だと書いてある set を、欠けたまま配ると、set が無いより悪い。** 画面を書く人は原則を読み、部品を探し、無いので自分で書きます。

包む側に `role="status"` は付けていません。`Spinner` が `<output aria-live>` なので、**live region を live region で包むと二重に読み上げられる**ためです。`aria-busy` で「進行中」だけを示します。

## 2. `Modal` — native `<dialog>`

| | |
|---|---|
| なぜ native | 焦点トラップ・Esc・バックドロップ・top-layer が**ブラウザ実装で手に入る**。**8艦が自前で書いた＝フリートは焦点トラップを8つ保守している** ── 対話コードで最も間違えやすい部分を製品ごとに再実装している |
| なぜ `showModal()` を命令的に呼ぶか | `open` 属性を立てるだけでは**top-layer に入らず焦点もトラップしない** |
| 🔴 フォールバック | **jsdom 25.0.1 は `showModal` を実装していない**〔自艦で実測: `typeof dialog.showModal === 'undefined'`〕。無い環境では `open` 属性へ縮退する。**これが無いと「開かない modal」になる** |

## 3. `ConfirmDialog` — cancel を先に置く

安全な選択肢なので、**キーボードで先に届くべきで、開いた直後に焦点が載るべき**もの。**破壊的な確認の既定が破壊側にある**のは footgun で、**5つの独立実装の間でちょうど食い違う類の細部**です。

## 4. `Badge` / `InlineAlert` — `tone` は色ではなく意味

`<Badge tone="danger">` はリブランドを生き延びます。`<Badge color="red">` は**テーマが変わった瞬間に嘘になり、全画面を読む以外に嘘を見つける方法がありません**。

🔴 **`InlineAlert` では `tone` が ARIA role も決めます。** `danger` → `role="alert"`（読み上げを中断）／`info` → `role="status"`（順番を待つ）。6艦がこれを書いており（`InlineAlert` 3 / `Alert` 3）、**role の選択こそ間違えやすく、間違えても画面は正しく見えます。**

## 5. README のインベントリを実装から生成し直した

「Not yet here」に `Stack` `Card` `Textarea` `Modal` `Badge` `LoadingState` `ConfirmDialog` が並んだままでした。**本 PR で自分が古くしたので、同じ PR で直します。** 以後 `src/index.ts` から生成する旨も書きました。

## 検証（自艦で実走・2026-08-23 13:5x）

| 確認 | 結果 |
|---|---|
| `npm run check` 全項目 | ✅ PASS（**41 files / 598 tests**） |
| Tailwind 4.3.2 実コンパイル | ✅ 新部品のクラス**20種すべてが CSS を生成**（欠落 0） |

### 陽性対照4種（**いずれも赤になることを確認し、実行後に復旧**）

| # | 壊し方 | 落ちるテスト |
|---|---|---|
| 1 | **`LoadingState` を export から外す（= v0.1 の状態）** | `the three states > all exist` |
| 2 | `ConfirmDialog` のボタン順を入れ替える | `puts the safe choice first` ほか計3件 |
| 3 | `showModal` 不在時のフォールバックを外す | `still shows itself where showModal does not exist`（**jsdom で実際に再現する経路**） |
| 4 | `InlineAlert` の role を tone で分けない | `interrupts for danger and waits its turn for info` |

## 射程外

`Toast` / `DataTable` / `Pagination` / `Checkbox` / `Radio` / `Switch` / `Icon` — 次波。状態管理や意匠の判断が要るので分けます。
