### PR TITLE
feat(ui) 0.5.0: Checkbox / Radio のラベル側にキットが届いていなかった＋Pagination が offset ベースを受けられなかった（#336）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -150,6 +150,25 @@ publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run �
 nene-payout の `shared/ui` から10部品を昇格（新規設計ゼロ）＋ `cx()` 是正。
 Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList。
 
+### `@hideyukimori/nene2-ui` 0.5.0（**minor — 選択系のラベル側とページ送りの2モデル**・#336）
+
+**vault が Tailwind クラスと CSS の両方で測った結果**に基づく（片方だけ見て4回過小を出した反省から、両形式で取ってもらったもの）。
+
+- 🔴 **`Checkbox` / `Radio` のラベル側**にキットが届いていなかった。`className` は `<input>` へ
+  渡るので、**`cursor-pointer` と間隔は props でも `className` でも設定できない**。
+  ⇒ **キットが持つ**。あわせて入力の寸法（`--spacing-x-slot-choice-box`・既定 1rem = 16px）と
+  アクセント色（`--color-x-slot-choice-accent`）をスロットへ。
+  **`Radio` にも同じ穴があった**（vault は両者で同じラベル style を共有している）
+- 🔴 **`Pagination` が offset ベースを受けられなかった。** vault の3画面とも offset を持ち、
+  **page 番号は誰も持っていない**。⇒ `canPrev` / `canNext` / `onPrev` / `onNext` でも使える形に。
+  `page` / `pageCount` の側は残す（判別可能な union）
+
+🔑 **`status` を呼び出し側が組み立てる形は変えない。** vault の文言は「**21–40件を表示（全384件）**」＝
+**件の範囲**で、**page 番号からは復元できない**（端数ページで崩れる）。
+⇒ **page へ寄せると3画面の文言が壊れる。**
+
+**線引きは既存の基準の適用**: `cursor-pointer` と間隔は**意匠でも構造の選択肢でもなく部品の構成要素**（キットが持つ）／ページ送りの2モデルは**有限の選択肢**（props で受けてよい）。
+
 ### `@hideyukimori/nene2-ui` 0.4.0（**minor — hover/active ＋ 構造の選択肢**・#332）
 
 🔴 **既存部品の見た目が変わる**（0.3.0 まで**ポインタに何も反応しなかった**）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/data/Pagination.tsx
+++ b/packages/nene2-ui/src/data/Pagination.tsx
@@ -1,61 +1,86 @@
 import { Button } from '../primitives/Button.js';
 import { Stack } from '../layout/Stack.js';
 
