### PR TITLE
feat(ui) 0.3.0: 意匠値を2層トークンへ — スケールは fleet 固定、割り当ては艦が決める（#328）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -150,25 +150,38 @@ publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run �
 nene-payout の `shared/ui` から10部品を昇格（新規設計ゼロ）＋ `cx()` 是正。
 Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList。
 
-### `@hideyukimori/nene2-ui` 0.3.0（**minor — 意匠値を部品からテーマへ出す**・#328）
+### `@hideyukimori/nene2-ui` 0.3.0（**minor — 意匠値を2層トークンへ**・#328）
 
-🔴 **既存部品の見た目が変わる**（0.2.0 の値を意図的に変えている・下記）。
+🔴 **既存部品の見た目が変わる**（ラベルの既定値を意図的に変えている・下記）。
 
-- `FormField` のラベルが `--color-x-label` / `--text-x-label-size` / `--font-weight-x-label` を参照する。
-  **既定値も変えた**: 0.2.0 は本文サイズ・`text-primary`（部品への直書き）だったが、
-  0.3.0 は **0.75rem・`text-muted`・500**。理由は下記
-- `Input` / `Select` / `Textarea` が `--text-x-control-size`（既定 `max(1rem, 16px)`）を持つ。
-  **iOS Safari は 16px 未満の入力にフォーカスするとページごと拡大する**ので、
-  本文が 14px の製品では旧実装の見た目に戻せない
-- README に**上書きしてよいトークンと、いけないトークン**（spacing の9段）の境界
+**テーマを2層にした**:
 
-**既定値を変えた理由**: 0.2.0 の値は**設計判断ではなく初期実装の残り**だった。
-0.3.0 の値は `nene-vault` の `.field-label`（同艦の意匠再生成 #361 で確定したもの）に合わせている。
-⇒ **「設計を経た値」を既定に置き、経ていない値を捨てた。** 艦は自艦のテーマで再定義できる。
+| 層             |                                                                          | 艦                    |
+| -------------- | ------------------------------------------------------------------------ | --------------------- |
+| ① **スケール** | `--spacing-x-3xs` … `--spacing-x-2xl`（9段）・radius・色                 | 🔒 **上書きしない**   |
+| ② **スロット** | `--spacing-x-slot-<部品>-<役割>` ほか **35本**。既定は全部スケールを指す | 🟢 **上書きしてよい** |
 
-🔴 **色とサイズに同じ suffix を使わないこと。** Tailwind は `text-<name>` を `--color-*` から先に
-解決するので、`--color-x-label` と `--text-x-label` を両方定義すると**サイズが到達不能になる**
-（コンパイルは通る）。`-size` を付けている理由。テストで固定した。
+**部品はスロットしか参照しない。** ⇒ 艦は**割り当てを変えられるが、段を発明できない**
+（`--spacing-x-slot-card-pad: var(--spacing-x-lg)` は書けるが `1.375rem` は書けない）。
+スロットは**部品ごと**に切ってある（施主裁定 2026-08-23 — **共有は後から寄せられるが、
+分けるのは後からだと全艦に影響する**）。
+
+- `FormField` のラベル: `--color-x-slot-field-label` / `--text-x-slot-field-label-size` /
+  `--font-weight-x-slot-field-label`。**既定値も変えた** — 0.2.0 は本文サイズ・`text-primary`
+  （部品への直書き）、0.3.0 は **0.75rem・`text-muted`・500**。
+  理由: 0.2.0 の値は**設計判断ではなく初期実装の残り**で、0.3.0 の値は `nene-vault` の
+  `.field-label`（同艦の意匠再生成 #361 で確定）に合わせた。**設計を経た値を既定に置いた。**
+- `Input` / `Select` / `Textarea`: `--text-x-slot-control-size`（既定 `max(1rem, 16px)`）。
+  **iOS Safari は 16px 未満の入力にフォーカスするとページごと拡大する**
+- README に**両方**書いた（🟢 スロットは上書きしてよい／🔒 スケールは上書きしない）。
+  **片方だけだと次の艦が反対側で迷う**
+
+🔴 **色とサイズに同じ suffix を使わないこと。** Tailwind は `text-<name>` を `--color-*` から
+先に解決するので、`--color-x-slot-field-label` と `--text-x-slot-field-label` を両方定義すると
+**サイズが到達不能になる**（コンパイルは通る）。`-size` を付けている理由。テストで固定した。
+
+🔴 **スロットは Tailwind の名前空間の中に置くこと**（`--spacing-x-slot-…`）。
+名前空間の外（`--x-slot-…`）に置くと**ユーティリティが1つも生成されない**〔実測〕。
 
 ### `@hideyukimori/nene2-ui` 0.2.0（**minor — 部品 10→28本**・#315）
 

--- a/docs/publish.md
+++ b/docs/publish.md
@@ -150,6 +150,26 @@ publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run �
 nene-payout の `shared/ui` から10部品を昇格（新規設計ゼロ）＋ `cx()` 是正。
 Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList。
 
