### PR TITLE
feat(ui) 0.6.0: Button の secondary が 2px 高い／InlineAlert の warn と danger が同一／README の規則とキットのテーマが食い違う（#338）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -150,6 +150,28 @@ publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run �
 nene-payout の `shared/ui` から10部品を昇格（新規設計ゼロ）＋ `cx()` 是正。
 Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList。
 
+### `@hideyukimori/nene2-ui` 0.6.0（**minor — alert の色・型スケール・Button の高さ**・#338）
+
+vault の波2（PR #391）からの上流3件 ＋ #389 の残り。**全部自艦で再測して確認済み。**
+
+- 🔴 **`Button` の `secondary` だけ 2px 高かった。** 高さは padding 由来で、**border を持つのが
+  `secondary` だけ**だったため。⇒ **BASE に `border border-transparent`**。
+  vault は**モーダルのフッター7箇所で primary と secondary を横に並べている** ⇒ 段差が出ていた
+- 🔴 **`InlineAlert` の `warn` と `danger` が文字列まで完全に同一だった。** `role` は分かれていたが、
+  vault の一文が核: **「role の違いは聞こえる人には届くが、見ている人には届かない」**。
+  ⇒ **`--color-x-slot-alert-{info,warn,danger}-{bg,fg,border}` を9本追加**。
+  **既定は現状のまま**なので、上書きしない艦には何も起きない
+- 🔴 **README の規則とキットのテーマが食い違っていた**（**自分の README に反する4件目**）。
+  vault が README どおりに検査を実装したところ、**キット本体の `--text-x-slot-field-label-size:
+0.75rem` と `--brightness-x-slot-hover: 95%` が落ちた**。
+  ⇒ **型スケールを新設**（`--text-x-2xs` … `--text-x-xl` ＋ `--text-x-ios-floor`）し、
+  **text スロットをスケール参照へ**。**`brightness` / `opacity` は例外**と README に明記
+  （**段を持てる種類の値ではない**）
+- **`FormField` の hint / error にスロット**（#389 の残り。サイズと色）
+
+🔴 **`--text-x-ios-floor: 16px` は意匠の段ではない。** iOS Safari の挙動という**物理的な制約**なので
+スケール層に置き、スロットから参照する（「スロットはスケール参照だけ」を保ったまま扱うため）。
+
 ### `@hideyukimori/nene2-ui` 0.5.0（**minor — 選択系のラベル側とページ送りの2モデル**・#336）
 
 **vault が Tailwind クラスと CSS の両方で測った結果**に基づく（片方だけ見て4回過小を出した反省から、両形式で取ってもらったもの）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -191,8 +191,22 @@ A slot can hold several steps — four-sided padding is just CSS:
 🔴 **There is no shorthand for this, on purpose.** The kit's tokens are written by tooling,
 not typed by hand, so brevity buys nothing — and a shorthand would need an expander, which is
 one more layer that can quietly drop meaning. Plain `var()` composition has no such layer, and
