### PR TITLE
feat(ui): W0.7 — 選択系コントロール（Checkbox / Radio / Switch）と表・ページ送り（DataTable / Pagination）＋ README を検査可能にする（#306・陽性対照6種）

### DIFF
--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -109,16 +109,16 @@ fetching and state are governed by `@hideyukimori/nene2-standards`, not by this 
 🔴 **This table is generated from `src/index.ts`.** Regenerate it when you add a component —
 a component list that lags the code is how a product ends up writing a part that already exists.
 
-| Group        | Components                                                  |
-| ------------ | ----------------------------------------------------------- |
-| `primitives` | `Button` `Input` `Select` `Spinner` `Text` `Textarea`       |
-| `layout`     | `PageHeader` `Stack` `Grid` `Box` `Section` `Card`          |
-| `forms`      | `FormField`                                                 |
-| `states`     | `LoadingState` `EmptyState` `ErrorState`                    |
-| `overlay`    | `Modal` `ConfirmDialog`                                     |
-| `feedback`   | `Badge` `InlineAlert`                                       |
-| `data`       | `DetailList`                                                |
-| `theme`      | `tokens` (read-only `var()` accessors for canvas/chart use) |
+| Group        | Components                                                                        |
+| ------------ | --------------------------------------------------------------------------------- |
+| `primitives` | `Button` `Input` `Select` `Spinner` `Text` `Textarea` `Checkbox` `Radio` `Switch` |
+| `layout`     | `PageHeader` `Stack` `Grid` `Box` `Section` `Card`                                |
+| `forms`      | `FormField`                                                                       |
+| `states`     | `LoadingState` `EmptyState` `ErrorState`                                          |
+| `overlay`    | `Modal` `ConfirmDialog`                                                           |
+| `feedback`   | `Badge` `InlineAlert`                                                             |
+| `data`       | `DetailList` `DataTable` `Pagination`                                             |
+| `theme`      | `tokens` (read-only `var()` accessors for canvas/chart use)                       |
 
 `Input`, `Select` and `Textarea` use `forwardRef`, so they drop straight into
 `react-hook-form`'s `register`, and pick up their `id` / `aria-describedby` from the
@@ -126,7 +126,7 @@ a component list that lags the code is how a product ends up writing a part that
 
 ### Not yet here
 
-`Toast` `DataTable` `Pagination` `Checkbox` `Radio` `Switch` `Icon` — all measured as recurring
+`Toast` `Icon` — measured as recurring
 across ≥3 products. They land as migrating products contribute their implementation upward,
 rather than being designed up front.
 