-export interface PaginationProps {
-  /** 1-based. */
-  page: number;
-  pageCount: number;
-  onPageChange: (page: number) => void;
+interface PaginationBase {
   /** Localized name for the navigation region, e.g. "Invoice pages". */
   label: string;
   previousLabel: string;
   nextLabel: string;
-  /** Localized current position, e.g. "Page 2 of 9". The kit ships no strings. */
+  /**
+   * Localized statement of where the reader is: "Page 2 of 9", or "Showing 21–40 of 384".
+   *
+   * 🔴 Composed by the caller, and it has to be. Across nene-vault's three paginated screens
+   * the sentence is a *range of items*, not a page number — and a range cannot be recovered
+   * from `page` and `pageCount` once the last page is short (measured 2026-08-23). A
+   * component that only knew about pages could not produce the sentence the product needs.
+   */
   status: string;
 }
+
+interface PagePagination extends PaginationBase {
+  /** 1-based. */
+  page: number;
+  pageCount: number;
+  onPageChange: (page: number) => void;
+  canPrev?: never;
+  canNext?: never;
+  onPrev?: never;
+  onNext?: never;
+}
+
+interface OffsetPagination extends PaginationBase {
+  canPrev: boolean;
+  canNext: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  page?: never;
+  pageCount?: never;
+  onPageChange?: never;
+}
+
+export type PaginationProps = PagePagination | OffsetPagination;
 
 /**
  * Page-by-page navigation for a list.
  *
+ * 🔴 Two models, because products keep the position in two different ways. All three of
+ * nene-vault's paginated screens hold an **offset**, and none of them holds a page number
+ * (measured 2026-08-23). Converting offset to a page is arithmetic; converting the sentence
+ * "21–40 of 384" back out of a page number is not. So the component takes whichever the
+ * caller already has, rather than making two thirds of the fleet keep a second copy of its
+ * own position.
+ *
+ * A finite choice between two arrangements, which is structure — not a design value that a
+ * caller could invent (design principle 3).
+ *
  * 🔴 The current position is text, and the region is a named `<nav>`. Four ships wrote this
- * component and the recurring shape marks the current page by colour alone — which is
- * invisible to a screen reader and to anyone who cannot distinguish the two shades. The
- * `status` string is required for the same reason: "you are here" has to be readable, not
- * merely visible.
+ * component and the recurring shape marks the current page by colour alone — invisible to a
+ * screen reader and to anyone who cannot distinguish the two shades.
  *
  * The ends are disabled rather than hidden. A control that disappears at the boundary makes
- * the row of controls jump, and moves the next-page button under the cursor that just
- * clicked it.
+ * the row jump, and moves the next-page button under the cursor that just clicked it.
  */
-export function Pagination({
-  page,
-  pageCount,
-  onPageChange,
-  label,
-  previousLabel,
-  nextLabel,
-  status,
-}: PaginationProps) {
+export function Pagination(props: PaginationProps) {
+  const { label, previousLabel, nextLabel, status } = props;
+
+  const atStart = props.page === undefined ? !props.canPrev : props.page <= 1;
+  const atEnd = props.page === undefined ? !props.canNext : props.page >= props.pageCount;
+
+  const goPrev = () =>
+    props.page === undefined ? props.onPrev() : props.onPageChange(props.page - 1);
+  const goNext = () =>
+    props.page === undefined ? props.onNext() : props.onPageChange(props.page + 1);
+
   return (
     <nav aria-label={label}>
       <Stack direction="horizontal" gap="2xs" align="center">
-        <Button
-          variant="secondary"
-          disabled={page <= 1}
-          onClick={() => onPageChange(page - 1)}
-          aria-label={previousLabel}
-        >
+        <Button variant="secondary" disabled={atStart} onClick={goPrev} aria-label={previousLabel}>
           {previousLabel}
         </Button>
         <span aria-current="page" className="font-sans text-text-muted">
           {status}
         </span>
-        <Button
-          variant="secondary"
-          disabled={page >= pageCount}
-          onClick={() => onPageChange(page + 1)}
-          aria-label={nextLabel}
-        >
+        <Button variant="secondary" disabled={atEnd} onClick={goNext} aria-label={nextLabel}>
           {nextLabel}
         </Button>
       </Stack>

--- a/packages/nene2-ui/src/data/table.test.tsx
+++ b/packages/nene2-ui/src/data/table.test.tsx
@@ -202,3 +202,90 @@ describe('Pagination', () => {
     expect(onPageChange).toHaveBeenNthCalledWith(2, 3);
   });
 });
+
+describe('Checkbox / Radio label side', () => {
+  // 🔴 className は <input> へ渡るので、ラベル側にはキットしか届かない。
+  // vault は cursor-pointer と間隔をラベルに持っており、届かないと
+  // **製品の全選択肢からポインタカーソルが消える**（マウス利用者には見え、diff には出ない）。
+  it.each([
+    ['Checkbox', <Checkbox key="c" label="x" />],
+    ['Radio', <Radio key="r" name="g" value="a" label="x" />],
+  ])('%s makes the whole label clickable-looking', (_n, ui) => {
+    const { container } = render(ui);
+    const cls = (container.querySelector('label')?.getAttribute('class') ?? '').split(/\s+/);
+    expect(cls).toContain('cursor-pointer');
+    expect(cls).toContain('gap-x-slot-choice-gap');
+  });
+
+  it.each([
+    ['Checkbox', <Checkbox key="c" label="x" />],
+    ['Radio', <Radio key="r" name="g" value="a" label="x" />],
+  ])('%s sizes and tints the box from the theme', (_n, ui) => {
+    const { container } = render(ui);
+    const cls = (container.querySelector('input')?.getAttribute('class') ?? '').split(/\s+/);
+    expect(cls).toContain('size-x-slot-choice-box');
+    expect(cls).toContain('accent-x-slot-choice-accent');
+    expect(cls).not.toContain('accent-accent');
+  });
+});
+
+describe('Pagination offset model', () => {
+  const base = {
+    label: 'Users',
+    previousLabel: 'Previous',
+    nextLabel: 'Next',
+    status: 'Showing 21–40 of 384',
+  };
+
+  it('takes canPrev / canNext instead of a page number', () => {
+    // vault の3画面とも offset ベースで、page 番号は誰も持っていない。
+    const { container } = render(
+      <Pagination {...base} canPrev canNext onPrev={() => {}} onNext={() => {}} />,
+    );
+    const [prev, next] = [...container.querySelectorAll('button')];
+    expect(prev?.disabled).toBe(false);
+    expect(next?.disabled).toBe(false);
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toBe(
+      'Showing 21–40 of 384',
+    );
+  });
+
+  it('disables each end from the flag it was given', () => {
+    const { container } = render(
+      <Pagination {...base} canPrev={false} canNext onPrev={() => {}} onNext={() => {}} />,
+    );
+    const [prev, next] = [...container.querySelectorAll('button')];
+    expect(prev?.disabled).toBe(true);
+    expect(next?.disabled).toBe(false);
+  });
+
+  it('calls the offset handlers, not a page setter', () => {
+    const onPrev = vi.fn();
+    const onNext = vi.fn();
+    const { container } = render(
+      <Pagination {...base} canPrev canNext onPrev={onPrev} onNext={onNext} />,
+    );
+    const [prev, next] = [...container.querySelectorAll('button')];
+    fireEvent.click(next!);
+    fireEvent.click(prev!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('still supports the page model', () => {
+    const onPageChange = vi.fn();
+    const { container } = render(
+      <Pagination
+        label="Invoices"
+        previousLabel="Previous"
+        nextLabel="Next"
+        status="Page 2 of 9"
+        page={2}
+        pageCount={9}
+        onPageChange={onPageChange}
+      />,
+    );
+    fireEvent.click([...container.querySelectorAll('button')][1]!);
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+});

--- a/packages/nene2-ui/src/primitives/Checkbox.tsx
+++ b/packages/nene2-ui/src/primitives/Checkbox.tsx
@@ -8,7 +8,7 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
   label: ReactNode;
 }
 
-const BOX_CLASS = `rounded-x-slot-control border border-border accent-accent ${CONTROL_CLASS}`;
+const BOX_CLASS = `size-x-slot-choice-box shrink-0 rounded-x-slot-control border border-border accent-x-slot-choice-accent ${CONTROL_CLASS}`;
 
 /**
  * A checkbox and its label, as one part.
@@ -17,6 +17,13 @@ const BOX_CLASS = `rounded-x-slot-control border border-border accent-accent ${C
  * `<input>` next to a `<label>` whose `htmlFor` is missing or stale — which loses nothing
  * visible, and loses the ability to click the text to toggle the box, plus the name the
  * control is announced by. Making the label a prop means it cannot be forgotten.
+ *
+ * 🔴 `cursor-pointer` and the gap live here rather than being left to the caller, because
+ * the caller cannot reach them: `className` is forwarded to the `<input>`, and both belong
+ * to the `<label>` that wraps it. nene-vault carries them on the label in its own
+ * implementation (measured 2026-08-23, checking Tailwind classes and CSS both), so a
+ * migration that could not set them would lose the pointer cursor on every choice in the
+ * product — visible to a mouse user, invisible in a diff.
  */
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
   {
@@ -33,7 +40,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
   const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return (
-    <label className="inline-flex items-center gap-x-slot-choice-gap font-sans text-text-primary">
+    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-text-primary">
       <input ref={ref} type="checkbox" className={cx(BOX_CLASS, className)} {...wiring} {...rest} />
       {label}
     </label>

--- a/packages/nene2-ui/src/primitives/Radio.tsx
+++ b/packages/nene2-ui/src/primitives/Radio.tsx
@@ -9,7 +9,7 @@ export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
   name: string;
 }
 
-const DOT_CLASS = `border border-border accent-accent ${CONTROL_CLASS}`;
+const DOT_CLASS = `size-x-slot-choice-box shrink-0 border border-border accent-x-slot-choice-accent ${CONTROL_CLASS}`;
 
 /**
  * One option in a radio group, with its label.
@@ -17,6 +17,10 @@ const DOT_CLASS = `border border-border accent-accent ${CONTROL_CLASS}`;
  * 🔴 `name` is required, unlike on a bare `<input type="radio">`. A radio without a name is
  * its own group of one: it can be checked but never unchecked, and arrow keys do not move
  * between the options. Nothing about the rendered page shows this, so it survives review.
+ *
+ * 🔴 `cursor-pointer`, the gap and the box size are the component's, for the same reason as
+ * on `Checkbox`: `className` reaches the `<input>`, and those belong to the `<label>`.
+ * nene-vault's radios share one label style with its checkboxes, so the same hole was here.
  *
  * 🔴 This does not take the `FormField` wiring. A group of radios shares one label and one
  * error, so the id and `aria-describedby` belong on a `<fieldset>` around the group, not on
@@ -27,7 +31,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   ref,
 ) {
   return (
-    <label className="inline-flex items-center gap-x-slot-choice-gap font-sans text-text-primary">
+    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-text-primary">
       <input ref={ref} type="radio" name={name} className={cx(DOT_CLASS, className)} {...rest} />
       {label}
     </label>

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -58,6 +58,10 @@
   --spacing-x-slot-control-pad-y: var(--spacing-x-xs);
   --spacing-x-slot-field-gap: var(--spacing-x-2xs);
   --spacing-x-slot-choice-gap: var(--spacing-x-2xs);
+  /* The box itself. 1rem = 16px, which is what every product that ships a checkbox uses
+   * (measured 2026-08-23). Sized from the scale so a product that wants a larger hit area
+   * moves a step rather than inventing a length. */
+  --spacing-x-slot-choice-box: var(--spacing-x-sm);
   --spacing-x-slot-badge-pad-x: var(--spacing-x-2xs);
   --spacing-x-slot-badge-pad-y: var(--spacing-x-3xs);
   --spacing-x-slot-switch-pad-x: var(--spacing-x-2xs);
@@ -95,6 +99,7 @@
   --brightness-x-slot-hover: 95%;
   --brightness-x-slot-press: 90%;
 
+  --color-x-slot-choice-accent: var(--color-accent);
   --color-x-slot-field-label: var(--color-text-muted);
   --text-x-slot-field-label-size: 0.75rem;
   --font-weight-x-slot-field-label: 500;


### PR DESCRIPTION
Closes #336

**vault が Tailwind クラスと CSS の両方で測った結果**に基づいています（片方だけ見て**4回過小を出した反省**から、両形式で取ってもらったもの）。

## 🔴 ① `Checkbox` / `Radio` のラベル側にキットが届いていなかった

vault の実体（`shared/ui/primitives/fieldBase.ts`）:

| どこに付いているか | クラス |
|---|---|
| **`<label>`（親）** | `inline-flex` `items-center` **`gap-2.25`** **`cursor-pointer`** `text-sm` `text-text-primary` |
| `<input>`（子） | `w-4` `h-4` **`accent-accent`** `flex-none` |

🔑 **キットは `className` を `<input>` へ渡すので、ラベル側の5クラスには原理的に届きません。** ⇒ **`cursor-pointer` と間隔は props でも `className` でも設定できない ＝ キットが持つしかない。**

届かないままだと、載せ替えで**製品の全選択肢からポインタカーソルが消えます** — **マウス利用者には見え、diff には現れません**。

⇒ 入れたもの:
- **`cursor-pointer`** をラベルへ
- 入力の寸法を **`--spacing-x-slot-choice-box`**（既定 **1rem = 16px**・vault の `w-4 h-4` と一致）
- アクセント色を **`--color-x-slot-choice-accent`**
- 🔴 **`Radio` にも同じ穴がありました**（vault は両者で同じラベル style を共有）

**CSS 側は空**であることも確認済み（当たるのはコメント1行だけ）。

## 🔴 ② `Pagination` が offset ベースを受けられなかった

vault の**3画面とも offset を持ち、page 番号は誰も持っていません**。⇒ `canPrev` / `canNext` / `onPrev` / `onNext` でも使える**判別可能 union** にしました（`page` / `pageCount` 側も残しています）。

🔑 **`status` を呼び出し側が組み立てる形は変えません。** vault の文言は「**21–40件を表示（全384件）**」＝**件の範囲**で、**page 番号からは復元できません**（端数ページで崩れる）。⇒ **page へ寄せると3画面の文言が壊れます。**

## 線引き（既存の基準の適用）

> **その prop に「新しい値」を書けるか。書けるなら意匠（禁止）、有限の選択肢から選ぶだけなら構造（可）。**

- `cursor-pointer` と間隔 ＝ **意匠でも構造の選択肢でもなく、部品の構成要素** ⇒ **キットが持つ**
- ページ送りの2モデル ＝ **有限の選択肢** ⇒ **props で受けてよい**

## 検証

- `npm run check` 全項目 PASS（46 files / **688 tests**）／版 **0.5.0**・lock 追随
- Tailwind 4.3.2 で `size-x-slot-choice-box` / `accent-x-slot-choice-accent` が解決することを実測
- **陽性対照3種**（いずれも赤→復旧）:
  1. ラベルから `cursor-pointer` を外す（= 0.4.0 の状態）
  2. アクセントをテーマ外の直クラスへ戻す
  3. offset モデルを落とす（page 前提へ戻す）

⇒ **これで vault の待ち条件6件がすべて解けます。**
