### PR TITLE
feat(ui): FormField に hint / labelAdornment / required / requiredMarker — hint は艦によって描画位置が違い、3艦とも aria-describedby に繋いでいない（#308）

### DIFF
--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -116,7 +116,7 @@ a component list that lags the code is how a product ends up writing a part that
 | `forms`      | `FormField`                                                                       |
 | `states`     | `LoadingState` `EmptyState` `ErrorState`                                          |
 | `overlay`    | `Modal` `ConfirmDialog`                                                           |
-| `feedback`   | `Badge` `InlineAlert`                                                             |
+| `feedback`   | `Badge` `InlineAlert` `ToastProvider`                                             |
 | `data`       | `DetailList` `DataTable` `Pagination`                                             |
 | `theme`      | `tokens` (read-only `var()` accessors for canvas/chart use)                       |
 
@@ -126,7 +126,7 @@ a component list that lags the code is how a product ends up writing a part that
 
 ### Not yet here
 
-`Toast` `Icon` — measured as recurring
+`Icon` — measured as recurring
 across ≥3 products. They land as migrating products contribute their implementation upward,
 rather than being designed up front.
 

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -109,16 +109,16 @@ fetching and state are governed by `@hideyukimori/nene2-standards`, not by this 
 🔴 **This table is generated from `src/index.ts`.** Regenerate it when you add a component —
 a component list that lags the code is how a product ends up writing a part that already exists.
 
-| Group        | Components                                                                        |
-| ------------ | --------------------------------------------------------------------------------- |
-| `primitives` | `Button` `Input` `Select` `Spinner` `Text` `Textarea` `Checkbox` `Radio` `Switch` |
-| `layout`     | `PageHeader` `Stack` `Grid` `Box` `Section` `Card`                                |
-| `forms`      | `FormField`                                                                       |
-| `states`     | `LoadingState` `EmptyState` `ErrorState`                                          |
-| `overlay`    | `Modal` `ConfirmDialog`                                                           |
-| `feedback`   | `Badge` `InlineAlert` `ToastProvider`                                             |
-| `data`       | `DetailList` `DataTable` `Pagination`                                             |
-| `theme`      | `tokens` (read-only `var()` accessors for canvas/chart use)                       |
+| Group        | Components                                                                               |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| `primitives` | `Button` `Input` `Select` `Spinner` `Text` `Textarea` `Icon` `Checkbox` `Radio` `Switch` |
+| `layout`     | `PageHeader` `Stack` `Grid` `Box` `Section` `Card`                                       |
+| `forms`      | `FormField`                                                                              |
+| `states`     | `LoadingState` `EmptyState` `ErrorState`                                                 |
+| `overlay`    | `Modal` `ConfirmDialog`                                                                  |
+| `feedback`   | `Badge` `InlineAlert` `ToastProvider`                                                    |
+| `data`       | `DetailList` `DataTable` `Pagination`                                                    |
+| `theme`      | `tokens` (read-only `var()` accessors for canvas/chart use)                              |
 
 `Input`, `Select` and `Textarea` use `forwardRef`, so they drop straight into
 `react-hook-form`'s `register`, and pick up their `id` / `aria-describedby` from the
@@ -126,7 +126,7 @@ a component list that lags the code is how a product ends up writing a part that
 
 ### Not yet here
 
-`Icon` — measured as recurring
+`BrandMark` — measured as recurring
 across ≥3 products. They land as migrating products contribute their implementation upward,
 rather than being designed up front.
 