--- a/packages/nene2-ui/src/data/DataTable.tsx
+++ b/packages/nene2-ui/src/data/DataTable.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from 'react';
+
+export interface DataColumn<Row> {
+  /** Stable key, also used as the React key. */
+  key: string;
+  /** Localized column heading. */
+  header: string;
+  /** Cell renderer. Kept explicit so a column can render a Badge, a link, anything. */
+  cell: (row: Row) => ReactNode;
+  /** Numeric columns read better right-aligned. Alignment, not styling. */
+  align?: 'start' | 'end';
+}
+
+export interface DataTableProps<Row> {
+  columns: DataColumn<Row>[];
+  rows: Row[];
+  /** Stable identity per row. Index-as-key breaks as soon as the list is sorted. */
+  rowKey: (row: Row) => string;
+  /** Localized description of what the table contains. Becomes the table's caption. */
+  caption: string;
+}
+
+/**
+ * A tabular list.
+ *
+ * 🔴 Every heading carries `scope="col"`. Without it a screen reader cannot pair a cell with
+ * its column, so each cell is read as a bare value — and nothing about the rendered table
+ * looks any different, which is why three ships each shipped a table and the `scope` is the
+ * detail most likely to differ between them.
+ *
+ * 🔴 The caption is required, not optional. A visually obvious table ("it's clearly the
+ * invoice list") is not obvious to someone arriving at it by keyboard from elsewhere on the
+ * page. It is visually hidden, not absent.
+ */
+export function DataTable<Row>({ columns, rows, rowKey, caption }: DataTableProps<Row>) {
+  return (
+    <table className="w-full border-collapse font-sans text-text-primary">
+      <caption className="sr-only">{caption}</caption>
+      <thead>
+        <tr>
+          {columns.map((col) => (
+            <th
+              key={col.key}
+              scope="col"
+              className={`border-b border-border px-x-2xs py-x-3xs font-medium text-text-muted ${
+                col.align === 'end' ? 'text-right' : 'text-left'
+              }`}
+            >
+              {col.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={rowKey(row)}>
+            {columns.map((col) => (
+              <td
+                key={col.key}
+                className={`border-b border-border px-x-2xs py-x-3xs ${
+                  col.align === 'end' ? 'text-right' : 'text-left'
+                }`}
+              >
+                {col.cell(row)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/packages/nene2-ui/src/data/Pagination.tsx
+++ b/packages/nene2-ui/src/data/Pagination.tsx
@@ -1,0 +1,64 @@
+import { Button } from '../primitives/Button.js';
+import { Stack } from '../layout/Stack.js';
+
+export interface PaginationProps {
+  /** 1-based. */
+  page: number;
+  pageCount: number;
+  onPageChange: (page: number) => void;
+  /** Localized name for the navigation region, e.g. "Invoice pages". */
+  label: string;
+  previousLabel: string;
+  nextLabel: string;
+  /** Localized current position, e.g. "Page 2 of 9". The kit ships no strings. */
+  status: string;
+}
+
+/**
+ * Page-by-page navigation for a list.
+ *
+ * 🔴 The current position is text, and the region is a named `<nav>`. Four ships wrote this
+ * component and the recurring shape marks the current page by colour alone — which is
+ * invisible to a screen reader and to anyone who cannot distinguish the two shades. The
+ * `status` string is required for the same reason: "you are here" has to be readable, not
+ * merely visible.
+ *
+ * The ends are disabled rather than hidden. A control that disappears at the boundary makes
+ * the row of controls jump, and moves the next-page button under the cursor that just
+ * clicked it.
+ */
+export function Pagination({
+  page,
+  pageCount,
+  onPageChange,
+  label,
+  previousLabel,
+  nextLabel,
+  status,
+}: PaginationProps) {
+  return (
+    <nav aria-label={label}>
+      <Stack direction="horizontal" gap="2xs" align="center">
+        <Button
+          variant="secondary"
+          disabled={page <= 1}
+          onClick={() => onPageChange(page - 1)}
+          aria-label={previousLabel}
+        >
+          {previousLabel}
+        </Button>
+        <span aria-current="page" className="font-sans text-text-muted">
+          {status}
+        </span>
+        <Button
+          variant="secondary"
+          disabled={page >= pageCount}
+          onClick={() => onPageChange(page + 1)}
+          aria-label={nextLabel}
+        >
+          {nextLabel}
+        </Button>
+      </Stack>
+    </nav>
+  );
+}

--- a/packages/nene2-ui/src/data/table.test.tsx
+++ b/packages/nene2-ui/src/data/table.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+/**
+ * W0.7（#306）— Checkbox / Radio / Switch / DataTable / Pagination。
+ *
+ * どれも「**間違えても画面は正しく見える**」種類の欠陥を見ている:
+ * ラベルの結び付き・radio の name・switch の役割・th の scope・現在位置の可読性。
+ */
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Checkbox } from '../primitives/Checkbox.js';
+import { Radio } from '../primitives/Radio.js';
+import { Switch } from '../primitives/Switch.js';
+import { DataTable } from './DataTable.js';
+import { Pagination } from './Pagination.js';
+import { FormField } from '../forms/FormField.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Checkbox', () => {
+  it('wraps its own label, so clicking the text toggles the box', () => {
+    const { container } = render(<Checkbox label="Agree" />);
+    const label = container.querySelector('label');
+    expect(label?.querySelector('input[type="checkbox"]')).toBeTruthy();
+    expect(label?.textContent).toBe('Agree');
+  });
+
+  it('toggles when the label text is clicked, not just the box', () => {
+    const { getByText, container } = render(<Checkbox label="Agree" />);
+    fireEvent.click(getByText('Agree'));
+    expect(container.querySelector<HTMLInputElement>('input')?.checked).toBe(true);
+  });
+
+  it('picks up the FormField wiring like the other controls', () => {
+    const { container } = render(
+      <FormField id="tos" label="Terms" error="required">
+        <Checkbox label="Agree" />
+      </FormField>,
+    );
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input?.getAttribute('id')).toBe('tos');
+    expect(input?.getAttribute('aria-describedby')).toBe('tos-error');
+  });
+
+  it('carries the shared focus and disabled treatment', () => {
+    const { container } = render(<Checkbox label="x" />);
+    const cls = (container.querySelector('input')?.getAttribute('class') ?? '').split(/\s+/);
+    expect(cls).toEqual(
+      expect.arrayContaining(['focus-visible:outline-2', 'disabled:opacity-x-disabled']),
+    );
+  });
+});
+
+describe('Radio', () => {
+  it('requires a name — a radio without one is a group of one', () => {
+    const { container } = render(<Radio name="plan" value="a" label="A" />);
+    expect(container.querySelector('input')?.getAttribute('name')).toBe('plan');
+  });
+
+  it('lets exactly one of a group be chosen', () => {
+    const { getByText, container } = render(
+      <>
+        <Radio name="plan" value="a" label="A" />
+        <Radio name="plan" value="b" label="B" />
+      </>,
+    );
+    fireEvent.click(getByText('A'));
+    fireEvent.click(getByText('B'));
+    const [a, b] = [...container.querySelectorAll<HTMLInputElement>('input')];
+    expect(a?.checked).toBe(false);
+    expect(b?.checked).toBe(true);
+  });
+
+  it('does not take the field id — that belongs to the group, not each option', () => {
+    const { container } = render(
+      <FormField id="plan" label="Plan">
+        <Radio name="plan" value="a" label="A" />
+      </FormField>,
+    );
+    // 各オプションに同じ id が付くと、id が重複して label が壊れる。
+    expect(container.querySelector('input')?.getAttribute('id')).toBeNull();
+  });
+});
+
+describe('Switch', () => {
+  it('is announced as a switch, not as a checkbox', () => {
+    const { container } = render(
+      <Switch checked={false} onCheckedChange={() => {}} label="Beta" />,
+    );
+    const el = container.querySelector('button');
+    expect(el?.getAttribute('role')).toBe('switch');
+    expect(el?.getAttribute('aria-checked')).toBe('false');
+    expect(container.querySelector('input')).toBeNull();
+  });
+
+  it('reports its state through aria, not only through colour', () => {
+    const { container } = render(<Switch checked onCheckedChange={() => {}} label="Beta" />);
+    expect(container.querySelector('button')?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('hands the caller the value it would become', () => {
+    const onCheckedChange = vi.fn();
+    const { container } = render(
+      <Switch checked={false} onCheckedChange={onCheckedChange} label="Beta" />,
+    );
+    fireEvent.click(container.querySelector('button')!);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+});
+
+interface Row {
+  id: string;
+  name: string;
+  amount: number;
+}
+const ROWS: Row[] = [
+  { id: '1', name: 'a', amount: 10 },
+  { id: '2', name: 'b', amount: 20 },
+];
+const COLUMNS = [
+  { key: 'name', header: 'Name', cell: (r: Row) => r.name },
+  { key: 'amount', header: 'Amount', cell: (r: Row) => r.amount, align: 'end' as const },
+];
+
+describe('DataTable', () => {
+  it('scopes every column heading, so cells can be paired with them', () => {
+    const { container } = render(
+      <DataTable columns={COLUMNS} rows={ROWS} rowKey={(r) => r.id} caption="Invoices" />,
+    );
+    const ths = [...container.querySelectorAll('th')];
+    expect(ths).toHaveLength(2);
+    for (const th of ths) expect(th.getAttribute('scope')).toBe('col');
+  });
+
+  it('always has a caption, visually hidden rather than absent', () => {
+    const { container } = render(
+      <DataTable columns={COLUMNS} rows={ROWS} rowKey={(r) => r.id} caption="Invoices" />,
+    );
+    const caption = container.querySelector('caption');
+    expect(caption?.textContent).toBe('Invoices');
+    expect(caption?.getAttribute('class')).toContain('sr-only');
+  });
+
+  it('renders a real row per item', () => {
+    const { container } = render(
+      <DataTable columns={COLUMNS} rows={ROWS} rowKey={(r) => r.id} caption="Invoices" />,
+    );
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(container.querySelectorAll('tbody td')[1]?.textContent).toBe('10');
+  });
+
+  it('is still a valid table with no rows', () => {
+    const { container } = render(
+      <DataTable columns={COLUMNS} rows={[]} rowKey={(r) => r.id} caption="Invoices" />,
+    );
+    expect(container.querySelectorAll('th')).toHaveLength(2);
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(0);
+  });
+});
+
+describe('Pagination', () => {
+  const props = {
+    pageCount: 9,
+    onPageChange: () => {},
+    label: 'Invoice pages',
+    previousLabel: 'Previous',
+    nextLabel: 'Next',
+    status: 'Page 2 of 9',
+  };
+
+  it('names its navigation region', () => {
+    const { container } = render(<Pagination {...props} page={2} />);
+    expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe('Invoice pages');
+  });
+
+  it('states the current position in text, not in colour alone', () => {
+    const { container } = render(<Pagination {...props} page={2} />);
+    const current = container.querySelector('[aria-current="page"]');
+    expect(current?.textContent).toBe('Page 2 of 9');
+  });
+
+  it('disables the ends rather than hiding them', () => {
+    const first = render(<Pagination {...props} page={1} />).container;
+    const [prev, next] = [...first.querySelectorAll('button')];
+    expect(prev?.disabled).toBe(true);
+    expect(next?.disabled).toBe(false);
+
+    const last = render(<Pagination {...props} page={9} />).container;
+    const [p2, n2] = [...last.querySelectorAll('button')];
+    expect(p2?.disabled).toBe(false);
+    expect(n2?.disabled).toBe(true);
+  });
+
+  it('moves one page at a time, in the direction asked', () => {
+    const onPageChange = vi.fn();
+    const { container } = render(<Pagination {...props} page={4} onPageChange={onPageChange} />);
+    const [prev, next] = [...container.querySelectorAll('button')];
+    fireEvent.click(next!);
+    fireEvent.click(prev!);
+    expect(onPageChange).toHaveBeenNthCalledWith(1, 5);
+    expect(onPageChange).toHaveBeenNthCalledWith(2, 3);
+  });
+});

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -5,6 +5,9 @@ export { Select, type SelectProps } from './primitives/Select.js';
 export { Spinner, type SpinnerProps } from './primitives/Spinner.js';
 export { Text, type TextProps } from './primitives/Text.js';
 export { Textarea, type TextareaProps } from './primitives/Textarea.js';
+export { Checkbox, type CheckboxProps } from './primitives/Checkbox.js';
+export { Radio, type RadioProps } from './primitives/Radio.js';
+export { Switch, type SwitchProps } from './primitives/Switch.js';
 
 // Layout
 export { PageHeader, type PageHeaderProps } from './layout/PageHeader.js';
@@ -36,6 +39,8 @@ export { InlineAlert, type InlineAlertProps } from './feedback/InlineAlert.js';
 
 // Data
 export { DetailList, type DetailListProps, type DetailRow } from './data/DetailList.js';
+export { DataTable, type DataTableProps, type DataColumn } from './data/DataTable.js';
+export { Pagination, type PaginationProps } from './data/Pagination.js';
 
 // Theme
 export { tokens } from './theme/tokens.js';

--- a/packages/nene2-ui/src/primitives/Checkbox.tsx
+++ b/packages/nene2-ui/src/primitives/Checkbox.tsx
@@ -1,0 +1,40 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
+import { useFieldWiring } from '../forms/field-context.js';
+
+export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** Localized label. Rendered inside the control's own `<label>`. */
+  label: ReactNode;
+}
+
+const BOX_CLASS = `rounded-x-md border border-border accent-accent ${CONTROL_CLASS}`;
+
+/**
+ * A checkbox and its label, as one part.
+ *
+ * 🔴 The label is not optional and not a sibling. The recurring shape in the fleet is an
+ * `<input>` next to a `<label>` whose `htmlFor` is missing or stale — which loses nothing
+ * visible, and loses the ability to click the text to toggle the box, plus the name the
+ * control is announced by. Making the label a prop means it cannot be forgotten.
+ */
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  {
+    label,
+    className,
+    id,
+    'aria-invalid': ariaInvalid,
+    'aria-describedby': ariaDescribedBy,
+    ...rest
+  },
+  ref,
+) {
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+
+  return (
+    <label className="inline-flex items-center gap-x-2xs font-sans text-text-primary">
+      <input ref={ref} type="checkbox" className={cx(BOX_CLASS, className)} {...wiring} {...rest} />
+      {label}
+    </label>
+  );
+});

--- a/packages/nene2-ui/src/primitives/Radio.tsx
+++ b/packages/nene2-ui/src/primitives/Radio.tsx
@@ -1,0 +1,35 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
+
+export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  /** Localized label. Rendered inside the control's own `<label>`. */
+  label: ReactNode;
+  /** Radios only mean anything in a group; `name` is what makes them one. */
+  name: string;
+}
+
+const DOT_CLASS = `border border-border accent-accent ${CONTROL_CLASS}`;
+
+/**
+ * One option in a radio group, with its label.
+ *
+ * 🔴 `name` is required, unlike on a bare `<input type="radio">`. A radio without a name is
+ * its own group of one: it can be checked but never unchecked, and arrow keys do not move
+ * between the options. Nothing about the rendered page shows this, so it survives review.
+ *
+ * 🔴 This does not take the `FormField` wiring. A group of radios shares one label and one
+ * error, so the id and `aria-describedby` belong on a `<fieldset>` around the group, not on
+ * each option — putting them here would give every option the same id.
+ */
+export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
+  { label, name, className, ...rest },
+  ref,
+) {
+  return (
+    <label className="inline-flex items-center gap-x-2xs font-sans text-text-primary">
+      <input ref={ref} type="radio" name={name} className={cx(DOT_CLASS, className)} {...rest} />
+      {label}
+    </label>
+  );
+});

--- a/packages/nene2-ui/src/primitives/Switch.tsx
+++ b/packages/nene2-ui/src/primitives/Switch.tsx
@@ -1,0 +1,47 @@
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
+
+export interface SwitchProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange' | 'type'> {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  /** Localized label. A switch with no name is a mystery toggle. */
+  label: string;
+}
+
+/**
+ * An on/off control that takes effect immediately.
+ *
+ * 🔴 A `<button role="switch">`, not a styled checkbox. The common shape is an
+ * `<input type="checkbox">` with a sliding track drawn over it, which assistive technology
+ * announces as "checkbox, not checked" — the wrong control, in the wrong tense. A checkbox
+ * states an intention that a later Save applies; a switch *is* the action. Different
+ * meanings get different elements.
+ *
+ * `aria-checked` carries the state; the visible track is decoration on top of it.
+ */
+export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch(
+  { checked, onCheckedChange, label, className, ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onCheckedChange(!checked)}
+      className={cx(
+        'inline-flex items-center rounded-x-md border border-border px-x-2xs py-x-3xs font-sans',
+        checked ? 'bg-accent text-on-accent' : 'bg-surface text-text-muted',
+        CONTROL_CLASS,
+        className,
+      )}
+      {...rest}
+    >
+      {label}
+    </button>
+  );
+});

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const readme = readFileSync(path.join(root, 'README.md'), 'utf8');
+const index = readFileSync(path.join(root, 'src/index.ts'), 'utf8');
+
+/** Component names as the package actually exports them. */
+function exportedComponents(): string[] {
+  const names: string[] = [];
+  for (const m of index.matchAll(/export \{([^}]+)\} from '\.\/([^']+)'/g)) {
+    for (const raw of m[1]!.split(',')) {
+      const name = raw.trim();
+      if (name === '' || name.startsWith('type ')) continue;
+      if (!/^[A-Z]/.test(name) || name.includes('CLASS')) continue;
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+describe('README component table', () => {
+  // 🔴 The README says this table is generated from src/index.ts. A claim like that is
+  // worth nothing unless something checks it — and a component list that lags the code is
+  // exactly how a product writes a part that already exists. v0.1 shipped with `Stack`,
+  // `Card`, `Textarea`, `Modal`, `Badge`, `LoadingState` and `ConfirmDialog` all listed
+  // under "Not yet here" while several of them were, in fact, already here.
+  const components = exportedComponents();
+
+  it('finds components to check, so a broken parser cannot pass vacuously', () => {
+    expect(components.length).toBeGreaterThan(15);
+  });
+
+  it('lists every exported component', () => {
+    const table = readme.slice(readme.indexOf('| Group'), readme.indexOf('### Not yet here'));
+    const missing = components.filter((name) => !table.includes(`\`${name}\``));
+    expect(missing, `missing from the README table: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('does not still promise a component it already ships', () => {
+    const notYet = readme.slice(readme.indexOf('### Not yet here'));
+    const contradictions = components.filter((name) => notYet.includes(`\`${name}\``));
+    expect(
+      contradictions,
+      `listed as "Not yet here" but exported: ${contradictions.join(', ')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #306

🔴 **ベースは `feat/304-feedback-parts`（PR #305）です。** 着地順 = **#295 → #299 → #301 → #305 → 本 PR**。

## 積んだもの

`Checkbox` / `Radio` / `Switch` / `DataTable` / `Pagination`。

🔑 **5つとも「間違えても画面は正しく見える」種類の欠陥を持つ部品**です。だから艦が別々に書くと必ずズレ、ズレたことに誰も気づきません。

| 部品 | 艦の実装 | 決めたこと |
|---|---:|---|
| `Pagination` | **4** | 現在位置を**テキスト**で出す（色だけにしない）／端は**隠さず disabled** |
| `DataTable` | 3 | `scope="col"` と `caption` を**必須**にする |
| `Checkbox` | — | **ラベルを内包**する |
| `Radio` | — | **`name` を必須**にする |
| `Switch` | — | **`<button role="switch">`**（styled checkbox にしない） |

### `Checkbox` — ラベルを内包する

艦の典型は `<input>` と `<label>` を別々に置いて `htmlFor` を書き忘れる形。**見た目は何も変わらず**、失うのは「ラベルのクリックで切り替わること」と「コントロールが読み上げられる名前」。⇒ `label` を prop にして**忘れられないようにする**。

### `Radio` — `name` を必須にする

素の `<input type="radio">` と違い必須にしました。🔴 **`name` の無い radio は自分ひとりのグループ**で、チェックはできるが外せず、矢印キーで選択肢を移動できません。**描画結果には何も現れない**のでレビューを通過します。

`FormField` の配線は**載せていません**。radio 群は**ラベルもエラーも群で1つ**なので、`id` と `aria-describedby` は群を囲む `<fieldset>` の持ち物です。ここに載せると**全オプションが同じ id** になります。

### `Switch` — `<button role="switch">`

`<input type="checkbox">` にスライダーを描く実装が多いですが、支援技術には**「チェックボックス、未チェック」**と読まれます。時制も違います —— **チェックボックスは後で Save が適用する意図の表明、スイッチはそれ自体が操作**。意味が違うなら要素も違う。

### `DataTable` — `scope` と `caption` を必須にする

`<th scope="col">` が無いと、スクリーンリーダーはセルと列見出しを対応づけられず、**各セルが裸の値として読まれます**。**描画された表は何も変わりません** —— 3艦が別々に書いたとき、いちばんズレやすい細部です。

`caption` も任意にしていません。「見れば請求一覧だと分かる」は、**キーボードで他所から到達した人には分かりません**。`sr-only` で置きます（**隠すのであって、無くさない**）。

### `Pagination` — 現在位置をテキストで

艦の典型は現在ページを**色だけ**で示します。支援技術からは見えず、2色の差を判別できない人からも見えません。⇒ `status` を必須に。

端は**隠さず disabled**。消える控えは行の幅を飛ばし、**いま押したカーソルの下に次のページ送りを移動させます**。

## 🔴 README のインベントリを検査可能にした

前 PR（#305）で README に「この表は `src/index.ts` から生成する」と書きましたが、**書いただけでは何も保証しません**。実際 v0.1 は `Stack` `Card` `Textarea` `Modal` `Badge` `LoadingState` `ConfirmDialog` を「Not yet here」に並べたまま、**いくつかは既に出荷していました**。

⇒ `src/readme.test.ts` を置きました:

1. **export された部品が全部表にあること**
2. **出荷済みの部品が「Not yet here」に残っていないこと**

（**今日ずっと潰してきた「名乗りが射程より広い」の、自分の README 版**です。）

## 検証（自艦で実走・2026-08-23 14:0x）

| 確認 | 結果 |
|---|---|
| `npm run check` 全項目 | ✅ PASS（**43 files / 619 tests**） |
| Tailwind 4.3.2 実コンパイル | ✅ `accent-accent` → `accent-color: var(--color-accent)` ／ `sr-only` も生成 |

### 陽性対照6種（**いずれも赤になることを確認し、実行後に復旧**）

| # | 壊し方 | 落ちるテスト |
|---|---|---|
| 1 | `DataTable` の `th` から `scope` を外す | `scopes every column heading` |
| 2 | `Switch` から `role="switch"` を外す | `is announced as a switch, not as a checkbox` |
| 3 | `Checkbox` のラベル内包をやめ兄弟に戻す | `wraps its own label` ほか計2件 |
| 4 | `Pagination` の `aria-current` を外す | `states the current position in text` |
| 5 | README の表から `Pagination` を落とす | `lists every exported component` |
| 6 | 出荷済みの `Switch` を「Not yet here」に戻す | `does not still promise a component it already ships` |

## キットの現在地

**部品26本** — primitives 9 / layout 6 / forms 1 / states 3 / overlay 2 / feedback 2 / data 3。

## 射程外（次波）

- `ToastProvider`（3実装）— **状態管理と portal** が要るので単独の波に
- `Icon`（3実装）— **アイコンセットの選定**という意匠判断が要る。施主判断待ち
