### PR TITLE
chore(release): nene2-ui 0.2.0 ＋ 🔴 README のとおりに入れるとクラスが1つも生成されない欠陥を潰す（#315 / #316・publish ブロッカー）

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ on:
           - nene2-tokens
           - nene2-standards
           - nene2-i18n
+          - nene2-ui
       dry_run:
         description: 'npm publish --dry-run only'
         required: false

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -145,6 +145,46 @@ release note 明記2点（hub 依頼・正直表記）:
 
 publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run → 本番とも**施主実行**。成功後に fleet-baseline.json の null → 実版数の**別 PR**（下記「publish 成功後にやること」）。
 
+### `@hideyukimori/nene2-ui` 0.1.0（**初回**・#294）
+
+nene-payout の `shared/ui` から10部品を昇格（新規設計ゼロ）＋ `cx()` 是正。
+Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList。
+
+### `@hideyukimori/nene2-ui` 0.2.0（**minor — 部品 10→28本**・#315）
+
+W0.5〜W0.7（#298 / #300 / #302 / #304 / #306 / #308 / #311 / #312）。
+
+この版に入った部品:
+
+| 群           | 追加                                          |
+| ------------ | --------------------------------------------- |
+| `primitives` | `Textarea` `Checkbox` `Radio` `Switch` `Icon` |
+| `layout`     | `Stack` `Grid` `Box` `Section` `Card`         |
+| `states`     | `LoadingState`                                |
+| `overlay`    | `Modal` `ConfirmDialog`                       |
+| `feedback`   | `Badge` `InlineAlert` `ToastProvider`         |
+| `data`       | `DataTable` `Pagination`                      |
+
+API の追加（後方互換）: `FormField` の `hint` / `labelAdornment` / `required` / `requiredMarker`、
+`useToast`、`CONTROL_CLASS` / `FOCUS_CLASS` / `DISABLED_CLASS`、型 `Space` / `Responsive`。
+
+🔴 **破壊的変更は無いが、既存部品の見た目が変わる箇所が2つある**（どちらも v0.1 に
+**無かった**状態表現の追加であって、呼び出し側の指定を上書きするものではない）:
+
+- `Button` / `Input` / `Select` に **disabled と focus-visible の表示が付く**
+  （v0.1 は両方とも1つも持っていなかった。画面側が39箇所で自前に補っていた）
+- `FormField` が **`aria-describedby` を自分で張る**
+  （v0.1 は呼び出し側の責務と doc コメントで宣言し、フリートは守っていなかった）
+
+🔴 **この版で `@source` の欠陥を潰してある**（#316）。0.1.0 の README のとおりに入れると
+**Tailwind がキットのクラスを1つも生成しない**（v4 の自動検出は `node_modules` を走査しない）。
+ビルドも型検査もテストも緑のまま無装飾になる。**npm の版は不変なので、publish 後に README を
+直しても 0.2.0 に固定した艦は壊れた手順を読み続ける** ⇒ **0.2.0 に同梱するのが唯一の機会だった。**
+キットは番兵クラス（`SOURCE_PROBE_CLASS`）も同梱し、consumer 側で1行で検知できるようにしてある。
+
+🔴 **`fleet-baseline.json` への登録は publish の後**。floor は消費側が従う下限なので、
+**公開されていない版を floor に書くと全艦が達成不能になる**。
+
 ## 初回 publish（パッケージごとに1回・hide のローカル操作）
 
 > 🔴 **`@hideyukimori/nene2-ui` の初回 publish が残っている**〔2026-08-23 実測: `npm view` が 404〕。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -55,7 +55,44 @@ Peer dependencies: `react >= 19`, `tailwindcss >= 4`.
 /* src/shared/ui/theme/index.css */
 @import 'tailwindcss';
 @import '@hideyukimori/nene2-ui/themes/default.css';
