### PR TITLE
feat(ui) 0.7.0: max() は「今どう指されているか」を問えない — iOS のフロアがデスクトップにも当たっていた（#344）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -150,6 +150,39 @@ publish 手順は「2回目以降（GitHub Actions）」（下記）。dry_run �
 nene-payout の `shared/ui` から10部品を昇格（新規設計ゼロ）＋ `cx()` 是正。
 Button / Input / Select / Spinner / Text / PageHeader / FormField / EmptyState / ErrorState / DetailList。
 
+### `@hideyukimori/nene2-ui` 0.7.0（**minor — コントロールの文字サイズを2段に**・#344）
+
+🔴 **既存の見た目が変わる**（0.6.0 は**デスクトップの入力欄も 16px** にしていた）。
+
+施主が実機で発見（2026-08-23）:
+
+> **InputField のフォントサイズと padding が違う気がする。**
+
+0.6.0 は `--text-x-slot-control-size: max(var(--text-x-md), var(--text-x-ios-floor))`。
+🔴 **`max()` は「今どう指されているか」を問えない**ので、**本文 14px の艦でもデスクトップの入力欄が
+16px** になり、周囲より大きく見えていた。
+
+⇒ **スロットを2本に割り、条件は部品が持つ**:
+
+```
+--text-x-slot-control-size: var(--text-x-md)               通常。艦が自由に上書き
+--text-x-slot-control-touch-size: var(--text-x-ios-floor)  タッチ端末のフロア
+```
+
+部品: `text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size`
+
+🔑 **幅ではなくポインタで分ける。** iOS のズームは**タッチ端末の挙動**なので、
+**横向きの iPad のような「広いタッチ端末」も拾う**必要がある。
+
+🔴 **艦側では解けなかった**（vault が両方の壁に実際にぶつかって確認）——
+`themes/*.css` は `@media` 禁止（AM-9 token-only）／`base.css` は custom property 禁止
+（ST-08 element-only）で、**意図的に排他かつ網羅**。かつ**キットは `@layer utilities` で当てるので
+`@layer base` は詳細度に関係なく負ける**。⇒ **キットが表現するしかない。**
+
+⚠️ **引き換えに、フロアがスロットになった＝艦が下げられる。** ⇒ README に
+**「このスロットは端末の制約であって意匠ではない」**と明記し、**キットの既定が `--text-x-ios-floor`
+を指していることをテストで固定**した。
+
 ### `@hideyukimori/nene2-ui` 0.6.0（**minor — alert の色・型スケール・Button の高さ**・#338）
 
 vault の波2（PR #391）からの上流3件 ＋ #389 の残り。**全部自艦で再測して確認済み。**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -179,6 +179,24 @@ own ends.
 
 🔑 **The scale is the set you keep to. The slots are what your brand looks like.**
 
