### PR TITLE
chore(fleet-baseline): nene2-ui を登録する — publish 済みになったので floor を入れられる（#320）

### DIFF
--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -5,6 +5,7 @@
     "@hideyukimori/nene2-client": "^1.1.0",
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.1.1",
-    "@hideyukimori/nene2-i18n": "^0.3.0"
+    "@hideyukimori/nene2-i18n": "^0.3.0",
+    "@hideyukimori/nene2-ui": "^0.2.0"
   }
 }


### PR DESCRIPTION
Closes #320

🟢 **ベースは `main`。独立に入ります。**

## いま登録できる理由

`docs/fleet-baseline.schema.json` の記述:

> `null` = 未発効（当該版がまだ npm に publish されていない — **未公開版を書かない・誠実性ガード**）。**実版数の記入は publish 成功後の別 PR。**

⇒ **`@hideyukimori/nene2-ui@0.2.0` が publish された**〔2026-08-23 実測: レジストリの `/0.2.0` エンドポイントが `shasum 6cd9bb29…` を返し、**publish 出力と一致**〕ので、条件が解けました。

## 入れたもの

```json
"@hideyukimori/nene2-ui": "^0.2.0"
```

**0.x なので `^0.2.0` は `>=0.2.0 <0.3.0`。** pre-1.0 では minor が破壊的変更を許すので、この範囲が正しいです。

スキーマ適合を自艦で実測（**5件とも key / value ともパターン一致**）。

## 🔴 既存3本の floor は触りません

| | floor | npm 実測 |
|---|---|---|
| `nene2-client` | `^1.1.0` | 1.4.0 |
| `nene2-tokens` | `^1.1.0` | 1.2.0 |
| `nene2-standards` | `^2.1.1` | 2.2.0 |

**#271 で「据え置き」と裁定済み**（floor の追随ではなく**実採用版の是正**が本筋）。本 PR の射程外です。