### PR TITLE
chore(fleet-baseline): nene2-ui の floor を ^0.3.0 へ — ^0.2.0 は 0.3.0 を含まない（#330）

### DIFF
--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -6,6 +6,6 @@
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.1.1",
     "@hideyukimori/nene2-i18n": "^0.3.0",
-    "@hideyukimori/nene2-ui": "^0.2.0"
+    "@hideyukimori/nene2-ui": "^0.3.0"
   }
 }


### PR DESCRIPTION
Closes #330

🟢 **ベースは `main`。独立に入ります。**

## 実測

| | |
|---|---|
| 現在の floor | `"@hideyukimori/nene2-ui": "^0.2.0"` |
| npm の latest | 🟢 **0.3.0**〔`shasum 0c473fd2…`・**provenance 付き**〕 |
| `semver.satisfies('0.3.0', '^0.2.0')` | 🔴 **false** |
| `semver.satisfies('0.3.0', '^0.3.0')` | 🟢 true |

🔴 **`^0.2.0` は `>=0.2.0 <0.3.0`。** pre-1.0 では **minor が破壊的変更を許す**ため caret は minor を跨ぎません。⇒ **現 floor は 0.3.0 を含みません。**

## W1 の艦が 0.3.0 を必要とする理由

- **ラベルの意匠がスロット経由になった** — 0.2.0 は部品への直書きで、**艦から変えられませんでした**（施主が実機で見つけた件）
- `--text-x-slot-control-size: max(1rem, 16px)` — **iOS のフォーカス時ズーム**
- **スロット35本** — 艦が割り当てを変えられる層

## 🔴 既存3本の floor は触りません

| | floor | npm |
|---|---|---|
| `nene2-client` | `^1.1.0` | 1.4.0 |
| `nene2-tokens` | `^1.1.0` | 1.2.0 |
| `nene2-standards` | `^2.1.1` | 2.2.0 |

**#271 で据え置きと裁定済み**（floor の追随ではなく**実採用版の是正**が本筋）。

⚠️ **`nene2-ui` だけ性質が違います**: 他3本は「**floor は低いが、艦は既に上を使っている**」状態。`nene2-ui` は「**W1 がこれから入れる版が floor に含まれていない**」状態です。⇒ #271 の据え置きには当たりません。

## 検証

スキーマ適合を全5件で確認。`npm run check` は CI で。