+### 🔴 One slot is not yours to tune
+
+`--text-x-slot-control-touch-size` is a **device constraint, not a design choice**. iOS Safari
+zooms the whole page when a focused control is under 16px, so lowering this brings that back.
+
+It is a slot at all only because the kit cannot know your rem base — not because the value is
+open. Set `--text-x-slot-control-size` to whatever suits your body text; leave the touch one
+pointing at `--text-x-ios-floor`.
+
+Until 0.7.0 the kit wrote this as `max(var(--text-x-md), var(--text-x-ios-floor))`, which is
+the same idea expressed in a way that cannot work: `max()` picks the larger number and cannot
+ask what kind of device it is on, so every desktop control was pushed to 16px too — visibly
+larger than the text beside it in any product whose body is 14px. The two slots split that
+into "the size you chose" and "the floor the device imposes", and the components apply the
+second only under `@media (pointer: coarse)`.
+
+🔑 **Pointer, not width.** An iPad in landscape is wide and still zooms.
+
 ### Composing a slot
 
 A slot can hold several steps — four-sided padding is just CSS:

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -251,6 +251,13 @@ describe('control font size', () => {
     // ページごと拡大する。旧実装は 16px を持っていた。トークンの値は max(1rem, 16px)。
     const { container } = render(control);
     const el = container.querySelector('input, select, textarea');
-    expect((el?.getAttribute('class') ?? '').split(/\s+/)).toContain('text-x-slot-control-size');
+    const cls = (el?.getAttribute('class') ?? '').split(/\s+/);
+    // 🔴 二段。`max()` は「今どう指されているか」を問えないので、0.6.0 は
+    // **デスクトップにも 16px を当てていた**（本文 14px の艦で入力欄だけ大きく見える）。
+    expect(cls).toContain('text-x-slot-control-size');
+    expect(cls).toContain('pointer-coarse:text-x-slot-control-touch-size');
+    // 幅ではなくポインタで分ける: iOS のズームは**タッチ端末の挙動**なので、
+    // 横向きの iPad のような「広いタッチ端末」も拾う必要がある。
+    for (const c of cls) expect(c).not.toMatch(/^max-(sm|md):text-x-slot-control/);
   });
 });

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
 
 /**
  * Text input primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -7,7 +7,7 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children: ReactNode;
 }
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size text-text-primary ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-text-primary ${CONTROL_CLASS}`;
 
 /**
  * Select primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Textarea.tsx
+++ b/packages/nene2-ui/src/primitives/Textarea.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
 
 /**
  * Multi-line text input. Deliberately identical to `Input` apart from the element, so the

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -178,3 +178,19 @@ describe('the two token layers', () => {
     expect(offenders, `components must use slots, not the scale directly`).toEqual([]);
   });
 });
+
+describe('the touch floor', () => {
+  const theme = readFileSync(path.join(root, 'themes/default.css'), 'utf8');
+
+  it('keeps the touch size on the iOS floor, not on a design step', () => {
+    // 🔴 `max()` を外した引き換えに、フロアがスロットになった＝艦が下げられる。
+    // 下げるとページごと拡大が戻るので、キットの既定が floor を指していることを固定する。
+    expect(theme).toMatch(/--text-x-slot-control-touch-size:\s*var\(--text-x-ios-floor\)/);
+  });
+
+  it('says the touch slot is a device constraint, not a design choice', () => {
+    const readmeSaysSo = /device constraint, not a design choice/.test(readme);
+    const themeSaysSo = /device constraint, not a design choice/.test(theme);
+    expect(readmeSaysSo || themeSaysSo).toBe(true);
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -139,7 +139,18 @@
   --text-x-slot-field-error-size: var(--text-x-2xs);
   --text-x-slot-field-label-size: var(--text-x-xs);
   --font-weight-x-slot-field-label: 500;
-  --text-x-slot-control-size: max(var(--text-x-md), var(--text-x-ios-floor));
+  /* Control text. Two slots, because one value cannot answer "how is this being pointed at".
+   *
+   * 0.6.0 used `max(var(--text-x-md), var(--text-x-ios-floor))`, which raised every control
+   * to 16px — including on a desktop whose body text is 14px, where the inputs then look
+   * oversized next to everything else (found by hide on a real screen, 2026-08-23). `max()`
+   * cannot ask what kind of device it is on; it only ever picks the larger number.
+   *
+   * 🔴 The touch slot is a device constraint, not a design choice. iOS Safari zooms the whole
+   * page when a focused control is under 16px, so lowering it re-introduces that. It is a slot
+   * only because the kit cannot know a product's rem base — not because it is yours to tune. */
+  --text-x-slot-control-size: var(--text-x-md);
+  --text-x-slot-control-touch-size: var(--text-x-ios-floor);
 
   /* Sentinel for the consumer's build (#316). Zero-width, so applying it does nothing.
    * Its only job is to exist: `p-x-source-probe` appears nowhere except this kit's `dist`,


### PR DESCRIPTION
Closes #344

施主が実機で発見（2026-08-23）:

> **InputField のフォントサイズと padding が違う気がする。これも指定できるようにできる？**

padding は vault がスロットで解決済み。**font-size が解けませんでした。**

## 🔴 `max()` は「今どう指されているか」を問えない

```css
--text-x-slot-control-size: max(var(--text-x-md), var(--text-x-ios-floor));
                               /* 1rem */        /* 16px */
```

**`--text-x-ios-floor` の判断自体は正しい**（iOS Safari は 16px 未満の入力にフォーカスするとページごと拡大する）。🔴 **表現の仕方が足りませんでした** —— `max()` は**大きい方を選ぶだけ**で、**幅もポインタも問えません**。⇒ 本文 14px の艦でも**デスクトップの入力欄が 16px** になり、**周囲より大きく見えていました**。

## 直し方 — スロットを2本に割り、条件は部品が持つ

```css
--text-x-slot-control-size: var(--text-x-md)               /* 通常。艦が自由に上書き */
--text-x-slot-control-touch-size: var(--text-x-ios-floor)  /* タッチ端末のフロア */
```

部品: `text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size`

🔑 **幅（`max-sm`）ではなくポインタ（`pointer-coarse`）で分けます。** iOS のズームは**タッチ端末の挙動**であって幅の問題ではないので、**横向きの iPad のような「広いタッチ端末」**も拾う必要があります。

## 🔴 艦側では解けませんでした

vault が**両方の壁に実際にぶつかって**確認しています:

| ファイル | 許可 | 禁止 |
|---|---|---|
| `themes/*.css` | custom property | 🔴 **`@media`**（AM-9 token-only） |
| `base.css` | element 規則・`@media` | 🔴 **custom property**（ST-08 element-only） |

`nene2-standards` の実装に「**AM-9 token-only の双対**」と明記されており、**意図的に排他かつ網羅**です。かつ**キットは `@layer utilities` で当てるので `@layer base` は詳細度に関係なく負けます**。⇒ **キットが表現するしかない。**

⚠️ **vault が規約の抜け道を探さずに上流へ回した**のが正しい判断でした。抜け道を作っていたら、今日ずっと潰してきた形が1つ増えていました。

## ⚠️ 引き換えに増えた逃げ道

`max()` を外すと、**フロアがスロットになる＝艦が下げられます**（下げるとズームが戻る）。

⇒ README に「**このスロットは端末の制約であって意匠ではない**」と明記し、**キットの既定が `--text-x-ios-floor` を指していることをテストで固定**しました。

## 🔴 vault だけの話ではありません

**本文が 16px 未満の艦は全部同じことが起きます**（実測: records `text-sm` 65 / field `text-sm` 59 / vault `text-2xs` 33）。

## 検証

- `npm run check` 全項目 PASS（46 files / **695 tests**）／版 **0.7.0**・lock 追随
- Tailwind 4.3.2 で `pointer-coarse:` が `@media (pointer: coarse)` へ解決することを実測
- **陽性対照3種**（`max()` へ戻す ／ フロアを意匠の段へ下げる ／ 幅で分ける形へ戻す）