--- a/packages/nene2-ui/src/feedback/ToastProvider.tsx
+++ b/packages/nene2-ui/src/feedback/ToastProvider.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
+import { CONTROL_CLASS } from '../lib/states.js';
+import { ToastContext, type ToastApi, type ToastOptions, type ToastTone } from './toast-context.js';
+
+interface Toast {
+  id: string;
+  message: string;
+  tone: ToastTone;
+}
+
+export interface ToastProviderProps {
+  /** Localized name for the toast region, e.g. "Notifications". */
+  regionLabel: string;
+  /** Localized label for each toast's dismiss control. */
+  dismissLabel: string;
+  /**
+   * How long a toast stays, in milliseconds.
+   *
+   * 🔴 Five seconds, not the two-and-a-bit the fleet settled on independently (nene-field
+   * 2200ms, nene-deal 2600ms). A toast that vanishes before a screen reader has finished
+   * reading it was never delivered, and 2.2s is not enough for a sentence. Callers can
+   * shorten it per toast if they have a reason.
+   */
+  defaultDurationMs?: number;
+  children: ReactNode;
+}
+
+const TONE_CLASS: Record<ToastTone, string> = {
+  info: 'bg-surface-raised text-text-primary border-border',
+  danger: 'bg-surface-raised text-danger border-danger',
+};
+
+/**
+ * Hosts the toast queue and the live regions that announce it.
+ *
+ * 🔴 The live regions are always in the DOM, even with nothing to show. Four ships
+ * (nene-records, nene-field, nene-invoice, nene-deal) each create theirs at the moment the
+ * first toast appears — `nene-deal` even returns `null` when the queue is empty. A live
+ * region that arrives together with its content is frequently not announced at all: the
+ * assistive technology has nothing to have been watching. The toast is on screen, looks
+ * right, and is silent — which is why this survived four independent implementations.
+ *
+ * 🔴 Two regions, not one. `polite` waits for a pause; `danger` needs `assertive`, which
+ * interrupts. Both must pre-exist for the same reason, so both are rendered empty.
+ */
+export function ToastProvider({
+  regionLabel,
+  dismissLabel,
+  defaultDurationMs = 5000,
+  children,
+}: ToastProviderProps) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const timers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+  const nextId = useRef(0);
+
+  const dismiss = useCallback((id: string) => {
+    const timer = timers.current.get(id);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const show = useCallback(
+    (message: string, options?: ToastOptions) => {
+      const id = `toast-${(nextId.current += 1)}`;
+      setToasts((current) => [...current, { id, message, tone: options?.tone ?? 'info' }]);
+      timers.current.set(
+        id,
+        setTimeout(() => dismiss(id), options?.durationMs ?? defaultDurationMs),
+      );
+      return id;
+    },
+    [defaultDurationMs, dismiss],
+  );
+
+  // Timers outlive the component otherwise, and fire setState on an unmounted tree.
+  useEffect(() => {
+    const pending = timers.current;
+    return () => {
+      for (const timer of pending.values()) clearTimeout(timer);
+      pending.clear();
+    };
+  }, []);
+
+  const api = useMemo<ToastApi>(() => ({ show, dismiss }), [show, dismiss]);
+
+  const region = (tone: ToastTone, live: 'polite' | 'assertive') => (
+    <div
+      aria-live={live}
+      aria-label={regionLabel}
+      role="region"
+      className="flex flex-col gap-x-2xs"
+    >
+      {toasts
+        .filter((toast) => toast.tone === tone)
+        .map((toast) => (
+          <div
+            key={toast.id}
+            className={cx(
+              'flex items-start gap-x-2xs rounded-x-md border p-x-2xs font-sans shadow-sm',
+              TONE_CLASS[toast.tone],
+            )}
+          >
+            <span>{toast.message}</span>
+            <button
+              type="button"
+              aria-label={dismissLabel}
+              onClick={() => dismiss(toast.id)}
+              className={cx('rounded-x-md px-x-3xs', CONTROL_CLASS)}
+            >
+              {dismissLabel}
+            </button>
+          </div>
+        ))}
+    </div>
+  );
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      {region('info', 'polite')}
+      {region('danger', 'assertive')}
+    </ToastContext.Provider>
+  );
+}

--- a/packages/nene2-ui/src/feedback/toast-context.ts
+++ b/packages/nene2-ui/src/feedback/toast-context.ts
@@ -1,0 +1,32 @@
+import { createContext, useContext } from 'react';
+
+export type ToastTone = 'info' | 'danger';
+
+export interface ToastOptions {
+  tone?: ToastTone;
+  /** Overrides the provider's default. */
+  durationMs?: number;
+}
+
+export interface ToastApi {
+  /** Shows a toast and returns its id, so a caller can dismiss it early. */
+  show: (message: string, options?: ToastOptions) => string;
+  dismiss: (id: string) => void;
+}
+
+export const ToastContext = createContext<ToastApi | null>(null);
+
+/**
+ * Read the toast API.
+ *
+ * Throws outside a provider rather than returning a no-op: a `show()` that silently does
+ * nothing is a bug that surfaces only when somebody notices a confirmation that never
+ * appeared, which may be never.
+ */
+export function useToast(): ToastApi {
+  const api = useContext(ToastContext);
+  if (api === null) {
+    throw new Error('useToast must be used inside a <ToastProvider>');
+  }
+  return api;
+}

