### PR TITLE
docs(ui): 配布ソースの実測値を、より強い実測へ差し替える — vault の overflow は「当たった先」が根拠／svg 222 の射程を明記（#324）

### DIFF
--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -13,10 +13,20 @@
  * that only shows the ring to keyboard users.
  *
  * 🔴 `outline`, not `ring`. Tailwind's `ring-*` is a box-shadow, so a parent with
- * `overflow-hidden` clips it away entirely. This kit's own `Card` does not clip — but the
- * products' existing containers do: `overflow-hidden` appears 12 times in nene-records and
- * twice each in nene-vault and nene-deal, which are the first two ships to be migrated
- * (measured 2026-08-23). `outline` is not clipped and carries its own offset.
+ * `overflow: hidden` clips it away entirely. This kit's own `Card` does not clip — the
+ * products' existing containers do, and what they clip decides how much this matters.
+ * In nene-vault, the first ship to migrate (measured 2026-08-23, counting CSS rules as well
+ * as Tailwind classes):
+ *
+ *   .center-card   the whole login form — two inputs and a button
+ *   .seg           the diff/json toggle on the audit screen
+ *   .rail-link     the mobile side-nav buttons
+ *
+ * A `ring` would have lost the focus indicator on all three, and the login form is the one
+ * screen an unauthenticated user can reach. nene-records clips in 12 places, which is more
+ * places but softer targets — the count is the weaker argument.
+ *
+ * `outline` is not clipped and carries its own offset.
  *
  * 🔴 The ring is `text-primary`, not `accent`. An accent ring is *the same colour as a
  * primary button* — contrast 1.00:1 against its own fill, and 1.11:1 against a danger

--- a/packages/nene2-ui/src/primitives/Icon.tsx
+++ b/packages/nene2-ui/src/primitives/Icon.tsx
@@ -34,9 +34,15 @@ const SIZE_CLASS: Record<IconSize, string> = {
  *
  * 🔴 The kit ships no artwork and takes on no icon library, because the fleet has none:
  * across all ten products the dependency count for lucide / heroicons / feather / phosphor
- * / tabler is zero, and every icon is an inline `<svg>` (222 of them, measured 2026-08-23).
- * Choosing a set would mean adding a dependency to seventeen ships to solve a problem they
- * do not have.
+ * / tabler is zero, and the icons are drawn inline: **222 `<svg>` elements** across eight
+ * products (measured 2026-08-23). Choosing a set would mean adding a dependency to
+ * seventeen ships to solve a problem they do not have.
+ *
+ * (Scope: that count is `<svg>` elements only. Icons can also be drawn as CSS backgrounds,
+ * and one is — the `select` chevron in nene-vault, a data-URI background. Searching for one
+ * spelling of a thing that has several always undercounts, so the form being counted is
+ * written down. A background-drawn icon has no element to announce either way, so it does
+ * not move the number below.)
  *
  * 🔴 What is not consistent is the meaning. Of those 222, **101 declare neither
  * `aria-hidden` nor `role="img"`** — they do not say whether they are decoration or


### PR DESCRIPTION
Closes #324

配布物のソースコメントに書いた実測値を2件直します。**11艦へ配られ、以後この部品を読む全員が読む**ので、根拠の質を上げます。

## 🔴 ① `states.ts` — `ring`→`outline` の根拠を「箇所数」から「当たった先」へ

vault が自分の過小報告を訂正しました:

> `grep -rn 'overflow-hidden' src --include='*.tsx'` で測ったので、**Tailwind クラスとして書かれたものしか見ていなかった。CSS で宣言された `overflow: hidden` が別に6件ある。**

| セレクタ | 中身 | フォーカス可能 |
|---|---|:---:|
| **`.center-card`** | 🔴 **ログイン画面のフォーム全体**（`input`×2 ＋ `button`×1） | ✅ |
| `.seg` | 監査画面の diff/json 切替ボタン | ✅ |
| `.rail-link` | モバイルのサイドナビのボタン | ✅ |

⇒ 🔴 **`ring` のままなら、vault は「ログイン画面」「監査の切替」「モバイルのナビ」で焦点表示を失っていました。ログイン画面は、未認証ユーザーが最初に触る唯一の画面です。**

🔑 **records の12箇所は「数が多い」、vault は「当たった先が悪い」。根拠としては後者が強い。**

> 経緯: 自艦が `Card` を誤って引用 → hub が訂正 → **その訂正が vault の過小報告に基づいていたので撤回** → いま戻る。**結論は最初から変わっていません。**

## ② `Icon.tsx` — 「222」に射程ラベル

「**every icon is an inline `<svg>`**」は言い過ぎでした。他の表現形式を自艦で実測:

| 形式 | ヒット | 判定 |
|---|---:|---|
| インライン `<svg>` | **222** | — |
| `mask-image`（deal 2 / invoice 1） | 3 | 🟢 **偽陽性** — グラデーションのマスク（意匠効果） |
| `fa-*`（invoice 3） | 3 | 🟢 **偽陽性** — FAQ の `.fa-body` というクラス名 |
| **CSS 背景で描かれたアイコン** | **1** | 🔴 **本物** — vault の `select` の chevron（data-URI 背景） |

⇒ **101 の向きは変わりません**（CSS 背景のアイコンは DOM 要素を持たないので、announce の対象ですらない）。ただし「すべてが inline svg」は偽なので、**数えた形式を書き添えました**。

🔑 vault の一般化: **同じ概念が2つ以上の書かれ方をする時、片方だけを検索すると必ず過小になる。** 過大は「多いな」と疑われて止まりますが、**過小は「無い」として通過します**。

## 検証

`npm run check` 全項目 PASS（45 files / 651 tests）。