### PR TITLE
chore(fleet-baseline): nene2-ui の floor を ^0.8.0 へ — ^0.7.0 は 0.8.0 を除外する（#350）

### DIFF
--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -6,6 +6,6 @@
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.1.1",
     "@hideyukimori/nene2-i18n": "^0.3.0",
-    "@hideyukimori/nene2-ui": "^0.7.0"
+    "@hideyukimori/nene2-ui": "^0.8.0"
   }
 }


### PR DESCRIPTION
Closes #350

`@hideyukimori/nene2-ui@0.8.0` publish 済み（2026-08-23 13:05 UTC・**provenance 署名つき**・sigstore logIndex 2571614762）。`latest` も 0.8.0。

## 🔴 上げないと 0.8.0 は誰にも届かない

**pre-1.0 の caret は minor を固定する**（`^0.7.0` ≡ `>=0.7.0 <0.8.0`）。⇒ **`^0.7.0` は 0.8.0 を「まだ入っていない」のではなく、積極的に除外する。**

## #347 とは理由が違う

| | |
|---|---|
| **#347（`^0.7.0`）** | **回帰の解消** — vault の iOS ズームが 0.7.0 でしか直らなかった |
| **本PR（`^0.8.0`）** | **選択肢の保証** — 0.8.0 は既定の見た目を変えないので、**上げないと壊れる艦は無い** |

⇒ 上げる意味は「**radius の段を選び直せる状態を、フリートの下限として保証する**」こと。**vault は今まさにそれを待っている**（(b) の形を書いて施主に止められ、退避済み・8px のまま待機）。

## 実測

- 差分は1行（`^0.7.0` → `^0.8.0`）
- `npm run check` 緑（46ファイル / 700テスト）
- `npm view @hideyukimori/nene2-ui version` = `0.8.0`（レジストリ実測）

## ⚠️ この PR で閉じない穴（別 Issue にします）

`docs/fleet-baseline.test.ts` は**スキーマの形しか見ていない** — floor が**実在する版を指しているか**は検査していない。`^0.9.0`（未 publish）を書いても緑になる。

このリポは `nene2-ui` を自分で publish しているので、**ワークスペースの `package.json` の版と突き合わせればネット無しで検査できる**。⇒ **1PR=1論点なので、ここでは入れず別に立てます。**