--- a/packages/nene2-ui/src/feedback/toast.test.tsx
+++ b/packages/nene2-ui/src/feedback/toast.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+/**
+ * Toast（#311）— 通知の待ち行列と、それを読み上げる live region。
+ *
+ * 🔴 見ている中心は「**live region が中身より先に DOM に在ること**」。
+ * 実測（2026-08-23）でフリートの4実装（records / field / invoice / deal）は
+ * **どれも最初のトーストと同時に region を作っている**（deal は空のとき `null` を返す）。
+ * その形の region は読み上げられないことが多く、**画面には出るのに無音**になる。
+ * だから4実装とも生き残った。
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToastProvider } from './ToastProvider.js';
+import { useToast } from './toast-context.js';
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+function Trigger({ tone, durationMs }: { tone?: 'info' | 'danger'; durationMs?: number }) {
+  const { show } = useToast();
+  return (
+    <button
+      onClick={() =>
+        show('Saved', {
+          ...(tone === undefined ? {} : { tone }),
+          ...(durationMs === undefined ? {} : { durationMs }),
+        })
+      }
+    >
+      go
+    </button>
+  );
+}
+
+const mount = (ui: React.ReactNode) =>
+  render(
+    <ToastProvider regionLabel="Notifications" dismissLabel="Dismiss">
+      {ui}
+    </ToastProvider>,
+  );
+
+describe('live regions', () => {
+  it('exist before there is anything to announce', () => {
+    // 🔴 これが本命。中身と同時に生まれた region は読み上げられない。
+    const { container } = mount(<Trigger />);
+    const regions = [...container.querySelectorAll('[role="region"]')];
+    expect(regions).toHaveLength(2);
+    expect(regions.map((r) => r.getAttribute('aria-live')).sort()).toEqual(['assertive', 'polite']);
+    expect(regions.every((r) => r.getAttribute('aria-label') === 'Notifications')).toBe(true);
+  });
+
+  it('are still there after the last toast goes away', () => {
+    const { container } = mount(<Trigger />);
+    fireEvent.click(screen.getByText('go'));
+    act(() => void vi.advanceTimersByTime(5000));
+    expect(container.querySelectorAll('[role="region"]')).toHaveLength(2);
+  });
+
+  it('announces politely by default and assertively for danger', () => {
+    const { container } = mount(<Trigger tone="danger" />);
+    fireEvent.click(screen.getByText('go'));
+    const assertive = container.querySelector('[aria-live="assertive"]');
+    const polite = container.querySelector('[aria-live="polite"]');
+    expect(assertive?.textContent).toContain('Saved');
+    expect(polite?.textContent).not.toContain('Saved');
+  });
+});
+
+describe('lifetime', () => {
+  it('stays five seconds by default — long enough to be read aloud', () => {
+    // field は 2200ms、deal は 2600ms。読み終わる前に消える通知は届いていない。
+    mount(<Trigger />);
+    fireEvent.click(screen.getByText('go'));
+    act(() => void vi.advanceTimersByTime(4999));
+    expect(screen.queryByText('Saved')).not.toBeNull();
+    act(() => void vi.advanceTimersByTime(1));
+    expect(screen.queryByText('Saved')).toBeNull();
+  });
+
+  it('honours a per-toast duration', () => {
+    mount(<Trigger durationMs={1000} />);
+    fireEvent.click(screen.getByText('go'));
+    act(() => void vi.advanceTimersByTime(1000));
+    expect(screen.queryByText('Saved')).toBeNull();
+  });
+
+  it('can be dismissed by hand, and does not come back when its timer fires', () => {
+    mount(<Trigger />);
+    fireEvent.click(screen.getByText('go'));
+    fireEvent.click(screen.getByLabelText('Dismiss'));
+    expect(screen.queryByText('Saved')).toBeNull();
+    act(() => void vi.advanceTimersByTime(5000));
+    expect(screen.queryByText('Saved')).toBeNull();
+  });
+
+  it('stacks several toasts rather than replacing them', () => {
+    mount(<Trigger />);
+    fireEvent.click(screen.getByText('go'));
+    fireEvent.click(screen.getByText('go'));
+    expect(screen.getAllByText('Saved')).toHaveLength(2);
+  });
+});
+
+describe('useToast outside a provider', () => {
+  it('throws instead of silently doing nothing', () => {
+    // 何も起きない show() は、誰かが「確認が出ない」と気づくまで見つからない。
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<Trigger />)).toThrow(/ToastProvider/);
+    spy.mockRestore();
+  });
+});

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -8,32 +8,75 @@ export interface FormFieldProps {
   label: string;
   /** Localized error message, or null when valid. */
   error?: string | null;
+  /**
+   * Localized help text, shown under the control and read out with it.
+   *
+   * 🔴 Under the control, not beside the label — see `labelAdornment` for that. Three ships
+   * ship a prop called `hint` and they do not agree on where it goes: nene-vault and
+   * nene-profile put it under the control, nene-invoice puts it inside the `<label>`. One
+   * name, two placements, so picking either one silently moves the other's text.
+   */
+  hint?: ReactNode;
+  /** Small node rendered beside the label — a keyboard hint, a unit, a link. */
+  labelAdornment?: ReactNode;
+  /** Marks the control `aria-required`. Carries no visible text of its own. */
+  required?: boolean;
+  /**
+   * Visible required marker, rendered after the label when `required` is set.
+   *
+   * 🔴 Separate from `required` on purpose. `required` is meaning and needs no words;
+   * a marker is presentation and does need them, and the kit ships no strings (principle 4).
+   * Folding the two together would mean the kit picking "*" for every locale.
+   */
+  requiredMarker?: ReactNode;
   children: ReactNode;
 }
 
 /**
- * Labelled form field wrapper: associates a `<label>` with its control and renders a
- * validation error that assistive technology can reach.
+ * Labelled form field wrapper: associates a `<label>` with its control, and links the
+ * control to its help text and its validation error.
  *
  * 🔴 The control no longer has to opt in. v0.1 documented that the control was "responsible
  * for setting `aria-describedby`", and the fleet did not do it — nene-vault sets
  * `aria-invalid` on 3 fields and links the reason zero times (measured 2026-08-23; see
- * field-context.ts for how that number differs from a raw grep). A field's own
- * error message is the field's job, so `FormField` publishes the ids through context and
- * the kit's controls read them. A control from outside the kit still works; it simply gets
- * the label association it always had.
+ * field-context.ts for how that number differs from a raw grep). A field's own error message
+ * is the field's job, so `FormField` publishes the ids through context and the kit's controls
+ * read them. A control from outside the kit still works; it simply gets the label association
+ * it always had.
+ *
+ * 🔴 The hint stays visible when there is an error. nene-profile hides it in that case, and
+ * that is the moment the user most needs it; the error is read first instead.
  */
