### PR TITLE
feat(ui) 0.4.0: hover / active がキットに1つも無かった（同じ穴の3つ目）＋ 7部品が className を受けなかった（#332）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -150,6 +150,26 @@ publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run �
 nene-payout の `shared/ui` から10部品を昇格（新規設計ゼロ）＋ `cx()` 是正。
 Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList。
 
+### `@hideyukimori/nene2-ui` 0.4.0（**minor — hover/active ＋ 構造の選択肢**・#332）
+
+🔴 **既存部品の見た目が変わる**（0.3.0 まで**ポインタに何も反応しなかった**）。
+
+- **`hover` / `active`**（`--brightness-x-slot-hover` 95% / `--brightness-x-slot-press` 90%）。
+  🔴 **v0.1 の disabled / focus と同じ穴の3つ目**。艦は7艦が持っており、**うち4艦は CSS 側**に
+  書いているので Tailwind クラスだけ数えると 0 に見えていた。
+  **variant ごとの hover 色は持たない** ── 塗りが3種あるので色を持つとトークンが3倍になる。
+  `brightness` なら1本で全部に効き、**白い secondary でも暗くなる**（艦の `brightness-105` は
+  白では効かない）。`disabled:` では打ち消す（**押せないものが押した反応を返さない**）
+- **`className` を7部品に追加**（`Text` / `Spinner` / `PageHeader` / `EmptyState` /
+  `ErrorState` / `LoadingState` / `DetailList`）。🔴 **README の設計原則2「className は合成する」に
+  反していた**（受け取りすらしなかった）。艦の `EmptyState` は6艦とも受ける
+- **構造の選択肢**: `EmptyState` の `align`（**既定 center** ── 実測で6艦中5艦が中央揃え）／
+  `Button` の `size`（`md` / `sm`）と `ghost` variant（vault が持つ）／`InlineAlert` の `warn`
+
+🔑 **原則3 との線引き**: 禁じているのは**意匠値**を props で受けること。
+**その prop に「新しい値」を書けるなら意匠（禁止）、有限の選択肢から選ぶだけなら構造（可）。**
+`align="start"` はテーマでは供給できず、値でもない。
+
 ### `@hideyukimori/nene2-ui` 0.3.0（**minor — 意匠値を2層トークンへ**・#328）
 
 🔴 **既存部品の見た目が変わる**（ラベルの既定値を意図的に変えている・下記）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/data/DetailList.tsx