-it can be checked with a regular expression exactly as written: **every value in a slot is a
-`var(--spacing-*)` or `var(--radius-*)`, and nothing else.**
+it can be checked with a regular expression exactly as written.
+
+### What the rule covers
+
+| namespace                             | slot values                  | why                                                                                                                                                                                   |
+| ------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--spacing-*` `--radius-*` `--text-*` | 🔒 **scale references only** | each has a scale, so a literal here is a step the product invented                                                                                                                    |
+| `--color-*`                           | scale (palette) references   | same                                                                                                                                                                                  |
+| `--brightness-*` `--opacity-*`        | literals are fine            | **there is no scale to reference.** A hover darkening of 95% is not a step in a series; inventing a "brightness scale" so the rule could cover it would be a scale with one real user |
+
+🔴 **Check the three namespaces that have scales, not every slot.** Until 0.6.0 this section
+said "and nothing else", while the kit's own theme held `--text-x-slot-field-label-size:
+0.75rem` and `--brightness-x-slot-hover: 95%` — so a product implementing the rule as written
+built a check that failed the kit (nene-vault did exactly that, 2026-08-23). The type scale
+now exists and the text slots reference it; brightness is stated as the exception it always
+was.
 
 That check is what keeps the scale from leaking. `--spacing-x-slot-field-gap: 0.5625rem`
 compiles, looks reasonable, and reintroduces the drift the scale exists to stop — so it fails

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/feedback/InlineAlert.tsx
+++ b/packages/nene2-ui/src/feedback/InlineAlert.tsx
@@ -8,16 +8,18 @@ export interface InlineAlertProps {
 }
 
 const TONE_CLASS: Record<NonNullable<InlineAlertProps['tone']>, string> = {
-  info: 'bg-surface text-text-primary border-border',
-  // `warn` reuses the danger colour deliberately: the kit's palette has one alert hue, and
-  // inventing a second here would be a design value living outside themes/default.css. What
-  // differs is the urgency it is announced with, which is the part that matters.
-  warn: 'bg-surface text-danger border-danger',
-  danger: 'bg-surface text-danger border-danger',
+  info: 'bg-x-slot-alert-info-bg text-x-slot-alert-info-fg border-x-slot-alert-info-border',
+  warn: 'bg-x-slot-alert-warn-bg text-x-slot-alert-warn-fg border-x-slot-alert-warn-border',
+  danger: 'bg-x-slot-alert-danger-bg text-x-slot-alert-danger-fg border-x-slot-alert-danger-border',
 };
 
 /**
  * A message attached to the thing it is about, rather than to the page.
+ *
+ * 🔴 Each tone reads its colours from the theme, so a product can tell "warning" from
+ * "failure" by sight. Until it sets them, `warn` and `danger` share this palette's single
+ * alert hue and only the announced urgency differs — and as nene-vault put it, that
+ * difference reaches someone listening and no one looking.
  *
  * 🔴 The tone decides the ARIA role, not just the colour. `danger` becomes `role="alert"`,
  * which interrupts a screen reader; `info` becomes `role="status"`, which waits its turn.

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -76,12 +76,19 @@ export function FormField({
         </label>
         {children}
         {hintId === null ? null : (
-          <span id={hintId} className="font-sans text-text-muted">
+          <span
+            id={hintId}
+            className="font-sans text-x-slot-field-hint-size text-x-slot-field-hint"
+          >
             {hint}
           </span>
         )}
         {errorId === null ? null : (
-          <p id={errorId} role="alert" className="font-sans text-danger">
+          <p
+            id={errorId}
+            role="alert"
+            className="font-sans text-x-slot-field-error-size text-x-slot-field-error"
+          >
             {error}
           </p>
         )}

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -16,7 +16,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
   primary: 'bg-accent text-on-accent',
-  secondary: 'bg-surface-raised text-text-primary border border-border',
+  secondary: 'bg-surface-raised text-text-primary border-border',
   danger: 'bg-danger text-on-accent',
   // No fill and no border: for the third action in a row, where two framed buttons would
   // compete with each other. nene-vault ships this variant already.
@@ -28,7 +28,12 @@ const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
   sm: 'px-x-slot-button-sm-pad-x py-x-slot-button-sm-pad-y',
 };
 
-const BASE_CLASS = `rounded-x-slot-button font-sans font-medium ${CLICKABLE_CLASS}`;
+// 🔴 `border border-transparent` is load-bearing. Height comes from the padding, so the
+// `secondary` variant — the only one with a visible border — would otherwise stand 2px
+// taller than the others. nene-vault puts a primary and a secondary side by side in seven
+// modal footers, where that shows up as a step (measured 2026-08-23); its own Button carries
+// the same transparent border for the same reason.
+const BASE_CLASS = `rounded-x-slot-button border border-transparent font-sans font-medium ${CLICKABLE_CLASS}`;
 
 export function Button({
   variant = 'primary',

--- a/packages/nene2-ui/src/primitives/pointer.test.tsx
+++ b/packages/nene2-ui/src/primitives/pointer.test.tsx
@@ -124,10 +124,51 @@ describe('EmptyState alignment', () => {
   });
 });
 
-describe('InlineAlert warn', () => {
-  it('exists, and waits its turn like info rather than interrupting', () => {
+describe('InlineAlert tones', () => {
+  it('warn waits its turn like info rather than interrupting', () => {
     const el = render(<InlineAlert tone="warn">x</InlineAlert>).container.firstElementChild;
     expect(el?.getAttribute('role')).toBe('status');
-    expect(classesOf(el)).toContain('text-danger');
+  });
+
+  it.each(['info', 'warn', 'danger'] as const)(
+    '%s reads its colours from the theme, so a product can tell them apart by sight',
+    (tone) => {
+      // 🔴 0.5.0 では warn と danger が**文字列まで完全に同一**だった。role は分かれていたが、
+      // vault の指摘どおり「role の違いは聞こえる人には届き、見ている人には届かない」。
+      const cls = classesOf(
+        render(<InlineAlert tone={tone}>x</InlineAlert>).container.firstElementChild,
+      );
+      expect(cls).toEqual(
+        expect.arrayContaining([
+          `bg-x-slot-alert-${tone}-bg`,
+          `text-x-slot-alert-${tone}-fg`,
+          `border-x-slot-alert-${tone}-border`,
+        ]),
+      );
+    },
+  );
+
+  it('gives warn and danger different slots, even where the defaults match', () => {
+    const warn = classesOf(
+      render(<InlineAlert tone="warn">x</InlineAlert>).container.firstElementChild,
+    );
+    const danger = classesOf(
+      render(<InlineAlert tone="danger">x</InlineAlert>).container.firstElementChild,
+    );
+    expect(warn).not.toEqual(danger);
+  });
+});
+
+describe('Button height', () => {
+  it('reserves the border on every variant, so a row of them lines up', () => {
+    // 🔴 高さは padding 由来。border を持つのが secondary だけだと、上下 1px ずつ増えて
+    // 他 variant より 2px 高くなる。vault はモーダルのフッター7箇所で primary と secondary を
+    // 横に並べており、そこに段差が出る（2026-08-23 実測）。
+    for (const variant of ['primary', 'secondary', 'danger', 'ghost'] as const) {
+      const cls = classesOf(
+        render(<Button variant={variant}>x</Button>).container.querySelector('button'),
+      );
+      expect(cls, `${variant} must reserve the border`).toContain('border');
+    }
   });
 });

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -109,6 +109,8 @@ describe('the override boundary', () => {
     expect(section, 'must say the scale is not').toMatch(/The scale — 🔒 do not redefine/);
     expect(section).toContain('--spacing-x-slot-card-pad');
     expect(section).toContain('--spacing-x-3xs');
+    // 🔴 規則の射程を書いていないと、艦がキット本体を落とす検査を作る（vault が実際に踏んだ）。
+    expect(section, 'must name the namespaces the rule covers').toMatch(/--brightness-\*/);
   });
 });
 
@@ -138,13 +140,24 @@ describe('the two token layers', () => {
     // than matching one whole `var(...)` — is only possible because the kit deliberately has
     // no shorthand syntax: plain CSS `var()` composition is directly greppable, while a
     // shorthand would need an expander before it could be inspected at all.
-    const slots = [...theme.matchAll(/--(?:spacing|radius)-x-slot-[a-z0-9-]+:\s*([^;]+);/g)];
-    expect(slots.length).toBeGreaterThan(20);
+    // Covers the namespaces that have a scale. `--brightness-*` and `--opacity-*` hold
+    // literals because there is nothing to reference — stated in the README as the exception.
+    const scaled = '(?:spacing|radius|text|color)';
+    const slots = [
+      ...theme.matchAll(new RegExp(`--${scaled}-x-slot-[a-z0-9-]+:\\s*([^;]+);`, 'g')),
+    ];
+    expect(slots.length).toBeGreaterThan(30);
     for (const [, raw] of slots) {
       const value = raw!.trim();
-      const refs = [...value.matchAll(/var\(--(?:spacing|radius)-x-[a-z0-9-]+\)/g)];
-      expect(refs.length, `slot must reference the scale: ${value}`).toBeGreaterThan(0);
-      const remainder = value.replace(/var\(--(?:spacing|radius)-x-[a-z0-9-]+\)/g, '').trim();
+      // The palette has no `x-` segment (`--color-accent`), the dimensional scales do
+      // (`--spacing-x-md`). Both count as references.
+      const refPattern = /var\(--(?:spacing|radius|text)-x-[a-z0-9-]+\)|var\(--color-[a-z0-9-]+\)/g;
+      expect(
+        [...value.matchAll(refPattern)].length,
+        `slot must reference a scale: ${value}`,
+      ).toBeGreaterThan(0);
+      // `max(...)` and friends are allowed to wrap references; bare lengths are not.
+      const remainder = value.replace(refPattern, '').replace(/[a-z]*\(|\)|,|\s/g, '');
       expect(remainder, `slot contains a literal outside the scale: ${value}`).toBe('');
     }
   });

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -38,6 +38,22 @@
    * focused input is under 16px, and a product whose body text is 14px would inherit that.
    * Keeping a control readable is the control's job, not the product's. */
 
+  /* The type scale. Six steps, from what the fleet actually writes (measured 2026-08-23):
+   * nene-records uses `sm` 65 times and `xs` 40, nene-field `sm` 59 / `xs` 57 / `base` 21 /
+   * `lg` 13, nene-vault `2xs` 33. Nothing above `xl` recurs.
+   *
+   * 🔴 `--text-x-ios-floor` is not a design step and products should not use it as one. It
+   * is here because iOS Safari zooms the page when a focused control is under 16px, which is
+   * a fact about the device rather than a decision about the product. Slots reference it so
+   * that the rule "a slot contains only scale references" stays true. */
+  --text-x-2xs: 0.6875rem;
+  --text-x-xs: 0.75rem;
+  --text-x-sm: 0.875rem;
+  --text-x-md: 1rem;
+  --text-x-lg: 1.125rem;
+  --text-x-xl: 1.5rem;
+  --text-x-ios-floor: 16px;
+
   /* ─────────────────────────────────────────────────────────────────────────
    * ② SLOTS — a product may redefine these.
    *
@@ -100,10 +116,30 @@
   --brightness-x-slot-press: 90%;
 
   --color-x-slot-choice-accent: var(--color-accent);
+
+  /* Alert colours. `warn` defaults to the same hue as `danger` because this palette has one
+   * alert colour — a second one is a decision a product makes, not something the kit can
+   * invent. Until a product sets these, "warning" and "failure" look alike, and only the
+   * announced urgency differs: role="status" against role="alert". That difference reaches
+   * someone listening and no one looking (nene-vault, 2026-08-23), which is why the slots
+   * exist rather than the tones being hard-coded. */
+  --color-x-slot-alert-info-bg: var(--color-surface);
+  --color-x-slot-alert-info-fg: var(--color-text-primary);
+  --color-x-slot-alert-info-border: var(--color-border);
+  --color-x-slot-alert-warn-bg: var(--color-surface);
+  --color-x-slot-alert-warn-fg: var(--color-danger);
+  --color-x-slot-alert-warn-border: var(--color-danger);
+  --color-x-slot-alert-danger-bg: var(--color-surface);
+  --color-x-slot-alert-danger-fg: var(--color-danger);
+  --color-x-slot-alert-danger-border: var(--color-danger);
   --color-x-slot-field-label: var(--color-text-muted);
-  --text-x-slot-field-label-size: 0.75rem;
+  --color-x-slot-field-hint: var(--color-text-muted);
+  --text-x-slot-field-hint-size: var(--text-x-2xs);
+  --color-x-slot-field-error: var(--color-danger);
+  --text-x-slot-field-error-size: var(--text-x-2xs);
+  --text-x-slot-field-label-size: var(--text-x-xs);
   --font-weight-x-slot-field-label: 500;
-  --text-x-slot-control-size: max(1rem, 16px);
+  --text-x-slot-control-size: max(var(--text-x-md), var(--text-x-ios-floor));
 
   /* Sentinel for the consumer's build (#316). Zero-width, so applying it does nothing.
    * Its only job is to exist: `p-x-source-probe` appears nowhere except this kit's `dist`,


### PR DESCRIPTION
Closes #338

vault の波2（PR #391）からの上流3件 ＋ #389 の残り。**全部自艦で再測して確認済み**です。

## 🔴 ① `Button` の `secondary` だけ 2px 高かった

高さは padding 由来で、**border を持つのが `secondary` だけ**でした。

⇒ **BASE に `border border-transparent`**（vault の自前実装が同じ形で避けていました）。

vault は**モーダルのフッター7箇所で primary と secondary を横に並べています** ⇒ **段差が出ていました**。**全艦に効きます。**

## 🔴 ② `InlineAlert` の `warn` と `danger` が文字列まで完全に同一だった

`role` は分かれていました（`status` / `alert`）が、vault の一文が核です：

> **role の違いは聞こえる人には届くが、見ている人には届かない。**

🔴 キットには **alert の色スロットがありませんでした**（radius と padding のスロットはあるのに**色だけ無い**）⇒ **テーマから再現できず、載せ替えると6箇所で「警告」と「失敗」が見分けられなくなります**。

⇒ **`--color-x-slot-alert-{info,warn,danger}-{bg,fg,border}` を9本**追加。**既定は現状のまま**なので、上書きしない艦には何も起きません。

キットの既定で warn と danger が同色なのは、**このパレットにアラート色が1つしかない**ためです —— **2つ目は製品が決めること**で、キットが発明するものではありません。だから**ハードコードではなくスロット**にしました。

## 🔴 ③ README の規則とキットのテーマが食い違っていた（**自分の README に反する4件目**）

vault が README の「products: apply the same check to your own theme」を実装したところ、**キット本体が落ちました**（`--text-x-slot-field-label-size: 0.75rem` ／ `--brightness-x-slot-hover: 95%`）。

⇒ **次の艦が README どおりに書くと、キットを落とす検査を作ります。**

**(b) 規則に実装を合わせる**を採りました：

| | |
|---|---|
| **型スケールを新設** | `--text-x-2xs` … `--text-x-xl`。艦の実測から6段（records `sm` 65 / `xs` 40・field `sm` 59 / `xs` 57 / `base` 21 / `lg` 13・vault `2xs` 33） |
| text スロット | **スケール参照へ** |
| 🔴 `--text-x-ios-floor: 16px` | **意匠の段ではなく物理的な制約**（iOS Safari の挙動）。スケール層に置き、スロットから参照する — 「**スロットはスケール参照だけ**」を保つため |
| `brightness` / `opacity` | **例外**と README に明記 — **段を持てる種類の値ではない**（brightness の「スケール」を発明すると、**利用者が1人のスケール**になる） |

## ④ `FormField` の hint / error にスロット（#389 の残り）

サイズと色。③ の型スケールに乗せました。

## 検証

- `npm run check` 全項目 PASS（46 files / **692 tests**）／版 **0.6.0**・lock 追随
- Tailwind 4.3.2 で**部品が使うスロットクラス54種すべてが CSS を生成**（欠落 0）
- **陽性対照3種**（いずれも赤→復旧）:
  1. text スロットに直値を戻す（= 0.5.0 の形）
  2. `Button` の `border-transparent` を外す（`secondary` が 2px 高くなる形）
  3. `warn` と `danger` を同一へ戻す（新テストが両者の差を要求）
