### PR TITLE
chore(fleet-baseline): nene2-ui の floor を ^0.7.0 へ — vault の iOS ズーム回帰が解ける（#346）

### DIFF
--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -6,6 +6,6 @@
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.1.1",
     "@hideyukimori/nene2-i18n": "^0.3.0",
-    "@hideyukimori/nene2-ui": "^0.6.0"
+    "@hideyukimori/nene2-ui": "^0.7.0"
   }
 }


### PR DESCRIPTION
Closes #346

| | |
|---|---|
| npm の latest | 🟢 **0.7.0**（`shasum 4e84072d…`・provenance 付き） |
| 現在の floor | `^0.6.0` |
| `semver.satisfies('0.7.0','^0.6.0')` | 🔴 **false** |

## 🔴 vault はいま回帰を抱えています

0.6.0 の `max(var(--text-x-md), var(--text-x-ios-floor))` は**デスクトップにも 16px を当てる**ため、vault は `var(--text-x-sm)` で上書きしました。⇒ **デスクトップの見た目は戻りましたが、モバイルの iOS ズーム対策が外れたまま**です。

**0.7.0 でスロットが2本に割れた**ので、**vault は上書きを外せば両方成立**します。⇒ **floor を上げないと 0.7.0 を floor 上で使えません。**

## 🔴 vault だけではありません

本文が 16px 未満の艦は全部同じことが起きます〔実測: records `text-sm` 65 / field `text-sm` 59 / vault `text-2xs` 33〕。**W1 の他艦へ配る前に必要です。**

## 既存3本の floor は触りません

**#271 で据え置きと裁定済み。**