+
+/* 🔴 Required. Adjust the relative path to reach your node_modules. */
+@source '../../../../node_modules/@hideyukimori/nene2-ui/dist';
 ```
+
+### 🔴 The `@source` line is not optional
+
+Tailwind v4 discovers classes by scanning your source files, and **it does not walk
+`node_modules`**. Every class this kit ships lives in its `dist/`, so without that line
+Tailwind never sees them and **generates none of them**.
+
+Nothing goes red when this happens. Measured by nene-vault on 2026-08-23 in a real
+application: the build passed with no warning, the types passed, **all 275 tests passed**,
+and the stylesheet came out 47.1 KB instead of 58.6 KB — with every `gap-*`, `rounded-*`,
+focus ring and disabled treatment missing. The tell was that `p-x-lg`, the _same token_
+written in the app's own `.tsx`, was generated. The only difference is which directory the
+file sits in.
+
+A test suite cannot catch it either: jsdom does not compute styles. On screen the symptom is
+simply "the kit does not seem to do anything".
+
+### Proving it, so nobody has to remember
+
+The kit exports a class that exists nowhere except its own `dist`. If your build generates
+it, the kit is in your `@source`; if not, every class the kit ships was dropped. Check it
+where you already check other things:
+
+```js
+import { SOURCE_PROBE_CLASS } from '@hideyukimori/nene2-ui';
+import { readFileSync } from 'node:fs';
+
+const css = readFileSync('dist/assets/index.css', 'utf8');
+if (!css.includes(`.${SOURCE_PROBE_CLASS}`)) {
+  throw new Error('nene2-ui is not in Tailwind @source — none of its classes were generated');
+}
+```
+
+The probe resolves to `padding: 0px`, so it changes nothing if it is ever applied.
 
 ```tsx
 import { PageHeader, Button, FormField, Input, EmptyState } from '@hideyukimori/nene2-ui';

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -58,3 +58,5 @@ export { cx } from './lib/cx.js';
 // Controls the kit does not ship yet (Textarea has 7 independent implementations in the
 // fleet) can at least carry the same focus and disabled behaviour instead of inventing it.
 export { CONTROL_CLASS, DISABLED_CLASS, FOCUS_CLASS } from './lib/states.js';
+// Lets a consumer's build prove the kit is in its Tailwind `@source` (#316).
+export { SOURCE_PROBE_CLASS } from './lib/source-probe.js';

--- a/packages/nene2-ui/src/lib/source-probe.ts
+++ b/packages/nene2-ui/src/lib/source-probe.ts
@@ -1,0 +1,28 @@
+/**
+ * A class that exists only inside this package's build output.
+ *
+ * 🔴 Why a consumer needs it. Tailwind v4's automatic content detection does not walk
+ * `node_modules`, and every class this kit ships lives in `dist/**` — so an app that
+ * imports the theme but does not add the kit to its `@source` generates **none** of them.
+ * Measured by nene-vault on 2026-08-23 against `origin/main` `e566a83`: the build was
+ * green, the types were green, all 275 tests passed, and the CSS was 47.1 KB instead of
+ * 58.6 KB with every `gap-*`, `rounded-*`, focus and disabled class missing. The decisive
+ * detail is that `p-x-lg` — the same token, written in the app's own tsx — was generated.
+ * The difference is only whether the file lives under `node_modules`.
+ *
+ * Nothing in that failure is visible: jsdom does not compute styles, so a test suite cannot
+ * see it, and the symptom on screen is "the kit does not seem to do anything".
+ *
+ * So the kit ships a sentinel instead of relying on the README being read:
+ *
+ * ```js
+ * import { SOURCE_PROBE_CLASS } from '@hideyukimori/nene2-ui';
+ * const css = readFileSync('dist/assets/index.css', 'utf8');
+ * if (!css.includes(`.${SOURCE_PROBE_CLASS}`)) {
+ *   throw new Error('nene2-ui is not in Tailwind @source — its classes were not generated');
+ * }
+ * ```
+ *
+ * The utility resolves to `padding: 0px`, so it is inert if anyone ever applies it.
+ */
+export const SOURCE_PROBE_CLASS = 'p-x-source-probe';

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -48,3 +48,30 @@ describe('README component table', () => {
     ).toEqual([]);
   });
 });