+### `@hideyukimori/nene2-ui` 0.3.0（**minor — 意匠値を部品からテーマへ出す**・#328）
+
+🔴 **既存部品の見た目が変わる**（0.2.0 の値を意図的に変えている・下記）。
+
+- `FormField` のラベルが `--color-x-label` / `--text-x-label-size` / `--font-weight-x-label` を参照する。
+  **既定値も変えた**: 0.2.0 は本文サイズ・`text-primary`（部品への直書き）だったが、
+  0.3.0 は **0.75rem・`text-muted`・500**。理由は下記
+- `Input` / `Select` / `Textarea` が `--text-x-control-size`（既定 `max(1rem, 16px)`）を持つ。
+  **iOS Safari は 16px 未満の入力にフォーカスするとページごと拡大する**ので、
+  本文が 14px の製品では旧実装の見た目に戻せない
+- README に**上書きしてよいトークンと、いけないトークン**（spacing の9段）の境界
+
+**既定値を変えた理由**: 0.2.0 の値は**設計判断ではなく初期実装の残り**だった。
+0.3.0 の値は `nene-vault` の `.field-label`（同艦の意匠再生成 #361 で確定したもの）に合わせている。
+⇒ **「設計を経た値」を既定に置き、経ていない値を捨てた。** 艦は自艦のテーマで再定義できる。
+
+🔴 **色とサイズに同じ suffix を使わないこと。** Tailwind は `text-<name>` を `--color-*` から先に
+解決するので、`--color-x-label` と `--text-x-label` を両方定義すると**サイズが到達不能になる**
+（コンパイルは通る）。`-size` を付けている理由。テストで固定した。
+
 ### `@hideyukimori/nene2-ui` 0.2.0（**minor — 部品 10→28本**・#315）
 
 W0.5〜W0.7（#298 / #300 / #302 / #304 / #306 / #308 / #311 / #312）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -131,6 +131,42 @@ Regenerate a theme from the token contract with:
 npx @hideyukimori/nene2-tokens themegen
 ```
 
+## 🔴 What a product may redefine, and what it may not
+
+Everything in `themes/default.css` is _technically_ overridable — a product's own `@theme`
+loads after the kit's and wins. That is not the same as being free to override it.
+
+|                        |                                                                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 🟢 **Redefine freely** | **Colour, typography, radius, shadow.** These are your brand. `--color-accent`, `--color-x-label`, `--text-x-label-size`, `--font-weight-x-label`, `--radius-x-md` … |
+| 🔴 **Do not redefine** | **The spacing scale** (`--spacing-x-3xs` … `--spacing-x-2xl`).                                                                                                       |
+
+### Why spacing is different
+
+The nine steps are not a suggestion; they are the thing the kit is for. A product that
+retunes them to match what it wrote before keeps the vocabulary and loses the rule — nine
+names, nine different meanings per product, and no way to say a screen is consistent.
+
+The temptation is real: after migrating, some spacing shifts by up to 2px. That shift is the
+point. Measured in nene-vault before its migration, 128 spacing utilities used **19 distinct
+values**, five of which appeared exactly once. That is drift, not design, and snapping it is
+the correction — not a regression to be tuned away.
+
+Retuning also makes the fit worse, not better (measured across those 128 uses):
+
+| scale                           | exact match | within 2px |  worst case |
+| ------------------------------- | ----------: | ---------: | ----------: |
+| **the kit's nine**              |         47% |    **99%** |     **4px** |
+| nine chosen to fit this product |         84% |        95% | 🔴 **24px** |
+
+More exact matches, five times the worst error — because a scale bent toward one product's
+histogram drops the ends.
+
+🔑 **The kit holds the set you keep to. Your theme holds what your brand looks like.**
+
+If a screen genuinely cannot be expressed on the scale, that is a missing step or a missing
+component — open an issue rather than editing the token, so every product gets the answer.
+
 ## What is in scope
 
 **In:** admin console and business-screen UI, page layout scaffolding, form field structure, the

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -179,9 +179,33 @@ own ends.
 
 🔑 **The scale is the set you keep to. The slots are what your brand looks like.**
 
-Both halves are enforced: a slot whose default is a literal, or a component that reaches past
-the slots into the scale, fails the test suite. If a screen cannot be expressed this way, it
-is a missing slot or a missing component — open an issue, so every product gets the answer.
+### Composing a slot
+
+A slot can hold several steps — four-sided padding is just CSS:
+
+```css
+--spacing-x-slot-login-form-pad: var(--spacing-x-xl) var(--spacing-x-md) var(--spacing-x-lg)
+  var(--spacing-x-md);
+```
+
+🔴 **There is no shorthand for this, on purpose.** The kit's tokens are written by tooling,
+not typed by hand, so brevity buys nothing — and a shorthand would need an expander, which is
+one more layer that can quietly drop meaning. Plain `var()` composition has no such layer, and
+it can be checked with a regular expression exactly as written: **every value in a slot is a
+`var(--spacing-*)` or `var(--radius-*)`, and nothing else.**
+
+That check is what keeps the scale from leaking. `--spacing-x-slot-field-gap: 0.5625rem`
+compiles, looks reasonable, and reintroduces the drift the scale exists to stop — so it fails
+here, including when it is hidden among three legitimate references in a composition.
+
+### Both halves are enforced
+
+A slot whose default contains a literal, or a component that reaches past the slots into the
+scale, fails the test suite. If a screen cannot be expressed this way, it is a missing slot or
+a missing component — open an issue, so every product gets the answer.
+
+**Products: apply the same check to your own theme.** The kit can only police its own file;
+the rule is the same one, and the regular expression above is the whole implementation.
 
 ## What is in scope
 

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -133,39 +133,55 @@ npx @hideyukimori/nene2-tokens themegen
 
 ## 🔴 What a product may redefine, and what it may not
 
-Everything in `themes/default.css` is _technically_ overridable — a product's own `@theme`
-loads after the kit's and wins. That is not the same as being free to override it.
+The theme has two layers, and the line between them is the point.
 
-|                        |                                                                                                                                                                      |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🟢 **Redefine freely** | **Colour, typography, radius, shadow.** These are your brand. `--color-accent`, `--color-x-label`, `--text-x-label-size`, `--font-weight-x-label`, `--radius-x-md` … |
-| 🔴 **Do not redefine** | **The spacing scale** (`--spacing-x-3xs` … `--spacing-x-2xl`).                                                                                                       |
+### ② Slots — 🟢 redefine these
 
-### Why spacing is different
+Every design value a component uses comes from a slot, and slots are named per component:
 
-The nine steps are not a suggestion; they are the thing the kit is for. A product that
-retunes them to match what it wrote before keeps the vocabulary and loses the rule — nine
-names, nine different meanings per product, and no way to say a screen is consistent.
+```css
+/* your product's theme, loaded after the kit's */
+@theme {
+  --spacing-x-slot-card-pad: var(--spacing-x-lg); /* roomier cards, everywhere */
+  --color-x-slot-field-label: var(--color-text-primary); /* darker field labels */
+  --radius-x-slot-control: var(--radius-x-md);
+}
+```
 
-The temptation is real: after migrating, some spacing shifts by up to 2px. That shift is the
-point. Measured in nene-vault before its migration, 128 spacing utilities used **19 distinct
-values**, five of which appeared exactly once. That is drift, not design, and snapping it is
-the correction — not a regression to be tuned away.
+This is where your product decides how it looks. Change a slot and every instance of that
+component follows.
 
-Retuning also makes the fit worse, not better (measured across those 128 uses):
+### ① The scale — 🔒 do not redefine
+
+`--spacing-x-3xs` … `--spacing-x-2xl`, and the radius and colour tokens they point at.
+
+```css
+--spacing-x-slot-card-pad: 1.375rem; /* 🔴 no */
+--spacing-x-md: 1.375rem; /* 🔴 no */
+```
+
+**A slot chooses a step; it may not invent one.** That is the whole mechanism: a product can
+make its cards roomier, and cannot end up with `2.25` again.
+
+### Why the scale is locked
+
+Measured in nene-vault before its migration: **128 spacing utilities using 19 distinct
+values**, five of which appeared exactly once. That is drift, not design. Retuning the scale
+to match it also fits _worse_, not better:
 
 | scale                           | exact match | within 2px |  worst case |
 | ------------------------------- | ----------: | ---------: | ----------: |
 | **the kit's nine**              |         47% |    **99%** |     **4px** |
 | nine chosen to fit this product |         84% |        95% | 🔴 **24px** |
 
-More exact matches, five times the worst error — because a scale bent toward one product's
-histogram drops the ends.
+More exact matches, five times the worst error — a scale bent toward one histogram drops its
+own ends.
 
-🔑 **The kit holds the set you keep to. Your theme holds what your brand looks like.**
+🔑 **The scale is the set you keep to. The slots are what your brand looks like.**
 
-If a screen genuinely cannot be expressed on the scale, that is a missing step or a missing
-component — open an issue rather than editing the token, so every product gets the answer.
+Both halves are enforced: a slot whose default is a literal, or a component that reaches past
+the slots into the scale, fails the test suite. If a screen cannot be expressed this way, it
+is a missing slot or a missing component — open an issue, so every product gets the answer.
 
 ## What is in scope
 

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/data/DataTable.tsx
+++ b/packages/nene2-ui/src/data/DataTable.tsx
@@ -42,7 +42,7 @@ export function DataTable<Row>({ columns, rows, rowKey, caption }: DataTableProp
             <th
               key={col.key}
               scope="col"
-              className={`border-b border-border px-x-2xs py-x-3xs font-medium text-text-muted ${
+              className={`border-b border-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y font-medium text-text-muted ${
                 col.align === 'end' ? 'text-right' : 'text-left'
               }`}
             >
@@ -57,7 +57,7 @@ export function DataTable<Row>({ columns, rows, rowKey, caption }: DataTableProp
             {columns.map((col) => (
               <td
                 key={col.key}
-                className={`border-b border-border px-x-2xs py-x-3xs ${
+                className={`border-b border-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y ${
                   col.align === 'end' ? 'text-right' : 'text-left'
                 }`}
               >

--- a/packages/nene2-ui/src/data/DetailList.tsx
+++ b/packages/nene2-ui/src/data/DetailList.tsx
@@ -16,11 +16,11 @@ export interface DetailListProps {
  */
 export function DetailList({ rows }: DetailListProps) {
   return (
-    <dl className="flex flex-col gap-x-stack-sm">
+    <dl className="flex flex-col gap-x-slot-detail-gap">
       {rows.map((row) => (
         <div
           key={row.label}
-          className="flex flex-col gap-x-inline-sm border-b border-border py-x-stack-sm"
+          className="flex flex-col gap-x-slot-detail-row-gap border-b border-border py-x-slot-detail-row-pad-y"
         >
           <dt className="font-sans font-medium text-text-muted">{row.label}</dt>
           <dd className="font-sans text-text-primary">{row.value}</dd>

--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -24,7 +24,7 @@ export function Badge({ tone = 'neutral', children }: BadgeProps) {
   return (
     <span
       className={cx(
-        'inline-flex items-center rounded-x-md border px-x-2xs py-x-3xs font-sans',
+        'inline-flex items-center rounded-x-slot-badge border px-x-slot-badge-pad-x py-x-slot-badge-pad-y font-sans',
         TONE_CLASS[tone],
       )}
     >

--- a/packages/nene2-ui/src/feedback/InlineAlert.tsx
+++ b/packages/nene2-ui/src/feedback/InlineAlert.tsx
@@ -24,7 +24,7 @@ export function InlineAlert({ tone = 'info', children }: InlineAlertProps) {
   return (
     <div
       role={tone === 'danger' ? 'alert' : 'status'}
-      className={cx('rounded-x-md border p-x-2xs font-sans', TONE_CLASS[tone])}
+      className={cx('rounded-x-slot-alert border p-x-slot-alert-pad font-sans', TONE_CLASS[tone])}
     >
       {children}
     </div>

--- a/packages/nene2-ui/src/feedback/ToastProvider.tsx
+++ b/packages/nene2-ui/src/feedback/ToastProvider.tsx
@@ -92,7 +92,7 @@ export function ToastProvider({
       aria-live={live}
       aria-label={regionLabel}
       role="region"
-      className="flex flex-col gap-x-2xs"
+      className="flex flex-col gap-x-slot-toast-gap"
     >
       {toasts
         .filter((toast) => toast.tone === tone)
@@ -100,7 +100,7 @@ export function ToastProvider({
           <div
             key={toast.id}
             className={cx(
-              'flex items-start gap-x-2xs rounded-x-md border p-x-2xs font-sans shadow-sm',
+              'flex items-start gap-x-slot-toast-gap rounded-x-slot-toast border p-x-slot-toast-pad font-sans shadow-sm',
               TONE_CLASS[toast.tone],
             )}
           >
@@ -109,7 +109,7 @@ export function ToastProvider({
               type="button"
               aria-label={dismissLabel}
               onClick={() => dismiss(toast.id)}
-              className={cx('rounded-x-md px-x-3xs', CONTROL_CLASS)}
+              className={cx('rounded-x-slot-toast px-x-slot-toast-dismiss-pad-x', CONTROL_CLASS)}
             >
               {dismissLabel}
             </button>

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -63,8 +63,11 @@ export function FormField({
 
   return (
     <FieldContext.Provider value={value}>
-      <div className="flex flex-col gap-x-inline-sm">
-        <label htmlFor={id} className="font-sans font-x-label text-x-label-size text-x-label">
+      <div className="flex flex-col gap-x-slot-field-gap">
+        <label
+          htmlFor={id}
+          className="font-sans font-x-slot-field-label text-x-slot-field-label-size text-x-slot-field-label"
+        >
           {label}
           {required && requiredMarker !== undefined && requiredMarker !== null ? (
             <span className="text-danger">{requiredMarker}</span>

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -64,7 +64,7 @@ export function FormField({
   return (
     <FieldContext.Provider value={value}>
       <div className="flex flex-col gap-x-inline-sm">
-        <label htmlFor={id} className="font-sans font-medium text-text-primary">
+        <label htmlFor={id} className="font-sans font-x-label text-x-label-size text-x-label">
           {label}
           {required && requiredMarker !== undefined && requiredMarker !== null ? (
             <span className="text-danger">{requiredMarker}</span>

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -211,7 +211,11 @@ describe('label typography', () => {
     );
     const cls = (container.querySelector('label')?.getAttribute('class') ?? '').split(/\s+/);
     expect(cls).toEqual(
-      expect.arrayContaining(['text-x-label', 'text-x-label-size', 'font-x-label']),
+      expect.arrayContaining([
+        'text-x-slot-field-label',
+        'text-x-slot-field-label-size',
+        'font-x-slot-field-label',
+      ]),
     );
   });
 
@@ -247,6 +251,6 @@ describe('control font size', () => {
     // ページごと拡大する。旧実装は 16px を持っていた。トークンの値は max(1rem, 16px)。
     const { container } = render(control);
     const el = container.querySelector('input, select, textarea');
-    expect((el?.getAttribute('class') ?? '').split(/\s+/)).toContain('text-x-control-size');
+    expect((el?.getAttribute('class') ?? '').split(/\s+/)).toContain('text-x-slot-control-size');
   });
 });

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -198,3 +198,55 @@ describe('required', () => {
     expect(container.querySelector('input')?.getAttribute('aria-required')).toBeNull();
   });
 });
+
+describe('label typography', () => {
+  it('reads its colour, size and weight from the theme, not from the component', () => {
+    // 🔴 0.2.0 は font-medium と色の選択を部品に直書きしていた。艦から変える口が無く、
+    // vault の載せ替えで **意匠再生成（#361）で決まったラベルの値が黙って上書きされた**
+    // （施主が実機で発見・2026-08-23）。
+    const { container } = render(
+      <FormField id="email" label="Email">
+        <Input />
+      </FormField>,
+    );
+    const cls = (container.querySelector('label')?.getAttribute('class') ?? '').split(/\s+/);
+    expect(cls).toEqual(
+      expect.arrayContaining(['text-x-label', 'text-x-label-size', 'font-x-label']),
+    );
+  });
+
+  it('hard-codes no typography of its own', () => {
+    const { container } = render(
+      <FormField id="email" label="Email">
+        <Input />
+      </FormField>,
+    );
+    for (const cls of (container.querySelector('label')?.getAttribute('class') ?? '').split(
+      /\s+/,
+    )) {
+      // font-sans は family（テーマ側の1本）なので許す。size / weight / 色は許さない。
+      expect(cls).not.toMatch(/^text-(xs|sm|base|lg|xl|\dxl)$/);
+      expect(cls).not.toMatch(/^font-(thin|light|normal|medium|semibold|bold)$/);
+      expect(cls).not.toMatch(/^text-text-(primary|muted)$/);
+    }
+  });
+});
+
+describe('control font size', () => {
+  it.each([
+    ['Input', <Input key="i" />],
+    ['Textarea', <Textarea key="t" />],
+    [
+      'Select',
+      <Select key="s">
+        <option>a</option>
+      </Select>,
+    ],
+  ])('%s carries a size of its own, so iOS does not zoom on focus', (_n, control) => {
+    // 🔴 vault の body は 14px。フォーカスした入力が 16px 未満だと iOS Safari は
+    // ページごと拡大する。旧実装は 16px を持っていた。トークンの値は max(1rem, 16px)。
+    const { container } = render(control);
+    const el = container.querySelector('input, select, textarea');
+    expect((el?.getAttribute('class') ?? '').split(/\s+/)).toContain('text-x-control-size');
+  });
+});

--- a/packages/nene2-ui/src/layout/Card.tsx
+++ b/packages/nene2-ui/src/layout/Card.tsx
@@ -20,7 +20,7 @@ export function Card({ pad = 'sm', gap, raised = false, children, className, ...
   return (
     <div
       className={cx(
-        'flex flex-col bg-surface-raised border border-border rounded-x-md',
+        'flex flex-col bg-surface-raised border border-border rounded-x-slot-card',
         raised && 'shadow-sm',
         resolve(pad, PAD),
         resolve(gap, GAP),

--- a/packages/nene2-ui/src/layout/PageHeader.tsx
+++ b/packages/nene2-ui/src/layout/PageHeader.tsx
@@ -8,7 +8,7 @@ export interface PageHeaderProps {
 
 export function PageHeader({ title, actions }: PageHeaderProps) {
   return (
-    <header className="flex items-center justify-between py-x-stack-md">
+    <header className="flex items-center justify-between py-x-slot-page-header-pad-y">
       <h1 className="font-sans font-medium text-text-primary">{title}</h1>
       {actions}
     </header>

--- a/packages/nene2-ui/src/layout/layout.test.tsx
+++ b/packages/nene2-ui/src/layout/layout.test.tsx
@@ -129,7 +129,12 @@ describe('Card', () => {
   it('carries surface, border and radius from the theme — none of them props', () => {
     const { container } = render(<Card>x</Card>);
     expect(classesOf(container.firstElementChild)).toEqual(
-      expect.arrayContaining(['bg-surface-raised', 'border', 'border-border', 'rounded-x-md']),
+      expect.arrayContaining([
+        'bg-surface-raised',
+        'border',
+        'border-border',
+        'rounded-x-slot-card',
+      ]),
     );
   });
 

--- a/packages/nene2-ui/src/overlay/Modal.tsx
+++ b/packages/nene2-ui/src/overlay/Modal.tsx
@@ -56,8 +56,8 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
       onClose={onClose}
       onCancel={onClose}
       className={cx(
-        'bg-surface-raised text-text-primary border border-border rounded-x-md',
-        'p-x-sm font-sans backdrop:bg-text-primary/50',
+        'bg-surface-raised text-text-primary border border-border rounded-x-slot-modal',
+        'p-x-slot-modal-pad font-sans backdrop:bg-text-primary/50',
       )}
     >
       {children}

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -13,7 +13,7 @@ const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
   danger: 'bg-danger text-on-accent',
 };
 
-const BASE_CLASS = `rounded-x-md px-x-inline-md py-x-stack-sm font-sans font-medium ${CONTROL_CLASS}`;
+const BASE_CLASS = `rounded-x-slot-button px-x-slot-button-pad-x py-x-slot-button-pad-y font-sans font-medium ${CONTROL_CLASS}`;
 
 export function Button({
   variant = 'primary',

--- a/packages/nene2-ui/src/primitives/Checkbox.tsx
+++ b/packages/nene2-ui/src/primitives/Checkbox.tsx
@@ -8,7 +8,7 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
   label: ReactNode;
 }
 
-const BOX_CLASS = `rounded-x-md border border-border accent-accent ${CONTROL_CLASS}`;
+const BOX_CLASS = `rounded-x-slot-control border border-border accent-accent ${CONTROL_CLASS}`;
 
 /**
  * A checkbox and its label, as one part.
@@ -33,7 +33,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
   const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return (
-    <label className="inline-flex items-center gap-x-2xs font-sans text-text-primary">
+    <label className="inline-flex items-center gap-x-slot-choice-gap font-sans text-text-primary">
       <input ref={ref} type="checkbox" className={cx(BOX_CLASS, className)} {...wiring} {...rest} />
       {label}
     </label>

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-x-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
 
 /**
  * Text input primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-x-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
 
 /**
  * Text input primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Radio.tsx
+++ b/packages/nene2-ui/src/primitives/Radio.tsx
@@ -27,7 +27,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   ref,
 ) {
   return (
-    <label className="inline-flex items-center gap-x-2xs font-sans text-text-primary">
+    <label className="inline-flex items-center gap-x-slot-choice-gap font-sans text-text-primary">
       <input ref={ref} type="radio" name={name} className={cx(DOT_CLASS, className)} {...rest} />
       {label}
     </label>

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -7,7 +7,7 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children: ReactNode;
 }
 
-const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-x-control-size text-text-primary ${CONTROL_CLASS}`;
 
 /**
  * Select primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -7,7 +7,7 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children: ReactNode;
 }
 
-const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-x-control-size text-text-primary ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size text-text-primary ${CONTROL_CLASS}`;
 
 /**
  * Select primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Switch.tsx
+++ b/packages/nene2-ui/src/primitives/Switch.tsx
@@ -34,7 +34,7 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch
       aria-label={label}
       onClick={() => onCheckedChange(!checked)}
       className={cx(
-        'inline-flex items-center rounded-x-md border border-border px-x-2xs py-x-3xs font-sans',
+        'inline-flex items-center rounded-x-slot-switch border border-border px-x-slot-switch-pad-x py-x-slot-switch-pad-y font-sans',
         checked ? 'bg-accent text-on-accent' : 'bg-surface text-text-muted',
         CONTROL_CLASS,
         className,

--- a/packages/nene2-ui/src/primitives/Textarea.tsx
+++ b/packages/nene2-ui/src/primitives/Textarea.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-x-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
 
 /**
  * Multi-line text input. Deliberately identical to `Input` apart from the element, so the

--- a/packages/nene2-ui/src/primitives/Textarea.tsx
+++ b/packages/nene2-ui/src/primitives/Textarea.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-md border border-border bg-surface-raised px-x-inline-sm py-x-stack-sm font-sans text-x-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
 
 /**
  * Multi-line text input. Deliberately identical to `Input` apart from the element, so the

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -128,15 +128,24 @@ describe('the two token layers', () => {
     return out;
   }
 
-  it('every slot default points at the scale, never at a literal', () => {
+  it('every slot default is built only from scale references', () => {
     // 🔴 A slot holding `0.6875rem` would be a product-invented value living in the kit —
     // exactly the drift the scale exists to stop.
+    //
+    // Compositions are fine and expected: a four-sided padding slot is
+    // `var(--spacing-x-xl) var(--spacing-x-md) var(--spacing-x-lg) var(--spacing-x-md)`.
+    // What is not fine is any literal appearing among them. Checking it this way — rather
+    // than matching one whole `var(...)` — is only possible because the kit deliberately has
+    // no shorthand syntax: plain CSS `var()` composition is directly greppable, while a
+    // shorthand would need an expander before it could be inspected at all.
     const slots = [...theme.matchAll(/--(?:spacing|radius)-x-slot-[a-z0-9-]+:\s*([^;]+);/g)];
     expect(slots.length).toBeGreaterThan(20);
-    for (const [, value] of slots) {
-      expect(value!.trim(), 'slot defaults must reference the scale').toMatch(
-        /^var\(--(spacing|radius)-x-[a-z0-9-]+\)$/,
-      );
+    for (const [, raw] of slots) {
+      const value = raw!.trim();
+      const refs = [...value.matchAll(/var\(--(?:spacing|radius)-x-[a-z0-9-]+\)/g)];
+      expect(refs.length, `slot must reference the scale: ${value}`).toBeGreaterThan(0);
+      const remainder = value.replace(/var\(--(?:spacing|radius)-x-[a-z0-9-]+\)/g, '').trim();
+      expect(remainder, `slot contains a literal outside the scale: ${value}`).toBe('');
     }
   });
 

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readdirSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -80,10 +81,10 @@ describe('typography tokens', () => {
   const theme = readFileSync(path.join(root, 'themes/default.css'), 'utf8');
 
   it.each([
-    '--color-x-label',
-    '--text-x-label-size',
-    '--font-weight-x-label',
-    '--text-x-control-size',
+    '--color-x-slot-field-label',
+    '--text-x-slot-field-label-size',
+    '--font-weight-x-slot-field-label',
+    '--text-x-slot-control-size',
   ])('defines %s', (token) => {
     expect(theme).toContain(`${token}:`);
   });
@@ -103,7 +104,55 @@ describe('the override boundary', () => {
     // 🔴 機構上は艦が全部上書きできる（読み込み順で勝つ）。書かないと、±2px で困った艦が
     // **善意で spacing を上書きし、9段という語彙だけ残して規律が消える**。
     const section = readme.slice(readme.indexOf('## 🔴 What a product may redefine'));
+    // 片方だけだと、次の艦が反対側で迷う。両方書く。
+    expect(section, 'must say slots are overridable').toMatch(/Slots — 🟢 redefine these/);
+    expect(section, 'must say the scale is not').toMatch(/The scale — 🔒 do not redefine/);
+    expect(section).toContain('--spacing-x-slot-card-pad');
     expect(section).toContain('--spacing-x-3xs');
-    expect(section).toMatch(/Do not redefine/);
+  });
+});
+
+describe('the two token layers', () => {
+  const theme = readFileSync(path.join(root, 'themes/default.css'), 'utf8');
+
+  function componentSources(): string[] {
+    const out: string[] = [];
+    const walk = (d: string) => {
+      for (const e of readdirSync(d, { withFileTypes: true })) {
+        const f = path.join(d, e.name);
+        if (e.isDirectory()) walk(f);
+        else if (/\.tsx?$/.test(f) && !/\.test\./.test(f)) out.push(f);
+      }
+    };
+    walk(path.join(root, 'src'));
+    return out;
+  }
+
+  it('every slot default points at the scale, never at a literal', () => {
+    // 🔴 A slot holding `0.6875rem` would be a product-invented value living in the kit —
+    // exactly the drift the scale exists to stop.
+    const slots = [...theme.matchAll(/--(?:spacing|radius)-x-slot-[a-z0-9-]+:\s*([^;]+);/g)];
+    expect(slots.length).toBeGreaterThan(20);
+    for (const [, value] of slots) {
+      expect(value!.trim(), 'slot defaults must reference the scale').toMatch(
+        /^var\(--(spacing|radius)-x-[a-z0-9-]+\)$/,
+      );
+    }
+  });
+
+  it('no component reaches past the slots into the scale', () => {
+    // 部品がスケールを直接使うと、艦はその部品だけ割り当てを変えられなくなる。
+    // 例外は lib/spacing.ts（Stack/Box の gap/pad prop そのもの＝呼び出し側が選ぶ層）。
+    const offenders: string[] = [];
+    for (const f of componentSources()) {
+      if (f.endsWith('lib/spacing.ts') || f.endsWith('lib/source-probe.ts')) continue;
+      const src = readFileSync(f, 'utf8');
+      for (const m of src.matchAll(
+        /(?<![\w-])(?:p|px|py|pt|pb|pl|pr|gap|m|mt|mb|rounded)-x-(?!slot-)[a-z0-9-]+/g,
+      )) {
+        offenders.push(`${path.relative(root, f)}: ${m[0]}`);
+      }
+    }
+    expect(offenders, `components must use slots, not the scale directly`).toEqual([]);
   });
 });

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -75,3 +75,35 @@ describe('the @source instruction', () => {
     expect(index).toContain('SOURCE_PROBE_CLASS');
   });
 });
+
+describe('typography tokens', () => {
+  const theme = readFileSync(path.join(root, 'themes/default.css'), 'utf8');
+
+  it.each([
+    '--color-x-label',
+    '--text-x-label-size',
+    '--font-weight-x-label',
+    '--text-x-control-size',
+  ])('defines %s', (token) => {
+    expect(theme).toContain(`${token}:`);
+  });
+
+  it('never gives a colour and a text size the same suffix', () => {
+    // 🔴 Tailwind resolves `text-<name>` against --color-* first, so a matching pair makes
+    // the size unreachable while everything still compiles (verified on tailwindcss 4.3.2).
+    const colours = new Set([...theme.matchAll(/--color-(x-[a-z0-9-]+):/g)].map((m) => m[1]));
+    const sizes = [...theme.matchAll(/--text-(x-[a-z0-9-]+):/g)].map((m) => m[1]);
+    const clash = sizes.filter((s) => colours.has(s));
+    expect(clash, `colour and text-size share a suffix: ${clash.join(', ')}`).toEqual([]);
+  });
+});
+
+describe('the override boundary', () => {
+  it('says which tokens a product may redefine, and which it may not', () => {
+    // 🔴 機構上は艦が全部上書きできる（読み込み順で勝つ）。書かないと、±2px で困った艦が
+    // **善意で spacing を上書きし、9段という語彙だけ残して規律が消える**。
+    const section = readme.slice(readme.indexOf('## 🔴 What a product may redefine'));
+    expect(section).toContain('--spacing-x-3xs');
+    expect(section).toMatch(/Do not redefine/);
+  });
+});

--- a/packages/nene2-ui/src/states/EmptyState.tsx
+++ b/packages/nene2-ui/src/states/EmptyState.tsx
@@ -5,7 +5,7 @@ export interface EmptyStateProps {
 
 export function EmptyState({ message }: EmptyStateProps) {
   return (
-    <div className="py-x-stack-lg font-sans text-text-muted" role="status">
+    <div className="py-x-slot-state-pad-y font-sans text-text-muted" role="status">
       {message}
     </div>
   );

--- a/packages/nene2-ui/src/states/ErrorState.tsx
+++ b/packages/nene2-ui/src/states/ErrorState.tsx
@@ -10,9 +10,9 @@ export interface ErrorStateProps {
 
 export function ErrorState({ message, retryLabel, onRetry }: ErrorStateProps) {
   return (
-    <div className="py-x-stack-lg" role="alert">
+    <div className="py-x-slot-state-pad-y" role="alert">
       <p className="font-sans text-danger">{message}</p>
-      <div className="py-x-stack-sm">
+      <div className="py-x-slot-state-action-pad-y">
         <Button variant="secondary" onClick={onRetry}>
           {retryLabel}
         </Button>

--- a/packages/nene2-ui/src/states/LoadingState.tsx
+++ b/packages/nene2-ui/src/states/LoadingState.tsx
@@ -20,7 +20,7 @@ export interface LoadingStateProps {
  */
 export function LoadingState({ label }: LoadingStateProps) {
   return (
-    <div className="py-x-stack-lg" aria-busy="true">
+    <div className="py-x-slot-state-pad-y" aria-busy="true">
       <Spinner label={label} />
     </div>
   );

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -21,6 +21,27 @@
 
   --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
 
+  /* Typography. Until 0.3.0 the kit had none of these and the components carried
+   * `font-medium` and a colour choice inline — which is a design value living outside this
+   * file, the one thing the rule at the top forbids. It showed up the first time a product
+   * migrated: nene-vault's field labels went from small-and-muted to body-size-and-dark,
+   * silently, because the kit had no opening to say otherwise (found by hide on a real
+   * screen, 2026-08-23). The old value came from `.field-label`, regenerated during that
+   * product's design pass — so the migration overwrote a decision, not an accident.
+   *
+   * 🔴 Colour and size must not share a suffix. Tailwind resolves `text-<name>` against
+   * `--color-*` first, so defining `--color-x-label` and `--text-x-label` together makes the
+   * size unreachable while everything still compiles (verified against tailwindcss 4.3.2).
+   * Hence `-size`. Same family as the `gap-x-2` collision noted below. */
+  --color-x-label: var(--color-text-muted);
+  --text-x-label-size: 0.75rem;
+  --font-weight-x-label: 500;
+
+  /* Form controls. `max(1rem, 16px)` rather than `1rem`: iOS Safari zooms the page when a
+   * focused input is under 16px, and a product whose body text is 14px would inherit that.
+   * Keeping a control readable is the control's job, not the product's. */
+  --text-x-control-size: max(1rem, 16px);
+
   /* Sentinel for the consumer's build (#316). Zero-width, so applying it does nothing.
    * Its only job is to exist: `p-x-source-probe` appears nowhere except this kit's `dist`,
    * so a build that generates it has the kit in its `@source`, and a build that does not

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -33,14 +33,60 @@
    * `--color-*` first, so defining `--color-x-label` and `--text-x-label` together makes the
    * size unreachable while everything still compiles (verified against tailwindcss 4.3.2).
    * Hence `-size`. Same family as the `gap-x-2` collision noted below. */
-  --color-x-label: var(--color-text-muted);
-  --text-x-label-size: 0.75rem;
-  --font-weight-x-label: 500;
 
   /* Form controls. `max(1rem, 16px)` rather than `1rem`: iOS Safari zooms the page when a
    * focused input is under 16px, and a product whose body text is 14px would inherit that.
    * Keeping a control readable is the control's job, not the product's. */
-  --text-x-control-size: max(1rem, 16px);
+
+  /* ─────────────────────────────────────────────────────────────────────────
+   * ② SLOTS — a product may redefine these.
+   *
+   * Every design value a component uses comes from here, and every slot's default points
+   * back at the scale above. That split is the whole idea: a product decides **which step
+   * a part uses**, and cannot invent a step. Change `--spacing-x-slot-card-pad` to
+   * `var(--spacing-x-lg)` and cards get roomier everywhere; you still cannot write `2.25`.
+   *
+   * Named per component rather than per role (hide's ruling, 2026-08-23): sharing one slot
+   * between `Modal` and `Card` can be arranged later by pointing both at the same value,
+   * but splitting a shared slot afterwards changes every product at once.
+   * ───────────────────────────────────────────────────────────────────────── */
+  --spacing-x-slot-button-pad-x: var(--spacing-x-sm);
+  --spacing-x-slot-button-pad-y: var(--spacing-x-xs);
+  --spacing-x-slot-control-pad-x: var(--spacing-x-2xs);
+  --spacing-x-slot-control-pad-y: var(--spacing-x-xs);
+  --spacing-x-slot-field-gap: var(--spacing-x-2xs);
+  --spacing-x-slot-choice-gap: var(--spacing-x-2xs);
+  --spacing-x-slot-badge-pad-x: var(--spacing-x-2xs);
+  --spacing-x-slot-badge-pad-y: var(--spacing-x-3xs);
+  --spacing-x-slot-switch-pad-x: var(--spacing-x-2xs);
+  --spacing-x-slot-switch-pad-y: var(--spacing-x-3xs);
+  --spacing-x-slot-alert-pad: var(--spacing-x-2xs);
+  --spacing-x-slot-toast-pad: var(--spacing-x-2xs);
+  --spacing-x-slot-toast-gap: var(--spacing-x-2xs);
+  --spacing-x-slot-toast-dismiss-pad-x: var(--spacing-x-3xs);
+  --spacing-x-slot-modal-pad: var(--spacing-x-sm);
+  --spacing-x-slot-table-cell-pad-x: var(--spacing-x-2xs);
+  --spacing-x-slot-table-cell-pad-y: var(--spacing-x-3xs);
+  --spacing-x-slot-detail-gap: var(--spacing-x-xs);
+  --spacing-x-slot-detail-row-gap: var(--spacing-x-2xs);
+  --spacing-x-slot-detail-row-pad-y: var(--spacing-x-xs);
+  --spacing-x-slot-state-pad-y: var(--spacing-x-xl);
+  --spacing-x-slot-state-action-pad-y: var(--spacing-x-xs);
+  --spacing-x-slot-page-header-pad-y: var(--spacing-x-md);
+
+  --radius-x-slot-button: var(--radius-x-md);
+  --radius-x-slot-control: var(--radius-x-md);
+  --radius-x-slot-badge: var(--radius-x-md);
+  --radius-x-slot-switch: var(--radius-x-md);
+  --radius-x-slot-alert: var(--radius-x-md);
+  --radius-x-slot-toast: var(--radius-x-md);
+  --radius-x-slot-modal: var(--radius-x-md);
+  --radius-x-slot-card: var(--radius-x-md);
+
+  --color-x-slot-field-label: var(--color-text-muted);
+  --text-x-slot-field-label-size: 0.75rem;
+  --font-weight-x-slot-field-label: 500;
+  --text-x-slot-control-size: max(1rem, 16px);
 
   /* Sentinel for the consumer's build (#316). Zero-width, so applying it does nothing.
    * Its only job is to exist: `p-x-source-probe` appears nowhere except this kit's `dist`,


### PR DESCRIPTION
Closes #328

**hub 経由で施主の意図が差し替えられたので、設計を2層トークンにし直しました。**

> 同じログインフォームでも各プロダクトでマージン、パディングのデザインは変えたい。`login-form-margin` と共通ではクラス定義しておいて、各艦では利用側で定義できるようにできない？ **xl, l, m, s, xs 等は fleet 固定でもいいので。**

🔑 **2軸ありました。** スケールの値は fleet 固定、**用途への割り当ては艦が決める**。

## 入れたもの

| 層 | | 艦 |
|---|---|---|
| ① **スケール** | `--spacing-x-3xs` … `--spacing-x-2xl`（9段）・radius・色 | 🔒 **上書きしない** |
| ② **スロット** | `--spacing-x-slot-<部品>-<役割>` ほか **35本**。既定は全部スケールを指す | 🟢 **上書きしてよい** |

**部品はスロットしか参照しません**（19ファイルを書き換え）。⇒ 艦は**割り当てを変えられるが、段を発明できない**：

```css
--spacing-x-slot-card-pad: var(--spacing-x-lg);   /* 🟢 カードを広く */
--spacing-x-slot-card-pad: 1.375rem;              /* 🔴 落ちる */
```

スロットは**部品ごと**に切っています（施主裁定 — **共有は後から寄せられるが、分けるのは後からだと全艦に影響する**）。

## 🔴 hub の案そのままでは動きませんでした

`--x-slot-card-pad`（**Tailwind の名前空間の外**）は**ユーティリティを1つも生成しません**〔実測〕。⇒ **名前空間の中に置きました**（`--spacing-x-slot-…` / `--color-x-slot-…` / `--text-x-slot-…`）。**部品が使う35種すべてが CSS を生成する**ことを実コンパイルで確認しています。

## 🔴 色とサイズに同じ suffix を使えない

`--color-x-slot-field-label` と `--text-x-slot-field-label` を両方定義すると、`text-x-slot-field-label` は**色として解決され font-size が到達不能**になります（**コンパイルは通る**）。⇒ `-size` を付けてテストで固定。`gap-x-2` の衝突と同族です。

## ラベルの既定値も変えました（hub の指示から1点外しています）

0.2.0 は本文サイズ・`text-primary`（部品への直書き）→ 0.3.0 は **0.75rem・`text-muted`・500**。

**0.2.0 の値は設計判断ではなく初期実装の残り**で、0.3.0 の値は **vault の意匠再生成 #361 で確定した値**です。⇒ **設計を経た値を既定に置きました。** 異論があれば2行で戻せます。

## iOS ズーム

`--text-x-slot-control-size: max(1rem, 16px)`。vault の body は 14px で、**iOS Safari は 16px 未満の入力にフォーカスするとページごと拡大**します。

## README には**両方**書きました

🟢 スロットは上書きしてよい／🔒 スケールは上書きしない。**片方だけだと次の艦が反対側で迷う**ので。どちらも**テストで強制**しています（スロットの既定が直値なら赤／部品がスケールを直接参照したら赤）。

## 検証

- `npm run check` 全項目 PASS（45 files / **664 tests**）／版 **0.3.0**・lock 追随
- Tailwind 4.3.2 で**スロットクラス35種すべてが CSS を生成**（欠落 0）
- **陽性対照5種**（直書きへ戻す ／ 同一 suffix ／ font-size を外す ／ **スロットに直値** ／ **部品がスケールを直接参照**）

🔴 **5つ目は最初発火しませんでした。** 検査の正規表現が spacing 系しか見ておらず `rounded-` を落としていた ＝ **検査自体の射程が名乗りより狭い**。正規表現を直してから取り直しています。
