### PR TITLE
chore(fleet-baseline): nene2-ui の floor を ^0.4.0 へ — vault の待ち条件4件が 0.4.0 で解ける（#334）

### DIFF
--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -6,6 +6,6 @@
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.1.1",
     "@hideyukimori/nene2-i18n": "^0.3.0",
-    "@hideyukimori/nene2-ui": "^0.3.0"
+    "@hideyukimori/nene2-ui": "^0.4.0"
   }
 }


### PR DESCRIPTION
Closes #334

🟢 **ベースは `main`。独立に入ります。**

| | |
|---|---|
| 現在の floor | `^0.3.0` |
| npm の latest | 🟢 **0.4.0**〔`shasum 0c044c9c…`・**provenance 付き**〕 |
| `semver.satisfies('0.4.0','^0.3.0')` | 🔴 **false** |

## vault の待ち条件6件のうち4件が 0.4.0 で解けます

| | |
|---|---|
| hover / active | 🟢 |
| `Button` の `size` / `ghost` | 🟢 |
| `InlineAlert` の `warn` | 🟢 |
| `EmptyState` の中央揃えと `className` | 🟢 |
| `Checkbox` の寸法・アクセント | 🔴 次波 |
| `Pagination` の offset モデル | 🔴 次波 |

🔴 とくに **hover / active** は、**0.3.0 のまま載せ替えると 39箇所のボタンからホバー反応と押下反応が消えます**。

## 既存3本の floor は触りません

**#271 で据え置きと裁定済み**。`nene2-ui` だけ性質が違います（**W1 がこれから入れる版が floor に含まれていない**）。