+
+describe('the @source instruction', () => {
+  // 🔴 Without it Tailwind generates none of the kit's classes, and nothing goes red:
+  // build, types and tests all pass (jsdom does not compute styles). #316.
+  it('is in the Use section, not only in prose further down', () => {
+    const use = readme.slice(readme.indexOf('## Use'), readme.indexOf('## Theming'));
+    expect(use).toContain('@source');
+    expect(use).toContain('@hideyukimori/nene2-ui/dist');
+  });
+
+  it('ships a probe class that the theme actually defines', () => {
+    // A sentinel naming a token that does not exist would never be generated even when the
+    // @source is correct — it would report failure forever, and be switched off.
+    const theme = readFileSync(path.join(root, 'themes/default.css'), 'utf8');
+    const probe = readFileSync(path.join(root, 'src/lib/source-probe.ts'), 'utf8');
+    const cls = probe.match(/SOURCE_PROBE_CLASS = '([^']+)'/)?.[1];
+    expect(cls).toBeTruthy();
+    const token = cls!.replace(/^p-/, '');
+    expect(theme, `--spacing-${token} missing from themes/default.css`).toContain(
+      `--spacing-${token}:`,
+    );
+  });
+
+  it('exports the probe, so a consumer can reference it instead of hard-coding it', () => {
+    expect(index).toContain('SOURCE_PROBE_CLASS');
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -21,6 +21,12 @@
 
   --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
 
+  /* Sentinel for the consumer's build (#316). Zero-width, so applying it does nothing.
+   * Its only job is to exist: `p-x-source-probe` appears nowhere except this kit's `dist`,
+   * so a build that generates it has the kit in its `@source`, and a build that does not
+   * has silently dropped every class the kit ships. See SOURCE_PROBE_CLASS. */
+  --spacing-x-source-probe: 0px;
+
   /* Disabled controls. A value, so it lives here rather than in a component — the same rule
    * the colours follow. 50% is what the fleet's screens most often reached for when the kit
    * gave them nothing (50 x10, 40 x4, 30 x6, measured 2026-08-23 across 20 uses). */

--- a/scripts/check-lock-sync.mjs
+++ b/scripts/check-lock-sync.mjs
@@ -23,6 +23,38 @@
  * ここで意味を言い直している（それをしないと「無視してよい赤」に化ける）。
  */
 import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * `npm ci` accepts a lock whose workspace entry records an out-of-date `version`, so a
+ * version bump leaves the lock behind without anything going red (measured 2026-08-23 while
+ * releasing nene2-ui 0.2.0: the lock still said 0.1.0 and this gate reported "in sync").
+ *
+ * 🔴 That made this script's own message wider than what it checked — the exact shape it
+ * was written to catch. Checked explicitly rather than reworded.
+ */
+function staleWorkspaceVersions() {
+  const lock = JSON.parse(readFileSync(path.join(root, 'package-lock.json'), 'utf8'));
+  const stale = [];
+  for (const dir of readdirSync(path.join(root, 'packages'))) {
+    const rel = `packages/${dir}`;
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(path.join(root, rel, 'package.json'), 'utf8'));
+    } catch {
+      continue; // not a workspace
+    }
+    const recorded = lock.packages?.[rel]?.version;
+    if (recorded !== undefined && recorded !== pkg.version) {
+      stale.push(`${rel}: package.json ${pkg.version} / lock ${recorded}`);
+    }
+  }
+  return stale;
+}
 
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const r = spawnSync(npm, ['ci', '--dry-run', '--ignore-scripts', '--offline'], {
@@ -36,8 +68,17 @@ if (r.error) {
 }
 
 if (r.status === 0) {
-  console.log('check:lock: package.json と package-lock.json は同期している');
-  process.exit(0);
+  const stale = staleWorkspaceVersions();
+  if (stale.length === 0) {
+    console.log('check:lock: package.json と package-lock.json は同期している');
+    process.exit(0);
+  }
+  console.error('🔴 check:lock: lock がワークスペースの版に追随していない');
+  for (const line of stale) console.error(`   ${line}`);
+  console.error('');
+  console.error('   直し方: npm install --package-lock-only --ignore-scripts');
+  console.error('   （npm ci はこの食い違いを通すので、CI は緑のまま lock だけが古くなる。）');
+  process.exit(1);
 }
 
 const out = `${r.stdout ?? ''}${r.stderr ?? ''}`;


### PR DESCRIPTION
Closes #315
Closes #316

**publish の最終工程。①②③④ を1本にまとめてあります**（施主裁定「**番兵込みで打つ**」に従い、**版は 0.2.0 の1つで済ませます**）。

## 🔴 ① / ② publish のブロッカーだった欠陥（#316・vault が第1段で発見）

README の `## Use` のとおりに入れると、**キットのクラスが1つも生成されません。** Tailwind v4 の自動コンテンツ検出は **`node_modules` を走査しない**ため、`dist/**` の中にしか無いクラス文字列は**存在しないものとして扱われます**。

### vault の実測（実アプリで `npm run build`・検証 ref `e566a83`）

| クラス | 出所 | README どおり | `@source` 追加後 |
|---|---|:---:|:---:|
| `gap-x-2xs` / `gap-x-sm` | `Stack` | 🔴 無し | 🟢 |
| `focus-visible:outline-*` | `FOCUS_CLASS` | 🔴 無し | 🟢 |
| `disabled:opacity-x-disabled` | `DISABLED_CLASS` | 🔴 無し | 🟢 |
| `rounded-x-md` | `Card` ほか | 🔴 無し | 🟢 |
| **`p-x-lg`** | **vault 自身の tsx** | **🟢** | 🟢 |
| 生成 CSS | | **47.1 KB** | **58.6 KB** |

🔑 **`p-x-lg` だけ通るのが決定的です。** 同じトークンでも、**consumer のソースに書かれていれば生成され、キットの中にしか無ければ生成されない。差は「node_modules かどうか」だけ。**

⚠️ **自艦では再現できませんでした**（走査を担う `@tailwindcss/oxide` がこのリポに無く、消費側アプリも無い）。**根拠は vault の実測**で、内部対照（`p-x-lg`）があるので十分と判断しています。

### なぜ publish 前でなければならなかったか

**ビルド緑・型検査緑・テスト緑**（vault の **275件が全部通る**。**jsdom は CSS を計算しないので、テストスイートには原理的に検出できません**）。症状は「gap も padding も focus リングも disabled も**全部無い**」で、**入れた側は原因に辿り着けません**。

🔴 **npm の版は不変**なので、0.2.0 を publish した後に README を直しても、**0.2.0 に固定した艦は壊れた手順を読み続けます**（直すなら 0.2.1）。⇒ **同梱が唯一の機会でした。**

### 直したもの

| | |
|---|---|
| README `## Use` | `@source` を追加し、**なぜ必須か**（何も赤くならないこと）を実測ごと記載 |
| 🔴 **番兵** | テーマに `--spacing-x-source-probe: 0px`／`SOURCE_PROBE_CLASS` を export。**キットの `dist` にしか無いクラス**なので、生成 CSS に在るかで `@source` の有無が分かる。**README は読まれないことがあるが、番兵は読まれなくても効く**（vault 提案） |
| 番兵自体の検査 | **実在しないトークンを指す番兵は永久に赤を出し、やがて切られる** ⇒ テーマに定義が在ることを落とすテストを置いた |

## ③ / ④ 版上げ

**0.1.0 → 0.2.0**（minor）。**部品 10本 → 28本**、export 総数 **35**（部品28＋ヘルパ7）。API 追加は後方互換。

🔴 破壊的変更は無いが、**v0.1 に無かった状態表現が付く**箇所が2つ（`Button`/`Input`/`Select` の disabled・focus-visible ／ `FormField` の `aria-describedby`）。

- 🔴 **`publish.yml` の package 選択肢に `nene2-ui` が無かった**ので追加（**CI からは publish できない状態**でした）
- `docs/publish.md` に 0.1.0 / 0.2.0 の節（#313 で決めた形＝**状態は書かず、何を出したかだけ**）
- 🔴 **`fleet-baseline.json` への登録は publish の後**（公開前の版を floor に書くと**全艦が達成不能**になる）

## 🔴 ついでに: `check:lock` の射程が名乗りより狭かった

版を上げても **`check:lock` が緑のまま**でした。**`npm ci` はワークスペースの版の食い違いを通す**ので、lock は 0.1.0 のまま置き去りになります。

⇒ **ワークスペースの版比較を明示的に足しました**（文言を狭めるのではなく**検査を広げた**）。今日ずっと追いかけている「ゲートの名乗りが射程より広い」の、**自分が書いたゲート版**です。

## 検証（自艦で実走・2026-08-23 15:5x）

| 確認 | 結果 |
|---|---|
| `npm run check` 全項目 | ✅ PASS（45 files / **651 tests**） |
| `npm publish --dry-run` | ✅ `@hideyukimori/nene2-ui` **0.2.0** / 112 files / 41.0 kB（`themes/default.css` と `dist/lib/source-probe.js` を含むことを確認） |
| Tailwind 4.3.2 | ✅ `p-x-source-probe` → `padding: var(--spacing-x-source-probe)` |

**陽性対照4種**（いずれも赤・実行後に復旧）:

1. README から `@source` を消す → `is in the Use section`
2. 番兵トークンをテーマから消す → `ships a probe class that the theme actually defines`
3. lock の版を 0.1.0 へ戻す → `lock がワークスペースの版に追随していない`
4. （3 の対照として）**`npm ci` 単体では exit 0** ＝ 旧ゲートが見逃していた理由

## publish 後にやること

1. **vault が第2段で最初の consumer になる。** `@source` を意図的に書かない状態を1回作り、**番兵が赤くなることを確認**する（**陽性対照を配布の境界で1回取る**）
2. `fleet-baseline.json` に `@hideyukimori/nene2-ui` を登録