-export function FormField({ id, label, error = null, children }: FormFieldProps) {
+export function FormField({
+  id,
+  label,
+  error = null,
+  hint,
+  labelAdornment,
+  required = false,
+  requiredMarker,
+  children,
+}: FormFieldProps) {
   const errorId = error === null ? null : `${id}-error`;
-  const value = useMemo(() => ({ id, errorId }), [id, errorId]);
+  const hintId = hint === undefined || hint === null ? null : `${id}-hint`;
+  const value = useMemo(() => ({ id, errorId, hintId, required }), [id, errorId, hintId, required]);
 
   return (
     <FieldContext.Provider value={value}>
       <div className="flex flex-col gap-x-inline-sm">
         <label htmlFor={id} className="font-sans font-medium text-text-primary">
           {label}
+          {required && requiredMarker !== undefined && requiredMarker !== null ? (
+            <span className="text-danger">{requiredMarker}</span>
+          ) : null}
+          {labelAdornment}
         </label>
         {children}
+        {hintId === null ? null : (
+          <span id={hintId} className="font-sans text-text-muted">
+            {hint}
+          </span>
+        )}
         {errorId === null ? null : (
           <p id={errorId} role="alert" className="font-sans text-danger">
             {error}

--- a/packages/nene2-ui/src/forms/field-context.ts
+++ b/packages/nene2-ui/src/forms/field-context.ts
@@ -5,6 +5,10 @@ export interface FieldContextValue {
   id: string;
   /** id of the rendered error message, or null when the field is valid. */
   errorId: string | null;
+  /** id of the rendered hint, or null when there is no hint. */
+  hintId: string | null;
+  /** Whether the field must be filled in. */
+  required: boolean;
 }
 
 export const FieldContext = createContext<FieldContextValue | null>(null);
@@ -15,6 +19,7 @@ export interface FieldWiring {
   id?: string | undefined;
   'aria-invalid'?: AriaAttributes['aria-invalid'] | undefined;
   'aria-describedby'?: string | undefined;
+  'aria-required'?: AriaAttributes['aria-required'] | undefined;
 }
 
 /**
@@ -37,8 +42,13 @@ export interface FieldWiring {
  * a comment, so its real count is zero, not one. Both of those wrong numbers reached a draft
  * of this comment — written down here so the next person to recount lands on the same one.)
  *
+ * 🔴 The same is true of hints. nene-invoice, nene-vault and nene-profile each render one,
+ * and none of the three links it — so the help text is visible and never read out. The kit
+ * puts both ids on the control, the error first, because once a field is wrong the reason
+ * matters more than the advice.
+ *
  * A contract a component states in prose and leaves to its callers is a contract that will
- * be half-kept. The kit knows the error's id, so the kit does the wiring.
+ * be half-kept. The kit knows the ids, so the kit does the wiring.
  *
  * Explicit props always win — a caller with its own error region can still say so.
  */
@@ -46,6 +56,7 @@ export function useFieldWiring(explicit: {
   id?: string | undefined;
   ariaInvalid?: AriaAttributes['aria-invalid'] | undefined;
   ariaDescribedBy?: string | undefined;
+  ariaRequired?: AriaAttributes['aria-required'] | undefined;
 }): FieldWiring {
   const field = useContext(FieldContext);
 
@@ -54,12 +65,16 @@ export function useFieldWiring(explicit: {
       id: explicit.id,
       'aria-invalid': explicit.ariaInvalid,
       'aria-describedby': explicit.ariaDescribedBy,
+      'aria-required': explicit.ariaRequired,
     };
   }
+
+  const described = [field.errorId, field.hintId].filter((v): v is string => v !== null).join(' ');
 
   return {
     id: explicit.id ?? field.id,
     'aria-invalid': explicit.ariaInvalid ?? (field.errorId === null ? undefined : true),
-    'aria-describedby': explicit.ariaDescribedBy ?? field.errorId ?? undefined,
+    'aria-describedby': explicit.ariaDescribedBy ?? (described === '' ? undefined : described),
+    'aria-required': explicit.ariaRequired ?? (field.required ? true : undefined),
   };
 }

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 /**
- * FormField の配線（#302）— エラーの id を部品が自分で拾うこと。
+ * FormField の配線（#302 / #308）— エラー・hint の id を部品が自分で拾うこと。
  *
  * 🔴 v0.1 は `aria-describedby` の付与を**呼び出し側の責務**と doc コメントで宣言していた。
- * 実測（2026-08-23）では守られていない: nene-vault は `aria-invalid` を **16回**書いて
- * `aria-describedby` を **0回**しか書いていない。⇒「不正だとは言うが、理由は読まれない」。
+ * 実測（2026-08-23・JSX prop のみを数える）では守られていない: nene-vault は
+ * `aria-invalid` を **3箇所**に付けて `aria-describedby` は **0回**。nene-payout は 26 対 0。
+ * ⇒「不正だとは言うが、理由は読まれない」。hint も同じで、invoice / vault / profile の
+ * 3艦とも**描画するだけで参照していない**（見えるが読まれない）。
  * 散文で宣言して呼び出し側に委ねた契約は、半分しか守られない。
  */
 import { render } from '@testing-library/react';
@@ -111,5 +113,88 @@ describe('Textarea', () => {
   it('sets no rows of its own — height is the screen’s decision', () => {
     const { container } = render(<Textarea />);
     expect(container.querySelector('textarea')?.getAttribute('rows')).toBeNull();
+  });
+});
+
+describe('hint', () => {
+  it('is read out with the control, not merely shown', () => {
+    // 🔴 invoice / vault / profile はどれも hint を描画するだけで参照していない。
+    const { container } = render(
+      <FormField id="email" label="Email" hint="Work address">
+        <Input />
+      </FormField>,
+    );
+    const input = container.querySelector('input');
+    expect(input?.getAttribute('aria-describedby')).toBe('email-hint');
+    expect(container.querySelector('#email-hint')?.textContent).toBe('Work address');
+  });
+
+  it('stays visible when there is an error, and is read after it', () => {
+    // profile は error のとき hint を隠す。採らない —— 助けが要るのは間違えた瞬間。
+    const { container } = render(
+      <FormField id="email" label="Email" hint="Work address" error="required">
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('#email-hint')).toBeTruthy();
+    expect(container.querySelector('input')?.getAttribute('aria-describedby')).toBe(
+      'email-error email-hint',
+    );
+  });
+
+  it('renders under the control, while labelAdornment renders beside the label', () => {
+    // 同じ名前で位置が2通りあったので、prop を分けた。
+    const { container } = render(
+      <FormField id="email" label="Email" hint="under" labelAdornment={<em>beside</em>}>
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('label')?.textContent).toBe('Emailbeside');
+    expect(container.querySelector('label em')).toBeTruthy();
+    expect(container.querySelector('#email-hint')?.tagName).toBe('SPAN');
+  });
+});
+
+describe('required', () => {
+  it('marks the control required without needing any words', () => {
+    const { container } = render(
+      <FormField id="email" label="Email" required>
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('input')?.getAttribute('aria-required')).toBe('true');
+  });
+
+  it('shows no marker unless the caller supplies one — the kit ships no strings', () => {
+    const { container } = render(
+      <FormField id="email" label="Email" required>
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('label')?.textContent).toBe('Email');
+  });
+
+  it('renders the caller’s marker after the label when both are given', () => {
+    const { container } = render(
+      <FormField id="email" label="Email" required requiredMarker="＊">
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('label')?.textContent).toBe('Email＊');
+  });
+
+  it('does not show a marker for an optional field, even if one is supplied', () => {
+    const { container } = render(
+      <FormField id="email" label="Email" requiredMarker="＊">
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('label')?.textContent).toBe('Email');
+    expect(container.querySelector('input')?.getAttribute('aria-required')).toBeNull();
+  });
+
+  it('says nothing about requiredness outside a FormField', () => {
+    const { container } = render(<Input />);
+    expect(container.querySelector('input')?.getAttribute('aria-required')).toBeNull();
   });
 });

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -103,7 +103,7 @@ describe('Textarea', () => {
     expect(cls).toEqual(
       expect.arrayContaining([
         'focus-visible:outline-2',
-        'focus-visible:outline-accent',
+        'focus-visible:outline-text-primary',
         'disabled:opacity-x-disabled',
         'placeholder:text-text-muted',
       ]),

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -5,6 +5,7 @@ export { Select, type SelectProps } from './primitives/Select.js';
 export { Spinner, type SpinnerProps } from './primitives/Spinner.js';
 export { Text, type TextProps } from './primitives/Text.js';
 export { Textarea, type TextareaProps } from './primitives/Textarea.js';
+export { Icon, type IconProps } from './primitives/Icon.js';
 export { Checkbox, type CheckboxProps } from './primitives/Checkbox.js';
 export { Radio, type RadioProps } from './primitives/Radio.js';
 export { Switch, type SwitchProps } from './primitives/Switch.js';

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -36,6 +36,13 @@ export { ConfirmDialog, type ConfirmDialogProps } from './overlay/ConfirmDialog.
 // Feedback
 export { Badge, type BadgeProps } from './feedback/Badge.js';
 export { InlineAlert, type InlineAlertProps } from './feedback/InlineAlert.js';
+export { ToastProvider, type ToastProviderProps } from './feedback/ToastProvider.js';
+export {
+  useToast,
+  type ToastApi,
+  type ToastOptions,
+  type ToastTone,
+} from './feedback/toast-context.js';
 
 // Data
 export { DetailList, type DetailListProps, type DetailRow } from './data/DetailList.js';

--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -17,11 +17,26 @@
  * products' existing containers do: `overflow-hidden` appears 12 times in nene-records and
  * twice each in nene-vault and nene-deal, which are the first two ships to be migrated
  * (measured 2026-08-23). `outline` is not clipped and carries its own offset.
+ *
+ * 🔴 The ring is `text-primary`, not `accent`. An accent ring is *the same colour as a
+ * primary button* — contrast 1.00:1 against its own fill, and 1.11:1 against a danger
+ * button (computed from the theme's oklch values, 2026-08-23). The offset keeps the ring
+ * off the fill, so what it actually sits against is the page, and both colours clear 3:1
+ * there; but a ring that disappears the moment the offset does is one layout change away
+ * from being invisible. `text-primary` measures 15.55:1 against `surface`, 16.00:1 against
+ * `surface-raised`, and still 3.30:1 / 2.97:1 against the accent and danger fills.
+ *
+ * No single colour clears 3:1 against *both* fills — accent and danger are both mid
+ * luminance — which is why nene-deal moved to a two-tone box-shadow ring (#183, after a
+ * 1.38:1 indicator went unnoticed because a contrast checker cannot see it). Here the
+ * offset provides the second tone: fill, page-coloured gap, dark ring, page.
+ *
+ * 🔴 `outline-offset` is therefore load-bearing, not decoration. Do not set it to 0.
  */
 
 /** Keyboard focus indicator. Colour comes from the theme, never from a caller. */
 export const FOCUS_CLASS =
-  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent';
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary';
 
 /**
  * Disabled appearance. The opacity is a theme token (`--opacity-x-disabled`) because a

--- a/packages/nene2-ui/src/primitives/Checkbox.tsx
+++ b/packages/nene2-ui/src/primitives/Checkbox.tsx
@@ -25,11 +25,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
     id,
     'aria-invalid': ariaInvalid,
     'aria-describedby': ariaDescribedBy,
+    'aria-required': ariaRequired,
     ...rest
   },
   ref,
 ) {
-  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return (
     <label className="inline-flex items-center gap-x-2xs font-sans text-text-primary">

--- a/packages/nene2-ui/src/primitives/Icon.tsx
+++ b/packages/nene2-ui/src/primitives/Icon.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode, SVGProps } from 'react';
+import { cx } from '../lib/cx.js';
+
+type IconSize = 'sm' | 'md' | 'lg';
+
+interface IconBase extends Omit<SVGProps<SVGSVGElement>, 'children' | 'aria-label'> {
+  /** The `<path>`, `<circle>`… of a 24×24 icon. The kit ships no artwork. */
+  children: ReactNode;
+  size?: IconSize;
+}
+
+interface MeaningfulIcon extends IconBase {
+  /** Localized name. Present when the icon carries meaning of its own. */
+  label: string;
+  decorative?: never;
+}
+
+interface DecorativeIcon extends IconBase {
+  /** The icon repeats something already in text, so it is hidden from assistive tech. */
+  decorative: true;
+  label?: never;
+}
+
+export type IconProps = MeaningfulIcon | DecorativeIcon;
+
+const SIZE_CLASS: Record<IconSize, string> = {
+  sm: 'h-4 w-4',
+  md: 'h-5 w-5',
+  lg: 'h-6 w-6',
+};
+
+/**
+ * The semantics around an icon — not the icon.
+ *
+ * 🔴 The kit ships no artwork and takes on no icon library, because the fleet has none:
+ * across all ten products the dependency count for lucide / heroicons / feather / phosphor
+ * / tabler is zero, and every icon is an inline `<svg>` (222 of them, measured 2026-08-23).
+ * Choosing a set would mean adding a dependency to seventeen ships to solve a problem they
+ * do not have.
+ *
+ * 🔴 What is not consistent is the meaning. Of those 222, **101 declare neither
+ * `aria-hidden` nor `role="img"`** — they do not say whether they are decoration or
+ * content, so assistive technology is left to guess, and the page looks entirely correct
+ * either way. Three carry `role="img"`; none carries a `<title>`.
+ *
+ * So `label` and `decorative` are mutually exclusive and one of them is required, enforced
+ * by the type. An icon that can be rendered without saying which it is would reproduce the
+ * 101 exactly.
+ */
+export function Icon({ children, size = 'md', className, ...rest }: IconProps) {
+  const { label, ...svgProps } = rest as {
+    label?: string;
+  } & SVGProps<SVGSVGElement>;
+  delete (svgProps as { decorative?: unknown }).decorative;
+
+  // 🔴 Falls back to decoration, not to `role="img"`. A JS caller or a stale build can reach
+  // here with neither prop, and a nameless `role="img"` is worse than silence: assistive
+  // technology announces "image" and stops. An empty string counts as missing too — that is
+  // what an unresolved translation key looks like at runtime.
+  const decorative = label === undefined || label === '';
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      className={cx(SIZE_CLASS[size], 'shrink-0', className)}
+      {...(decorative
+        ? { 'aria-hidden': true, focusable: false }
+        : { role: 'img', 'aria-label': label })}
+      {...svgProps}
+    >
+      {children}
+    </svg>
+  );
+}

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -12,10 +12,17 @@ const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised p
  * Visual values come from theme tokens only.
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { className, id, 'aria-invalid': ariaInvalid, 'aria-describedby': ariaDescribedBy, ...rest },
+  {
+    className,
+    id,
+    'aria-invalid': ariaInvalid,
+    'aria-describedby': ariaDescribedBy,
+    'aria-required': ariaRequired,
+    ...rest
+  },
   ref,
 ) {
-  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return <input ref={ref} className={cx(BASE_CLASS, className)} {...wiring} {...rest} />;
 });

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -20,11 +20,12 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select
     id,
     'aria-invalid': ariaInvalid,
     'aria-describedby': ariaDescribedBy,
+    'aria-required': ariaRequired,
     ...rest
   },
   ref,
 ) {
-  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return (
     <select ref={ref} className={cx(BASE_CLASS, className)} {...wiring} {...rest}>

--- a/packages/nene2-ui/src/primitives/Textarea.tsx
+++ b/packages/nene2-ui/src/primitives/Textarea.tsx
@@ -16,10 +16,17 @@ const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised p
  * wanted one set it on the element already.
  */
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { className, id, 'aria-invalid': ariaInvalid, 'aria-describedby': ariaDescribedBy, ...rest },
+  {
+    className,
+    id,
+    'aria-invalid': ariaInvalid,
+    'aria-describedby': ariaDescribedBy,
+    'aria-required': ariaRequired,
+    ...rest
+  },
   ref,
 ) {
-  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy });
+  const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return <textarea ref={ref} className={cx(BASE_CLASS, className)} {...wiring} {...rest} />;
 });

--- a/packages/nene2-ui/src/primitives/icon.test.tsx
+++ b/packages/nene2-ui/src/primitives/icon.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+/**
+ * Icon（#312）— 配るのは絵ではなく意味づけ。
+ *
+ * 🔴 フリート実測（2026-08-23）: アイコンライブラリの npm 依存は**10艦とも0**、
+ * インライン `<svg>` は **222個**、うち **101個が `aria-hidden` も `role="img"` も持たない**。
+ * 装飾なのか意味を持つのかを宣言していないので、支援技術は推測するしかなく、
+ * **画面はどちらでも完全に正しく見える**。
+ */
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Icon } from './Icon.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const path = <path d="M4 4h16" />;
+
+describe('Icon', () => {
+  it('names itself when it carries meaning', () => {
+    const { container } = render(<Icon label="Delete">{path}</Icon>);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('role')).toBe('img');
+    expect(svg?.getAttribute('aria-label')).toBe('Delete');
+    expect(svg?.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('hides itself when it only repeats nearby text', () => {
+    const { container } = render(<Icon decorative>{path}</Icon>);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.getAttribute('focusable')).toBe('false');
+    expect(svg?.getAttribute('role')).toBeNull();
+    expect(svg?.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('falls back to hidden, never to a nameless image', () => {
+    // 🔴 型で塞いであるが、JS からの呼び出しと古いビルドは実在する。
+    // ここで role="img" を出すと**名前の無い画像**になり、支援技術は「画像」と読んで止まる。
+    // 実測した101個より悪い。黙る側へ倒す。
+    const { container } = render(<Icon {...({} as never)}>{path}</Icon>);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.getAttribute('role')).toBeNull();
+  });
+
+  it('does the same for an empty label, which is what a missing translation looks like', () => {
+    const { container } = render(<Icon label="">{path}</Icon>);
+    expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+    expect(container.querySelector('svg')?.getAttribute('role')).toBeNull();
+  });
+
+  it('takes its colour from the text around it', () => {
+    const { container } = render(<Icon decorative>{path}</Icon>);
+    expect(container.querySelector('svg')?.getAttribute('stroke')).toBe('currentColor');
+  });
+
+  it('offers sizes, not dimensions', () => {
+    const { container } = render(
+      <Icon decorative size="lg">
+        {path}
+      </Icon>,
+    );
+    const cls = (container.querySelector('svg')?.getAttribute('class') ?? '').split(/\s+/);
+    expect(cls).toEqual(expect.arrayContaining(['h-6', 'w-6']));
+  });
+
+  it('keeps the artwork the caller passed', () => {
+    const { container } = render(<Icon decorative>{path}</Icon>);
+    expect(container.querySelector('svg path')?.getAttribute('d')).toBe('M4 4h16');
+  });
+});

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -39,9 +39,22 @@ describe.each(CONTROLS)('%s', (_name, mount) => {
       expect.arrayContaining([
         'focus-visible:outline-2',
         'focus-visible:outline-offset-2',
-        'focus-visible:outline-accent',
+        'focus-visible:outline-text-primary',
       ]),
     );
+  });
+
+  it('does not draw its focus ring in a button fill colour', () => {
+    // 🔴 accent リングは primary ボタンと**同色**（1.00:1・テーマの oklch から計算）。
+    // offset があるので実際に隣接するのは地色だが、offset が消えた瞬間に見えなくなる。
+    for (const cls of classesOf(mount())) {
+      expect(cls).not.toBe('focus-visible:outline-accent');
+      expect(cls).not.toBe('focus-visible:outline-danger');
+    }
+  });
+
+  it('keeps the offset — it is what puts page colour between fill and ring', () => {
+    expect(classesOf(mount())).toContain('focus-visible:outline-offset-2');
   });
 
   it('never uses bare :focus, which also fires on a mouse click', () => {


### PR DESCRIPTION
Closes #308

🔴 ベースは `feat/306-controls-table`（PR #307）。着地順 = **#295 → #299 → #301 → #305 → #307 → 本 PR**。

vault が W1 の下ごしらえで見つけ、hub がフリート全数を測った3件（`hint` 6艦19箇所 / `required` 5艦16箇所 / `requiredMarker` vault のみ21箇所）。**そのまま足す前に実装を読んだら、`hint` は同じ名前で意味が2つありました。**

## 🔴 `hint` の描画位置が艦によって違う

| 艦 | 定義 | **位置** |
|---|---|---|
| **nene-invoice** | trailing adornment **beside the label** | 🔴 `<label>` の中・ラベルの隣 |
| **nene-vault** | helper text below the control | コントロールの下 |
| **nene-profile** | muted hint under the control | コントロールの下・**error 時は隠す** |

⇒ **キットが片方に決めると、もう片方の艦のテキストが黙って移動します。** 名前が同じなので載せ替えでは気づけません。

### prop を2つに分けた

| prop | 位置 |
|---|---|
| `hint` | **コントロールの下**（vault / profile 型・多数派） |
| `labelAdornment` | **ラベルの隣**（invoice 型） |

## 🔴 そして3艦とも `hint` を `aria-describedby` に繋いでいない

invoice / vault / profile とも、hint は**視覚的に出るだけ**でコントロールから参照されていません ＝ **見えるが読まれない**。#302 で潰した `aria-describedby` の穴と**同じ形**です。

⇒ キットは **`hint` と `error` の両方**を `aria-describedby` に載せます。**error が先**（間違えた後は、助言より理由が先に読まれるべき）。

⚠️ profile は error のとき hint を**隠します**。**採りません** —— 助けが要るのは、まさに間違えた瞬間なので。

## `required` と `requiredMarker` を2つに割る

| prop | 担うもの | 文字列 |
|---|---|---|
| `required` | **a11y の意味**（`aria-required`） | 不要 |
| `requiredMarker` | **見た目**（ラベル横） | 要る（呼び出し側が渡す・i18n 済み） |

🔴 **1つに混ぜると、キットが「*」を決め打ちすることになります**（ロケールによってマーカーは違う）。原則4（キットは文字列を持たない）に反します。

### `requiredMarker` が vault のみである件（hub 依頼の裏取り・自艦で実測）

| 艦 | Field 実装 | 必須マーカー |
|---|---|---|
| nene-field | あり | **表現なし** |
| nene-profile | あり | **表現なし** |
| nene-invoice | あり | **表現なし**（「必須」は stories のみ） |
| nene-vault | あり | `requiredMarker` |

⇒ **他の形でやっているのではなく、していない。** 口が無いから諦めている側なので、**キットが口を作れば揃う方に倒れます**（hub の読みを支持する実測）。

## 検証（自艦で実走・2026-08-23 14:1x）

| 確認 | 結果 |
|---|---|
| `npm run check` 全項目 | ✅ PASS（**43 files / 627 tests**） |

### 陽性対照3種（**いずれも赤・実行後に復旧**）

| # | 壊し方 | 落ちるテスト |
|---|---|---|
| 1 | **`hint` を `describedby` に載せない（= 3艦の現状へ戻す）** | `is read out with the control` ほか計2件 |
| 2 | error のとき hint を隠す（profile 型へ退化） | `stays visible when there is an error` |
| 3 | `requiredMarker` を `required` と無関係に描く | `does not show a marker for an optional field` |

## 併せて

テストファイル冒頭に残っていた**訂正前の数字（vault 16回）**も 3 へ直しました（#301 のソース側は別コミットで訂正済み）。