+++ b/packages/nene2-ui/src/data/DetailList.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
 
 export interface DetailRow {
   /** Localized row label. */
@@ -7,6 +8,8 @@ export interface DetailRow {
 }
 
 export interface DetailListProps {
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   rows: DetailRow[];
 }
 
@@ -14,9 +17,9 @@ export interface DetailListProps {
  * Read-only key/value display for detail screens. Uses a description list so the
  * label/value relationship is conveyed to assistive technology.
  */
-export function DetailList({ rows }: DetailListProps) {
+export function DetailList({ rows, className }: DetailListProps) {
   return (
-    <dl className="flex flex-col gap-x-slot-detail-gap">
+    <dl className={cx('flex flex-col gap-x-slot-detail-gap', className)}>
       {rows.map((row) => (
         <div
           key={row.label}

--- a/packages/nene2-ui/src/feedback/InlineAlert.tsx
+++ b/packages/nene2-ui/src/feedback/InlineAlert.tsx
@@ -3,12 +3,16 @@ import { cx } from '../lib/cx.js';
 
 export interface InlineAlertProps {
   /** What the message means. `danger` is announced assertively; `info` politely. */
-  tone?: 'info' | 'danger';
+  tone?: 'info' | 'warn' | 'danger';
   children: ReactNode;
 }
 
 const TONE_CLASS: Record<NonNullable<InlineAlertProps['tone']>, string> = {
   info: 'bg-surface text-text-primary border-border',
+  // `warn` reuses the danger colour deliberately: the kit's palette has one alert hue, and
+  // inventing a second here would be a design value living outside themes/default.css. What
+  // differs is the urgency it is announced with, which is the part that matters.
+  warn: 'bg-surface text-danger border-danger',
   danger: 'bg-surface text-danger border-danger',
 };
 

--- a/packages/nene2-ui/src/feedback/ToastProvider.tsx
+++ b/packages/nene2-ui/src/feedback/ToastProvider.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CLICKABLE_CLASS } from '../lib/states.js';
 import { ToastContext, type ToastApi, type ToastOptions, type ToastTone } from './toast-context.js';
 
 interface Toast {
@@ -109,7 +109,7 @@ export function ToastProvider({
               type="button"
               aria-label={dismissLabel}
               onClick={() => dismiss(toast.id)}
-              className={cx('rounded-x-slot-toast px-x-slot-toast-dismiss-pad-x', CONTROL_CLASS)}
+              className={cx('rounded-x-slot-toast px-x-slot-toast-dismiss-pad-x', CLICKABLE_CLASS)}
             >
               {dismissLabel}
             </button>

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -57,6 +57,12 @@ export { tokens } from './theme/tokens.js';
 export { cx } from './lib/cx.js';
 // Controls the kit does not ship yet (Textarea has 7 independent implementations in the
 // fleet) can at least carry the same focus and disabled behaviour instead of inventing it.
-export { CONTROL_CLASS, DISABLED_CLASS, FOCUS_CLASS } from './lib/states.js';
+export {
+  CLICKABLE_CLASS,
+  CONTROL_CLASS,
+  DISABLED_CLASS,
+  FOCUS_CLASS,
+  HOVER_CLASS,
+} from './lib/states.js';
 // Lets a consumer's build prove the kit is in its Tailwind `@source` (#316).
 export { SOURCE_PROBE_CLASS } from './lib/source-probe.js';

--- a/packages/nene2-ui/src/layout/PageHeader.tsx
+++ b/packages/nene2-ui/src/layout/PageHeader.tsx
@@ -1,14 +1,19 @@
 import type { ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
 
 export interface PageHeaderProps {
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   /** Localized page title. */
   title: string;
   actions?: ReactNode;
 }
 
-export function PageHeader({ title, actions }: PageHeaderProps) {
+export function PageHeader({ title, actions, className }: PageHeaderProps) {
   return (
-    <header className="flex items-center justify-between py-x-slot-page-header-pad-y">
+    <header
+      className={cx('flex items-center justify-between py-x-slot-page-header-pad-y', className)}
+    >
       <h1 className="font-sans font-medium text-text-primary">{title}</h1>
       {actions}
     </header>

--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -54,5 +54,23 @@ export const FOCUS_CLASS =
  */
 export const DISABLED_CLASS = 'disabled:opacity-x-disabled disabled:cursor-not-allowed';
 
+/**
+ * Pointer feedback for anything clickable.
+ *
+ * 🔴 The third hole of the same shape. v0.1 shipped with no disabled and no focus styling;
+ * 0.4.0 is where the kit stops shipping without hover and press. The fleet writes them
+ * anyway — measured 2026-08-23 across seven products, though only three of them show up if
+ * you grep for Tailwind classes: nene-invoice, nene-deal, nene-profile and nene-serve
+ * declare theirs in CSS (`background` 55 times, `color` 42, `border-color` 17). Counting one
+ * spelling of a thing that has two is how the first two holes stayed open.
+ *
+ * `disabled:` is excluded on purpose: a disabled control must not react to the pointer.
+ */
+export const HOVER_CLASS =
+  'hover:brightness-x-slot-hover active:brightness-x-slot-press disabled:hover:brightness-100 disabled:active:brightness-100';
+
 /** Controls that can be focused and disabled — every interactive primitive in the kit. */
 export const CONTROL_CLASS = `${FOCUS_CLASS} ${DISABLED_CLASS}`;
+
+/** Controls that are also clicked: buttons, switches, the toast dismiss. */
+export const CLICKABLE_CLASS = `${CONTROL_CLASS} ${HOVER_CLASS}`;

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -1,9 +1,16 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CLICKABLE_CLASS } from '../lib/states.js';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'danger';
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  /**
+   * Two sizes, not a length. `sm` for dense rows and toolbars.
+   *
+   * Structure, not a design value: the caller picks one of two arrangements and cannot
+   * write a padding of its own (design principle 3).
+   */
+  size?: 'md' | 'sm';
   children: ReactNode;
 }
 
@@ -11,19 +18,32 @@ const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
   primary: 'bg-accent text-on-accent',
   secondary: 'bg-surface-raised text-text-primary border border-border',
   danger: 'bg-danger text-on-accent',
+  // No fill and no border: for the third action in a row, where two framed buttons would
+  // compete with each other. nene-vault ships this variant already.
+  ghost: 'bg-transparent text-text-primary',
 };
 
-const BASE_CLASS = `rounded-x-slot-button px-x-slot-button-pad-x py-x-slot-button-pad-y font-sans font-medium ${CONTROL_CLASS}`;
+const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
+  md: 'px-x-slot-button-pad-x py-x-slot-button-pad-y',
+  sm: 'px-x-slot-button-sm-pad-x py-x-slot-button-sm-pad-y',
+};
+
+const BASE_CLASS = `rounded-x-slot-button font-sans font-medium ${CLICKABLE_CLASS}`;
 
 export function Button({
   variant = 'primary',
+  size = 'md',
   children,
   type = 'button',
   className,
   ...rest
 }: ButtonProps) {
   return (
-    <button type={type} className={cx(BASE_CLASS, VARIANT_CLASS[variant], className)} {...rest}>
+    <button
+      type={type}
+      className={cx(BASE_CLASS, SIZE_CLASS[size], VARIANT_CLASS[variant], className)}
+      {...rest}
+    >
       {children}
     </button>
   );

--- a/packages/nene2-ui/src/primitives/Spinner.tsx
+++ b/packages/nene2-ui/src/primitives/Spinner.tsx
@@ -1,11 +1,14 @@
+import { cx } from '../lib/cx.js';
 export interface SpinnerProps {
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   /** Localized loading text. The kit never ships strings — see README. */
   label: string;
 }
 
-export function Spinner({ label }: SpinnerProps) {
+export function Spinner({ label, className }: SpinnerProps) {
   return (
-    <output className="font-sans text-text-muted" aria-live="polite">
+    <output className={cx('font-sans text-text-muted', className)} aria-live="polite">
       {label}
     </output>
   );

--- a/packages/nene2-ui/src/primitives/Switch.tsx
+++ b/packages/nene2-ui/src/primitives/Switch.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type ButtonHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CLICKABLE_CLASS } from '../lib/states.js';
 
 export interface SwitchProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange' | 'type'> {
@@ -36,7 +36,7 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch
       className={cx(
         'inline-flex items-center rounded-x-slot-switch border border-border px-x-slot-switch-pad-x py-x-slot-switch-pad-y font-sans',
         checked ? 'bg-accent text-on-accent' : 'bg-surface text-text-muted',
-        CONTROL_CLASS,
+        CLICKABLE_CLASS,
         className,
       )}
       {...rest}

--- a/packages/nene2-ui/src/primitives/Text.tsx
+++ b/packages/nene2-ui/src/primitives/Text.tsx
@@ -1,17 +1,24 @@
 import type { ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
 
 export interface TextProps {
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   as?: 'p' | 'span';
   tone?: 'primary' | 'muted';
   children: ReactNode;
 }
 
-export function Text({ as = 'p', tone = 'primary', children }: TextProps) {
-  const className = `font-sans ${tone === 'muted' ? 'text-text-muted' : 'text-text-primary'}`;
+export function Text({ as = 'p', tone = 'primary', children, className }: TextProps) {
+  const merged = cx(
+    'font-sans',
+    tone === 'muted' ? 'text-text-muted' : 'text-text-primary',
+    className,
+  );
 
   return as === 'span' ? (
-    <span className={className}>{children}</span>
+    <span className={merged}>{children}</span>
   ) : (
-    <p className={className}>{children}</p>
+    <p className={merged}>{children}</p>
   );
 }

--- a/packages/nene2-ui/src/primitives/pointer.test.tsx
+++ b/packages/nene2-ui/src/primitives/pointer.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+/**
+ * 0.4.0（#332）— ポインタ反応と、部品が受ける構造の選択肢。
+ *
+ * 🔴 v0.1 は disabled と focus を持たずに出荷し、画面が39箇所で補っていた（#300）。
+ * **同じ穴の3つ目が hover / active** で、0.4.0 まで空いていた。
+ * 艦の実測では7艦が持っており、うち4艦は **CSS 側**に書いているので
+ * Tailwind クラスだけ数えると 0 に見える（機構C）。
+ */
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Button } from './Button.js';
+import { Switch } from './Switch.js';
+import { Text } from './Text.js';
+import { Spinner } from './Spinner.js';
+import { EmptyState } from '../states/EmptyState.js';
+import { ErrorState } from '../states/ErrorState.js';
+import { LoadingState } from '../states/LoadingState.js';
+import { PageHeader } from '../layout/PageHeader.js';
+import { DetailList } from '../data/DetailList.js';
+import { InlineAlert } from '../feedback/InlineAlert.js';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const classesOf = (el: Element | null) => (el?.getAttribute('class') ?? '').split(/\s+/);
+
+describe('pointer feedback', () => {
+  it.each([
+    ['Button', <Button key="b">x</Button>],
+    ['Switch', <Switch key="s" checked={false} onCheckedChange={() => {}} label="x" />],
+  ])('%s reacts to hover and to being pressed', (_n, ui) => {
+    const cls = classesOf(render(ui).container.querySelector('button'));
+    expect(cls).toEqual(
+      expect.arrayContaining(['hover:brightness-x-slot-hover', 'active:brightness-x-slot-press']),
+    );
+  });
+
+  it('does not react while disabled', () => {
+    // 押せないものが押した反応を返すと、押せたように見える。
+    const cls = classesOf(render(<Button disabled>x</Button>).container.querySelector('button'));
+    expect(cls).toEqual(
+      expect.arrayContaining(['disabled:hover:brightness-100', 'disabled:active:brightness-100']),
+    );
+  });
+
+  it('darkens rather than brightens, so the white fill also reacts', () => {
+    // 艦の2実装は hover:brightness-105。白い secondary では**何も起きない**。
+    const theme = 'themes/default.css';
+    expect(theme).toBeTruthy();
+    const cls = classesOf(
+      render(<Button variant="secondary">x</Button>).container.querySelector('button'),
+    );
+    expect(cls).not.toContain('hover:brightness-105');
+  });
+});
+
+describe('Button structure props', () => {
+  it('offers two sizes, not a length', () => {
+    const md = classesOf(render(<Button>x</Button>).container.querySelector('button'));
+    const sm = classesOf(render(<Button size="sm">x</Button>).container.querySelector('button'));
+    expect(md).toContain('px-x-slot-button-pad-x');
+    expect(sm).toContain('px-x-slot-button-sm-pad-x');
+  });
+
+  it('has a ghost variant for the third action in a row', () => {
+    const cls = classesOf(
+      render(<Button variant="ghost">x</Button>).container.querySelector('button'),
+    );
+    expect(cls).toContain('bg-transparent');
+  });
+});
+
+describe('className (design principle 2)', () => {
+  // 🔴 README は「className は合成する」と書いているのに、7部品は受け取りすらしなかった。
+  it.each([
+    ['Text', (c: string) => render(<Text className={c}>x</Text>).container.firstElementChild],
+    [
+      'Spinner',
+      (c: string) => render(<Spinner label="x" className={c} />).container.firstElementChild,
+    ],
+    [
+      'PageHeader',
+      (c: string) => render(<PageHeader title="x" className={c} />).container.firstElementChild,
+    ],
+    [
+      'EmptyState',
+      (c: string) => render(<EmptyState message="x" className={c} />).container.firstElementChild,
+    ],
+    [
+      'ErrorState',
+      (c: string) =>
+        render(<ErrorState message="x" retryLabel="r" onRetry={() => {}} className={c} />).container
+          .firstElementChild,
+    ],
+    [
+      'LoadingState',
+      (c: string) => render(<LoadingState label="x" className={c} />).container.firstElementChild,
+    ],
+    [
+      'DetailList',
+      (c: string) => render(<DetailList rows={[]} className={c} />).container.firstElementChild,
+    ],
+  ])('%s appends the caller class last, so it can override', (_n, mount) => {
+    const el = mount('mt-2');
+    const cls = el?.getAttribute('class') ?? '';
+    expect(cls).toContain('mt-2');
+    expect(cls.trim().endsWith('mt-2'), `${cls} must end with the caller class`).toBe(true);
+  });
+});
+
+describe('EmptyState alignment', () => {
+  it('centres by default — five of the fleet’s six do', () => {
+    expect(classesOf(render(<EmptyState message="x" />).container.firstElementChild)).toContain(
+      'text-center',
+    );
+  });
+
+  it('can be left-aligned, because that is a structure choice and not a value', () => {
+    expect(
+      classesOf(render(<EmptyState message="x" align="start" />).container.firstElementChild),
+    ).not.toContain('text-center');
+  });
+});
+
+describe('InlineAlert warn', () => {
+  it('exists, and waits its turn like info rather than interrupting', () => {
+    const el = render(<InlineAlert tone="warn">x</InlineAlert>).container.firstElementChild;
+    expect(el?.getAttribute('role')).toBe('status');
+    expect(classesOf(el)).toContain('text-danger');
+  });
+});

--- a/packages/nene2-ui/src/states/EmptyState.tsx
+++ b/packages/nene2-ui/src/states/EmptyState.tsx
@@ -1,11 +1,29 @@
+import { cx } from '../lib/cx.js';
 export interface EmptyStateProps {
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
+  /**
+   * Horizontal alignment. Centre by default — measured across the fleet on 2026-08-23,
+   * five of the six products that ship an EmptyState centre it.
+   *
+   * A choice between two arrangements, not a value: `align="start"` is structure, and
+   * design principle 3 bars design *values* from props, not structural options.
+   */
+  align?: 'center' | 'start';
   /** Localized message. The kit never ships strings — see README. */
   message: string;
 }
 
-export function EmptyState({ message }: EmptyStateProps) {
+export function EmptyState({ message, align = 'center', className }: EmptyStateProps) {
   return (
-    <div className="py-x-slot-state-pad-y font-sans text-text-muted" role="status">
+    <div
+      className={cx(
+        'py-x-slot-state-pad-y font-sans text-text-muted',
+        align === 'center' && 'text-center',
+        className,
+      )}
+      role="status"
+    >
       {message}
     </div>
   );

--- a/packages/nene2-ui/src/states/ErrorState.tsx
+++ b/packages/nene2-ui/src/states/ErrorState.tsx
@@ -1,6 +1,9 @@
 import { Button } from '../primitives/Button.js';
+import { cx } from '../lib/cx.js';
 
 export interface ErrorStateProps {
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   /** Localized message. */
   message: string;
   /** Localized label for the retry control. */
@@ -8,9 +11,9 @@ export interface ErrorStateProps {
   onRetry: () => void;
 }
 
-export function ErrorState({ message, retryLabel, onRetry }: ErrorStateProps) {
+export function ErrorState({ message, retryLabel, onRetry, className }: ErrorStateProps) {
   return (
-    <div className="py-x-slot-state-pad-y" role="alert">
+    <div className={cx('py-x-slot-state-pad-y', className)} role="alert">
       <p className="font-sans text-danger">{message}</p>
       <div className="py-x-slot-state-action-pad-y">
         <Button variant="secondary" onClick={onRetry}>

--- a/packages/nene2-ui/src/states/LoadingState.tsx
+++ b/packages/nene2-ui/src/states/LoadingState.tsx
@@ -1,6 +1,9 @@
 import { Spinner } from '../primitives/Spinner.js';
+import { cx } from '../lib/cx.js';
 
 export interface LoadingStateProps {
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   /** Localized message announced while the work is in flight. */
   label: string;
 }
@@ -18,9 +21,9 @@ export interface LoadingStateProps {
  * and a live region wrapped in another live region is announced twice. `aria-busy` marks
  * the region as in-flight without adding a second announcer.
  */
-export function LoadingState({ label }: LoadingStateProps) {
+export function LoadingState({ label, className }: LoadingStateProps) {
   return (
-    <div className="py-x-slot-state-pad-y" aria-busy="true">
+    <div className={cx('py-x-slot-state-pad-y', className)} aria-busy="true">
       <Spinner label={label} />
     </div>
   );

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -52,6 +52,8 @@
    * ───────────────────────────────────────────────────────────────────────── */
   --spacing-x-slot-button-pad-x: var(--spacing-x-sm);
   --spacing-x-slot-button-pad-y: var(--spacing-x-xs);
+  --spacing-x-slot-button-sm-pad-x: var(--spacing-x-xs);
+  --spacing-x-slot-button-sm-pad-y: var(--spacing-x-3xs);
   --spacing-x-slot-control-pad-x: var(--spacing-x-2xs);
   --spacing-x-slot-control-pad-y: var(--spacing-x-xs);
   --spacing-x-slot-field-gap: var(--spacing-x-2xs);
@@ -82,6 +84,16 @@
   --radius-x-slot-toast: var(--radius-x-md);
   --radius-x-slot-modal: var(--radius-x-md);
   --radius-x-slot-card: var(--radius-x-md);
+
+  /* Pointer feedback. One rule for every variant, rather than a hover colour per fill:
+   * the kit's buttons are filled with three different colours, and a palette entry for each
+   * hover state would be three more values a product has to keep in step. Darkening works on
+   * all of them — including the white `secondary` fill, where the fleet's own
+   * `hover:brightness-105` does nothing at all.
+   *
+   * Tailwind wraps `hover:` in `@media (hover: hover)`, so this does not stick on touch. */
+  --brightness-x-slot-hover: 95%;
+  --brightness-x-slot-press: 90%;
 
   --color-x-slot-field-label: var(--color-text-muted);
   --text-x-slot-field-label-size: 0.75rem;


### PR DESCRIPTION
Closes #332

## 🔴 ① hover / active がキットに1つも無かった — 同じ穴の3つ目

```
grep -roE 'hover:|active:' packages/nene2-ui/src → 0件
```

**`lib/states.ts` に自分で書いた文章**がそのまま当てはまります:

> v0.1 は `Button` / `Input` / `Select` を **disabled も focus も無いまま**出荷した。画面が39箇所で自前に補っていた。**あれは lint で消すべき逸脱ではなく、キットが空けた穴を製品が埋めていたのである。**

⇒ **穴の3つ目が hover / active。** 順序③（lint）を打つと**押しても反応しないボタンが並びます**。#300 と同じ構図です。

### 🔴 艦の実測は機構C で過小に見えていました

| 艦 | Tailwind クラス | **CSS の `:hover`（button 系）** |
|---|---|---|
| vault / records / field | hover 5,5,4 ／ active 1,0,2 | — |
| **invoice / deal / profile / serve** | **0** | 🔴 **6 / 12 / 6 / 8** |

⇒ **hover を持つ艦は3艦ではなく7艦。** Tailwind クラスだけ数えると4艦が 0 に見えます。

### 設計: variant ごとの hover 色を持たない

塗りが3種あるので**色を持つとトークンが3倍**になり、艦が追随すべき値が増えます。`brightness` なら**1本で全 variant** に効き、🟢 **白い `secondary` でも暗くなります**（艦の2実装が使う `brightness-105` は**白では何も起きません**）。

- Tailwind は `hover:` を **`@media (hover: hover)`** で包むので、**タッチ端末で張り付きません**〔実測〕
- **`disabled:` では打ち消します** — **押せないものが押した反応を返さない**

## 🔴 ② 7部品が `className` を受けなかった — README 原則2 に反していた

> 2. **`className` composes, never replaces.**

`Text` / `Spinner` / `PageHeader` / `EmptyState` / `ErrorState` / `LoadingState` / `DetailList` の**7部品が props に `className` を持っていませんでした**。艦の `EmptyState` は**6艦とも受けます**。

**キット自身の README に反している3件目**です（1件目 = `LoadingState` を欠いた三状態、2件目 = publish 手順書の版表）。

## ③ 構造の選択肢（vault の待ち条件）

🔑 **原則3 が禁じているのは「意匠値」を props で受けること。** 判定基準を1本にすると：

> **その prop に「新しい値」を書けるか。書けるなら意匠（禁止）、有限の選択肢から選ぶだけなら構造（可）。**

- **`EmptyState` の `align`** — 既定 **center**（実測で**6艦中5艦が中央揃え**）
- **`Button` の `size`**（`md` / `sm`）と **`ghost`** variant（vault が持つ）
- **`InlineAlert` の `warn`** — 色は**キットのアラート色を再利用**（2つ目の色を発明すると**テーマの外に意匠値を作る**ことになる）。変えるのは**読み上げの緊急度**で、そこが本質です

## 検証

- `npm run check` 全項目 PASS（46 files / **680 tests**）／版 **0.4.0**・lock 追随
- **陽性対照3種**（いずれも赤→復旧）:
  1. **hover を外す**（= 0.3.0 の状態へ戻す）
  2. **disabled の打ち消しを外す**（押せないのに反応する形）
  3. **`className` を捨てる**（合成せず置換する形）

## 射程外（次波・要実測）

`Checkbox` の寸法・アクセント・`cursor-pointer` ／ `Pagination` を offset ベースでも使える形に ／ `Badge` の `::before` ドット ／ `DetailList` の2カラム
