### PR TITLE
feat(ui) 0.9.0: 色・字重・型段をすべてスロット経由へ — 「Every design value comes from a slot」が26部品で偽だった（#353）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -193,11 +193,11 @@ into `0`, because 2px is a 2px error — but nene-records ships nine themes at 0
 2–3px as separate product themes, so that error deletes a distinction rather than rounding
 one.
 
-| radius scale                | exact match | within 2px | designed values collapsed |
-| --------------------------- | ----------: | ---------: | ------------------------: |
-| **the kit's nine + pill**   |   **69.9%** |  **97.7%** |          **3** (all 1px apart) |
+| radius scale                 | exact match | within 2px | designed values collapsed |
+| ---------------------------- | ----------: | ---------: | ------------------------: |
+| **the kit's nine + pill**    |   **69.9%** |  **97.7%** |     **3** (all 1px apart) |
 | eight, without a `10px` step |       64.3% |      97.7% |                         4 |
-| seven, without `2px`        |       43.2% |      97.7% |                         4 |
+| seven, without `2px`         |       43.2% |      97.7% |                         4 |
 
 🔑 **A scale is judged by what it can still tell apart, not only by how far it moves things.**
 
@@ -242,6 +242,23 @@ it can be checked with a regular expression exactly as written.
 | `--spacing-*` `--radius-*` `--text-*` | 🔒 **scale references only** | each has a scale, so a literal here is a step the product invented                                                                                                                    |
 | `--color-*`                           | scale (palette) references   | same                                                                                                                                                                                  |
 | `--brightness-*` `--opacity-*`        | literals are fine            | **there is no scale to reference.** A hover darkening of 95% is not a step in a series; inventing a "brightness scale" so the rule could cover it would be a scale with one real user |
+
+### 🔴 What a slot check must cover
+
+The rule above — _every design value a component uses comes from a slot_ — was false in 26 of
+28 components until 0.9.0, and the check meant to enforce it was green throughout. It listed
+the utility prefixes it knew about (`p px py … rounded`), so **colour and weight were never
+inspected**: 59 palette reaches across 20 files, plus four inline `font-medium`.
+
+It surfaced when nene-vault compared its production screens against the migrated build in a
+real browser — Playwright, computed styles, element by element (2026-08-23). 73 elements
+matched and 21 differed, and **every difference was inside a kit component**; the product's
+own markup matched on every property. A product cannot make its controls darker than its body
+text while the component writes `text-text-primary` itself.
+
+🔑 **A check written as an enumeration passes everything the enumeration omits.** So the
+colour half of that check is not enumerated: it reads the palette out of the theme. A colour
+added tomorrow is covered today.
 
 🔴 **Check the three namespaces that have scales, not every slot.** Until 0.6.0 this section
 said "and nothing else", while the kit's own theme held `--text-x-slot-field-label-size:

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/data/DataTable.tsx
+++ b/packages/nene2-ui/src/data/DataTable.tsx
@@ -34,7 +34,7 @@ export interface DataTableProps<Row> {
  */
 export function DataTable<Row>({ columns, rows, rowKey, caption }: DataTableProps<Row>) {
   return (
-    <table className="w-full border-collapse font-sans text-text-primary">
+    <table className="w-full border-collapse font-sans text-x-slot-table-fg">
       <caption className="sr-only">{caption}</caption>
       <thead>
         <tr>
@@ -42,7 +42,7 @@ export function DataTable<Row>({ columns, rows, rowKey, caption }: DataTableProp
             <th
               key={col.key}
               scope="col"
-              className={`border-b border-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y font-medium text-text-muted ${
+              className={`border-b border-x-slot-table-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y font-x-slot-table-header text-x-slot-table-header-fg ${
                 col.align === 'end' ? 'text-right' : 'text-left'
               }`}
             >
@@ -57,7 +57,7 @@ export function DataTable<Row>({ columns, rows, rowKey, caption }: DataTableProp
             {columns.map((col) => (
               <td
                 key={col.key}
-                className={`border-b border-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y ${
+                className={`border-b border-x-slot-table-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y ${
                   col.align === 'end' ? 'text-right' : 'text-left'
                 }`}
               >

--- a/packages/nene2-ui/src/data/DetailList.tsx
+++ b/packages/nene2-ui/src/data/DetailList.tsx
@@ -23,10 +23,12 @@ export function DetailList({ rows, className }: DetailListProps) {
       {rows.map((row) => (
         <div
           key={row.label}
-          className="flex flex-col gap-x-slot-detail-row-gap border-b border-border py-x-slot-detail-row-pad-y"
+          className="flex flex-col gap-x-slot-detail-row-gap border-b border-x-slot-detail-border py-x-slot-detail-row-pad-y"
         >
-          <dt className="font-sans font-medium text-text-muted">{row.label}</dt>
-          <dd className="font-sans text-text-primary">{row.value}</dd>
+          <dt className="font-sans font-x-slot-detail-term text-x-slot-detail-term-fg">
+            {row.label}
+          </dt>
+          <dd className="font-sans text-x-slot-detail-description-fg">{row.value}</dd>
         </div>
       ))}
     </dl>

--- a/packages/nene2-ui/src/data/Pagination.tsx
+++ b/packages/nene2-ui/src/data/Pagination.tsx
@@ -77,7 +77,7 @@ export function Pagination(props: PaginationProps) {
         <Button variant="secondary" disabled={atStart} onClick={goPrev} aria-label={previousLabel}>
           {previousLabel}
         </Button>
-        <span aria-current="page" className="font-sans text-text-muted">
+        <span aria-current="page" className="font-sans text-x-slot-pagination-fg">
           {status}
         </span>
         <Button variant="secondary" disabled={atEnd} onClick={goNext} aria-label={nextLabel}>

--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -8,9 +8,10 @@ export interface BadgeProps {
 }
 
 const TONE_CLASS: Record<NonNullable<BadgeProps['tone']>, string> = {
-  neutral: 'bg-surface text-text-muted border-border',
-  accent: 'bg-accent text-on-accent border-accent',
-  danger: 'bg-danger text-on-accent border-danger',
+  neutral:
+    'bg-x-slot-badge-neutral-bg text-x-slot-badge-neutral-fg border-x-slot-badge-neutral-border',
+  accent: 'bg-x-slot-badge-accent-bg text-x-slot-badge-accent-fg border-x-slot-badge-accent-border',
+  danger: 'bg-x-slot-badge-danger-bg text-x-slot-badge-danger-fg border-x-slot-badge-danger-border',
 };
 
 /**

--- a/packages/nene2-ui/src/feedback/ToastProvider.tsx
+++ b/packages/nene2-ui/src/feedback/ToastProvider.tsx
@@ -27,8 +27,8 @@ export interface ToastProviderProps {
 }
 
 const TONE_CLASS: Record<ToastTone, string> = {
-  info: 'bg-surface-raised text-text-primary border-border',
-  danger: 'bg-surface-raised text-danger border-danger',
+  info: 'bg-x-slot-toast-bg text-x-slot-toast-fg border-x-slot-toast-border',
+  danger: 'bg-x-slot-toast-bg text-x-slot-toast-danger-fg border-x-slot-toast-danger-border',
 };
 
 /**

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -122,7 +122,7 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog {...props} tone="danger" onConfirm={() => {}} onCancel={() => {}} />,
     );
     const confirm = [...container.querySelectorAll('button')].at(-1);
-    expect(confirm?.getAttribute('class')).toContain('bg-danger');
+    expect(confirm?.getAttribute('class')).toContain('bg-x-slot-button-danger-bg');
   });
 
   it('is not destructive-looking by default', () => {
@@ -130,7 +130,7 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog {...props} onConfirm={() => {}} onCancel={() => {}} />,
     );
     const confirm = [...container.querySelectorAll('button')].at(-1);
-    expect(confirm?.getAttribute('class')).toContain('bg-accent');
+    expect(confirm?.getAttribute('class')).toContain('bg-x-slot-button-primary-bg');
   });
 
   it('routes a dismissal to onCancel, never to onConfirm', () => {
@@ -149,13 +149,15 @@ describe('Badge', () => {
   it('takes a meaning, and reads its colour from the theme', () => {
     const { container } = render(<Badge tone="danger">x</Badge>);
     const cls = container.firstElementChild?.getAttribute('class') ?? '';
-    expect(cls).toContain('bg-danger');
+    expect(cls).toContain('bg-x-slot-badge-danger-bg');
     expect(cls).not.toMatch(/#|rgb|\[/);
   });
 
   it('is neutral unless told otherwise', () => {
     const { container } = render(<Badge>x</Badge>);
-    expect(container.firstElementChild?.getAttribute('class')).toContain('text-text-muted');
+    expect(container.firstElementChild?.getAttribute('class')).toContain(
+      'text-x-slot-badge-neutral-fg',
+    );
   });
 });
 

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -70,7 +70,7 @@ export function FormField({
         >
           {label}
           {required && requiredMarker !== undefined && requiredMarker !== null ? (
-            <span className="text-danger">{requiredMarker}</span>
+            <span className="text-x-slot-field-error-fg">{requiredMarker}</span>
           ) : null}
           {labelAdornment}
         </label>

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -103,9 +103,9 @@ describe('Textarea', () => {
     expect(cls).toEqual(
       expect.arrayContaining([
         'focus-visible:outline-2',
-        'focus-visible:outline-text-primary',
+        'focus-visible:outline-x-slot-focus-ring',
         'disabled:opacity-x-disabled',
-        'placeholder:text-text-muted',
+        'placeholder:text-x-slot-control-placeholder',
       ]),
     );
   });

--- a/packages/nene2-ui/src/layout/Card.tsx
+++ b/packages/nene2-ui/src/layout/Card.tsx
@@ -20,7 +20,7 @@ export function Card({ pad = 'sm', gap, raised = false, children, className, ...
   return (
     <div
       className={cx(
-        'flex flex-col bg-surface-raised border border-border rounded-x-slot-card',
+        'flex flex-col bg-x-slot-card-bg border border-x-slot-card-border rounded-x-slot-card',
         raised && 'shadow-sm',
         resolve(pad, PAD),
         resolve(gap, GAP),

--- a/packages/nene2-ui/src/layout/PageHeader.tsx
+++ b/packages/nene2-ui/src/layout/PageHeader.tsx
@@ -14,7 +14,7 @@ export function PageHeader({ title, actions, className }: PageHeaderProps) {
     <header
       className={cx('flex items-center justify-between py-x-slot-page-header-pad-y', className)}
     >
-      <h1 className="font-sans font-medium text-text-primary">{title}</h1>
+      <h1 className="font-sans font-x-slot-page-header text-x-slot-page-header-fg">{title}</h1>
       {actions}
     </header>
   );

--- a/packages/nene2-ui/src/layout/layout.test.tsx
+++ b/packages/nene2-ui/src/layout/layout.test.tsx
@@ -130,9 +130,9 @@ describe('Card', () => {
     const { container } = render(<Card>x</Card>);
     expect(classesOf(container.firstElementChild)).toEqual(
       expect.arrayContaining([
-        'bg-surface-raised',
+        'bg-x-slot-card-bg',
         'border',
-        'border-border',
+        'border-x-slot-card-border',
         'rounded-x-slot-card',
       ]),
     );

--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -46,7 +46,7 @@
 
 /** Keyboard focus indicator. Colour comes from the theme, never from a caller. */
 export const FOCUS_CLASS =
-  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-text-primary';
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-x-slot-focus-ring';
 
 /**
  * Disabled appearance. The opacity is a theme token (`--opacity-x-disabled`) because a

--- a/packages/nene2-ui/src/overlay/Modal.tsx
+++ b/packages/nene2-ui/src/overlay/Modal.tsx
@@ -56,8 +56,8 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
       onClose={onClose}
       onCancel={onClose}
       className={cx(
-        'bg-surface-raised text-text-primary border border-border rounded-x-slot-modal',
-        'p-x-slot-modal-pad font-sans backdrop:bg-text-primary/50',
+        'bg-x-slot-modal-bg text-x-slot-modal-fg border border-x-slot-modal-border rounded-x-slot-modal',
+        'p-x-slot-modal-pad font-sans backdrop:bg-x-slot-modal-scrim/50',
       )}
     >
       {children}

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -15,12 +15,13 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
-  primary: 'bg-accent text-on-accent',
-  secondary: 'bg-surface-raised text-text-primary border-border',
-  danger: 'bg-danger text-on-accent',
+  primary: 'bg-x-slot-button-primary-bg text-x-slot-button-primary-fg',
+  secondary:
+    'bg-x-slot-button-secondary-bg text-x-slot-button-secondary-fg border-x-slot-button-secondary-border',
+  danger: 'bg-x-slot-button-danger-bg text-x-slot-button-danger-fg',
   // No fill and no border: for the third action in a row, where two framed buttons would
   // compete with each other. nene-vault ships this variant already.
-  ghost: 'bg-transparent text-text-primary',
+  ghost: 'bg-transparent text-x-slot-button-ghost-fg',
 };
 
 const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
@@ -33,7 +34,7 @@ const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
 // taller than the others. nene-vault puts a primary and a secondary side by side in seven
 // modal footers, where that shows up as a step (measured 2026-08-23); its own Button carries
 // the same transparent border for the same reason.
-const BASE_CLASS = `rounded-x-slot-button border border-transparent font-sans font-medium ${CLICKABLE_CLASS}`;
+const BASE_CLASS = `rounded-x-slot-button border border-transparent font-sans text-x-slot-button-size font-x-slot-button ${CLICKABLE_CLASS}`;
 
 export function Button({
   variant = 'primary',

--- a/packages/nene2-ui/src/primitives/Checkbox.tsx
+++ b/packages/nene2-ui/src/primitives/Checkbox.tsx
@@ -8,7 +8,7 @@ export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement
   label: ReactNode;
 }
 
-const BOX_CLASS = `size-x-slot-choice-box shrink-0 rounded-x-slot-control border border-border accent-x-slot-choice-accent ${CONTROL_CLASS}`;
+const BOX_CLASS = `size-x-slot-choice-box shrink-0 rounded-x-slot-control border border-x-slot-choice-border accent-x-slot-choice-accent ${CONTROL_CLASS}`;
 
 /**
  * A checkbox and its label, as one part.
@@ -40,7 +40,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
   const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return (
-    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-text-primary">
+    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg">
       <input ref={ref} type="checkbox" className={cx(BOX_CLASS, className)} {...wiring} {...rest} />
       {label}
     </label>

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg placeholder:text-x-slot-control-placeholder ${CONTROL_CLASS}`;
 
 /**
  * Text input primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Radio.tsx
+++ b/packages/nene2-ui/src/primitives/Radio.tsx
@@ -9,7 +9,7 @@ export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 
   name: string;
 }
 
-const DOT_CLASS = `size-x-slot-choice-box shrink-0 border border-border accent-x-slot-choice-accent ${CONTROL_CLASS}`;
+const DOT_CLASS = `size-x-slot-choice-box shrink-0 border border-x-slot-choice-border accent-x-slot-choice-accent ${CONTROL_CLASS}`;
 
 /**
  * One option in a radio group, with its label.
@@ -31,7 +31,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   ref,
 ) {
   return (
-    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-text-primary">
+    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg">
       <input ref={ref} type="radio" name={name} className={cx(DOT_CLASS, className)} {...rest} />
       {label}
     </label>

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -7,7 +7,7 @@ export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children: ReactNode;
 }
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-text-primary ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg ${CONTROL_CLASS}`;
 
 /**
  * Select primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Spinner.tsx
+++ b/packages/nene2-ui/src/primitives/Spinner.tsx
@@ -8,7 +8,7 @@ export interface SpinnerProps {
 
 export function Spinner({ label, className }: SpinnerProps) {
   return (
-    <output className={cx('font-sans text-text-muted', className)} aria-live="polite">
+    <output className={cx('font-sans text-x-slot-spinner-fg', className)} aria-live="polite">
       {label}
     </output>
   );

--- a/packages/nene2-ui/src/primitives/Switch.tsx
+++ b/packages/nene2-ui/src/primitives/Switch.tsx
@@ -34,8 +34,10 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch
       aria-label={label}
       onClick={() => onCheckedChange(!checked)}
       className={cx(
-        'inline-flex items-center rounded-x-slot-switch border border-border px-x-slot-switch-pad-x py-x-slot-switch-pad-y font-sans',
-        checked ? 'bg-accent text-on-accent' : 'bg-surface text-text-muted',
+        'inline-flex items-center rounded-x-slot-switch border border-x-slot-switch-border px-x-slot-switch-pad-x py-x-slot-switch-pad-y font-sans',
+        checked
+          ? 'bg-x-slot-switch-on-bg text-x-slot-switch-on-fg'
+          : 'bg-x-slot-switch-off-bg text-x-slot-switch-off-fg',
         CLICKABLE_CLASS,
         className,
       )}

--- a/packages/nene2-ui/src/primitives/Text.tsx
+++ b/packages/nene2-ui/src/primitives/Text.tsx
@@ -12,7 +12,7 @@ export interface TextProps {
 export function Text({ as = 'p', tone = 'primary', children, className }: TextProps) {
   const merged = cx(
     'font-sans',
-    tone === 'muted' ? 'text-text-muted' : 'text-text-primary',
+    tone === 'muted' ? 'text-x-slot-text-muted-fg' : 'text-x-slot-text-fg',
     className,
   );
 

--- a/packages/nene2-ui/src/primitives/Textarea.tsx
+++ b/packages/nene2-ui/src/primitives/Textarea.tsx
@@ -5,7 +5,7 @@ import { useFieldWiring } from '../forms/field-context.js';
 
 export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-border bg-surface-raised px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-text-primary placeholder:text-text-muted ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg placeholder:text-x-slot-control-placeholder ${CONTROL_CLASS}`;
 
 /**
  * Multi-line text input. Deliberately identical to `Input` apart from the element, so the

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -39,7 +39,7 @@ describe.each(CONTROLS)('%s', (_name, mount) => {
       expect.arrayContaining([
         'focus-visible:outline-2',
         'focus-visible:outline-offset-2',
-        'focus-visible:outline-text-primary',
+        'focus-visible:outline-x-slot-focus-ring',
       ]),
     );
   });
@@ -85,7 +85,9 @@ describe.each(CONTROLS)('%s', (_name, mount) => {
 describe('Input', () => {
   it('distinguishes placeholder text from real text', () => {
     const { container } = render(<Input placeholder="name" />);
-    expect(classesOf(container.firstElementChild)).toContain('placeholder:text-text-muted');
+    expect(classesOf(container.firstElementChild)).toContain(
+      'placeholder:text-x-slot-control-placeholder',
+    );
   });
 
   it('passes disabled through to the element, so the styling has something to hook onto', () => {
@@ -103,7 +105,7 @@ describe('Button', () => {
   it('keeps its variant styling alongside the state classes', () => {
     const { container } = render(<Button variant="danger">x</Button>);
     const cls = classesOf(container.firstElementChild);
-    expect(cls).toContain('bg-danger');
+    expect(cls).toContain('bg-x-slot-button-danger-bg');
     expect(cls).toContain('disabled:cursor-not-allowed');
   });
 });

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -149,6 +149,12 @@ describe('the two token layers', () => {
     expect(slots.length).toBeGreaterThan(30);
     for (const [, raw] of slots) {
       const value = raw!.trim();
+      // 🔴 `inherit` is allowed, and only `inherit`. It is not a value the kit invented —
+      // it is the kit declining to have an opinion, in a place a product can now answer.
+      // `Button` and the choice controls set no font-size before 0.9.0, so any step chosen
+      // here would change how every product already renders. See the theme for the case
+      // that made this necessary (nene-vault: 13px buttons against a 14px body).
+      if (value === 'inherit') continue;
       // The palette has no `x-` segment (`--color-accent`), the dimensional scales do
       // (`--spacing-x-md`). Both count as references.
       const refPattern =
@@ -163,6 +169,37 @@ describe('the two token layers', () => {
     }
   });
 
+  /**
+   * Utilities that put a design value on an element without going through a slot.
+   *
+   * Three kinds, deliberately built differently:
+   *  - the dimensional scales, matched by their `x-` namespace (`px-x-md`);
+   *  - the palette, matched by names read out of the theme, so it cannot fall behind;
+   *  - bare literals for weight and size (`font-medium`, `text-sm`).
+   *
+   * `font-sans` is the family — one per theme, nothing to choose — and `text-center` is
+   * alignment, not a design value. Neither is matched.
+   */
+  const palette = [
+    ...readFileSync(path.join(root, 'themes/default.css'), 'utf8').matchAll(
+      /--color-((?!x-)[a-z0-9-]+):/g,
+    ),
+  ].map((m) => m[1]!);
+  const variant =
+    '(?:hover:|active:|focus:|focus-visible:|disabled:|placeholder:|checked:|group-hover:)?';
+  const reachPattern = new RegExp(
+    [
+      // ① a dimensional scale step, reached directly
+      `(?<![\\w-])${variant}(?:p|px|py|pt|pb|pl|pr|gap|m|mt|mb|rounded|size|w|h|max-h|max-w|text|font|shadow)-x-(?!slot-)[a-z0-9-]+`,
+      // ② a palette colour, reached directly
+      `(?<![\\w-])${variant}(?:text|bg|border|accent|outline|ring|fill|stroke|decoration)-(?:${palette.join('|')})(?![a-z0-9-])`,
+      // ③ a literal weight or type step
+      `(?<![\\w-])${variant}font-(?:thin|extralight|light|normal|medium|semibold|bold|extrabold|black)(?![a-z0-9-])`,
+      `(?<![\\w-])${variant}text-(?:xs|sm|base|lg|xl|[2-9]xl)(?![a-z0-9-])`,
+    ].join('|'),
+    'g',
+  );
+
   it('no component reaches past the slots into the scale', () => {
     // 部品がスケールを直接使うと、艦はその部品だけ割り当てを変えられなくなる。
     // 例外は lib/spacing.ts（Stack/Box の gap/pad prop そのもの＝呼び出し側が選ぶ層）。
@@ -170,9 +207,17 @@ describe('the two token layers', () => {
     for (const f of componentSources()) {
       if (f.endsWith('lib/spacing.ts') || f.endsWith('lib/source-probe.ts')) continue;
       const src = readFileSync(f, 'utf8');
-      for (const m of src.matchAll(
-        /(?<![\w-])(?:p|px|py|pt|pb|pl|pr|gap|m|mt|mb|rounded)-x-(?!slot-)[a-z0-9-]+/g,
-      )) {
+      // 🔴 The prefix list is the whole point of failure. Until 0.9.0 it named only the
+      // spacing and radius utilities, so `text-text-primary` and `font-medium` — a colour
+      // and a weight written straight into a component — were never inspected at all. The
+      // rule read "every design value comes from a slot" while 59 of them did not, across
+      // 20 components, and the check was green the entire time.
+      // 🔑 A check written as an enumeration passes everything the enumeration omits.
+      //
+      // So the colour half is not enumerated here at all: the palette is READ FROM THE
+      // THEME. A colour added to the palette tomorrow is covered by this check today,
+      // which is the only version of it that cannot fall behind.
+      for (const m of src.matchAll(reachPattern)) {
         offenders.push(`${path.relative(root, f)}: ${m[0]}`);
       }
     }

--- a/packages/nene2-ui/src/states/EmptyState.tsx
+++ b/packages/nene2-ui/src/states/EmptyState.tsx
@@ -18,7 +18,7 @@ export function EmptyState({ message, align = 'center', className }: EmptyStateP
   return (
     <div
       className={cx(
-        'py-x-slot-state-pad-y font-sans text-text-muted',
+        'py-x-slot-state-pad-y font-sans text-x-slot-empty-state-fg',
         align === 'center' && 'text-center',
         className,
       )}

--- a/packages/nene2-ui/src/states/ErrorState.tsx
+++ b/packages/nene2-ui/src/states/ErrorState.tsx
@@ -14,7 +14,7 @@ export interface ErrorStateProps {
 export function ErrorState({ message, retryLabel, onRetry, className }: ErrorStateProps) {
   return (
     <div className={cx('py-x-slot-state-pad-y', className)} role="alert">
-      <p className="font-sans text-danger">{message}</p>
+      <p className="font-sans text-x-slot-error-state-fg">{message}</p>
       <div className="py-x-slot-state-action-pad-y">
         <Button variant="secondary" onClick={onRetry}>
           {retryLabel}

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -157,6 +157,116 @@
   --text-x-slot-control-size: var(--text-x-md);
   --text-x-slot-control-touch-size: var(--text-x-ios-floor);
 
+  /* ── Colour slots ─────────────────────────────────────────────────────────────
+   * Every colour a component paints comes from here.
+   *
+   * 🔴 Until 0.9.0 only `FormField` and `InlineAlert` had any, and the other 26 components
+   * reached straight into the palette (`text-text-primary`, `bg-surface-raised`) — 59 places
+   * in 20 files. The README said "every design value a component uses comes from a slot"
+   * the whole time. The check that was supposed to enforce it listed the utility prefixes
+   * it knew about — `p px py … rounded` — so colour and weight were never inspected at all.
+   *
+   * Found by nene-vault comparing its production screens against the migrated build in a
+   * real browser (Playwright, computed styles, element by element, 2026-08-23): 73 elements
+   * matched, 21 differed, and every difference was inside a kit component. Its own markup —
+   * side nav, tables, headings — matched on every property. A product cannot make a control
+   * darker than its body text while the kit writes the colour itself.
+   *
+   * Defaults are palette references, so nothing renders differently. What changes is that
+   * there is now an opening. */
+  --color-x-slot-focus-ring: var(--color-text-primary);
+
+  --color-x-slot-button-primary-bg: var(--color-accent);
+  --color-x-slot-button-primary-fg: var(--color-on-accent);
+  --color-x-slot-button-secondary-bg: var(--color-surface-raised);
+  --color-x-slot-button-secondary-fg: var(--color-text-primary);
+  --color-x-slot-button-secondary-border: var(--color-border);
+  --color-x-slot-button-danger-bg: var(--color-danger);
+  --color-x-slot-button-danger-fg: var(--color-on-accent);
+  --color-x-slot-button-ghost-fg: var(--color-text-primary);
+
+  /* Shared by Input, Select and Textarea — they are one control with three shapes, and a
+   * product that darkens one and not the others has a bug, not a design. */
+  --color-x-slot-control-fg: var(--color-text-primary);
+  --color-x-slot-control-bg: var(--color-surface-raised);
+  --color-x-slot-control-border: var(--color-border);
+  --color-x-slot-control-placeholder: var(--color-text-muted);
+
+  --color-x-slot-choice-fg: var(--color-text-primary);
+  --color-x-slot-choice-border: var(--color-border);
+
+  --color-x-slot-switch-on-bg: var(--color-accent);
+  --color-x-slot-switch-on-fg: var(--color-on-accent);
+  --color-x-slot-switch-off-bg: var(--color-surface);
+  --color-x-slot-switch-off-fg: var(--color-text-muted);
+  --color-x-slot-switch-border: var(--color-border);
+
+  --color-x-slot-badge-neutral-bg: var(--color-surface);
+  --color-x-slot-badge-neutral-fg: var(--color-text-muted);
+  --color-x-slot-badge-neutral-border: var(--color-border);
+  --color-x-slot-badge-accent-bg: var(--color-accent);
+  --color-x-slot-badge-accent-fg: var(--color-on-accent);
+  --color-x-slot-badge-accent-border: var(--color-accent);
+  --color-x-slot-badge-danger-bg: var(--color-danger);
+  --color-x-slot-badge-danger-fg: var(--color-on-accent);
+  --color-x-slot-badge-danger-border: var(--color-danger);
+
+  --color-x-slot-toast-bg: var(--color-surface-raised);
+  --color-x-slot-toast-fg: var(--color-text-primary);
+  --color-x-slot-toast-border: var(--color-border);
+  --color-x-slot-toast-danger-fg: var(--color-danger);
+  --color-x-slot-toast-danger-border: var(--color-danger);
+
+  --color-x-slot-card-bg: var(--color-surface-raised);
+  --color-x-slot-card-border: var(--color-border);
+
+  --color-x-slot-modal-bg: var(--color-surface-raised);
+  --color-x-slot-modal-fg: var(--color-text-primary);
+  --color-x-slot-modal-border: var(--color-border);
+  /* The dim behind a modal. A colour, so it belongs here — the opacity that goes with it is
+   * applied by the component, since it is not a palette entry. */
+  --color-x-slot-modal-scrim: var(--color-text-primary);
+
+  --color-x-slot-table-fg: var(--color-text-primary);
+  --color-x-slot-table-header-fg: var(--color-text-muted);
+  --color-x-slot-table-border: var(--color-border);
+
+  --color-x-slot-detail-term-fg: var(--color-text-muted);
+  --color-x-slot-detail-description-fg: var(--color-text-primary);
+  --color-x-slot-detail-border: var(--color-border);
+
+  --color-x-slot-pagination-fg: var(--color-text-muted);
+  --color-x-slot-page-header-fg: var(--color-text-primary);
+  --color-x-slot-text-fg: var(--color-text-primary);
+  --color-x-slot-text-muted-fg: var(--color-text-muted);
+  --color-x-slot-spinner-fg: var(--color-text-muted);
+  --color-x-slot-empty-state-fg: var(--color-text-muted);
+  --color-x-slot-error-state-fg: var(--color-danger);
+  --color-x-slot-field-error-fg: var(--color-danger);
+
+  /* ── Weight slots ─────────────────────────────────────────────────────────────
+   * `font-medium` appeared inline in four components. Same rule, same reason as colour. */
+  --font-weight-x-slot-button: var(--font-weight-medium);
+  --font-weight-x-slot-table-header: var(--font-weight-medium);
+  --font-weight-x-slot-detail-term: var(--font-weight-medium);
+  --font-weight-x-slot-page-header: var(--font-weight-medium);
+
+  /* ── Size slots that decline to choose ────────────────────────────────────────
+   * 🔴 `inherit`, not a step. Button and the choice controls set no font-size today, so
+   * they take the page's — and picking a step here would change how every product already
+   * renders, which is the one thing this release must not do. `inherit` is not a design
+   * value the kit invented; it is the kit saying it has no opinion, in a place a product
+   * can now answer. nene-vault's production buttons are 13px against a 14px body, which is
+   * exactly the distinction that had nowhere to live.
+   *
+   * ⚠️ 13px is not on the type scale (0.6875 / 0.75 / 0.875 / 1 / 1.125 / 1.5rem). The
+   * scale was measured from what the fleet writes in Tailwind classes, which cannot express
+   * a value it has no step for — so that measurement could not have seen it. Recorded here
+   * rather than acted on: changing the type scale is its own decision, with its own
+   * measurement, and it is not this release's. */
+  --text-x-slot-button-size: inherit;
+  --text-x-slot-choice-size: inherit;
+
   /* Sentinel for the consumer's build (#316). Zero-width, so applying it does nothing.
    * Its only job is to exist: `p-x-source-probe` appears nowhere except this kit's `dist`,
    * so a build that generates it has the kit in its `@source`, and a build that does not


### PR DESCRIPTION
Closes #353

## vault が実ブラウザで見つけた

Playwright + Chromium で本番デモとローカルを開き、**計算済みスタイルを要素単位で突合**:

```
一致 73 要素 / 差あり 21 要素
```

🔑 **サイドナビ・テーブル・見出しなど自前 markup は全項目一致。差はすべてキット部品に閉じていた。**

⚠️ **静的解析では出ない差でした。** vault が見落としていた差が3つ、この方法で出ています。

## 🔴 歯抜けは3件ではなく、規則が26部品で偽だった

README §② は **「Every design value a component uses comes from a slot」**。実測（2026-08-23）:

```
パレット直接参照       59箇所 / 20ファイル
font-medium 直書き      4箇所（DataTable / DetailList / PageHeader / Button）
色スロットを持つ部品    FormField と InlineAlert の2つだけ
```

🔴 **パレットは 🔒 ロック**（艦の口は themegen によるファイルごとの差し替え）⇒ **`text-text-primary` を直接書いた部品には、艦が変える口が一切無い。**

## 🔴 なぜ誰も気づかなかったか — 今日3件目の同型

到達検査の正規表現:

```js
/(?:p|px|py|pt|pb|pl|pr|gap|m|mt|mb|rounded)-x-(?!slot-)[a-z0-9-]+/
```

**`text-` も `bg-` も `border-` も `font-` も入っていない。** ⇒ **色と字重は最初から検査対象外。**

| 本日 | 検査 | 主張より狭かった点 |
|---|---|---|
| #296 / #297 | lock ゲート | `npm ci` はワークスペース版ズレを通す |
| #348 | スロット既定 | **知っている名前空間だけ**（`font-weight` が漏れ） |
| **本件** | 部品の到達 | **知っているプレフィクスだけ**（色・字重が漏れ） |

🔑 **列挙で書いた検査は、列挙に無いものを緑にします。**

## ⇒ 検査の色の半分は、列挙をやめました

```js
const palette = [...theme.matchAll(/--color-((?!x-)[a-z0-9-]+):/g)].map(m => m[1]);
```

**パレットをテーマから読みます。** ⇒ **明日パレットに色が増えても、今日の検査が覆う。** 列挙を手で書かなければ、列挙漏れも起きません。

⚠️ 一度**広げすぎて** `text-center`（配置）・`font-sans`（family・テーマに1本しかない）・**スロット自身**まで拾いました。⇒ 3種に分けて精密化: ①スケールの段への直接到達 ②パレット色（テーマ由来）③字重・型段のリテラル。

## 入れたもの

**色スロット48本・字重4本・サイズ2本。** 既定はすべてパレット／スケール参照。

```css
--color-x-slot-focus-ring        --color-x-slot-control-fg / -bg / -border / -placeholder
--color-x-slot-button-*(8)       --color-x-slot-choice-fg / -border
--color-x-slot-switch-*(5)       --color-x-slot-badge-*(9)
--color-x-slot-toast-*(5)        --color-x-slot-modal-*(4)
--color-x-slot-table-*(3)        --color-x-slot-detail-*(3)
--color-x-slot-card-bg / -border  ほか単発7本
--font-weight-x-slot-button / -table-header / -detail-term / -page-header
```

**Input / Select / Textarea は `control` を共有**します——**1つのコントロールの3つの形**であって、片方だけ濃い製品はバグであって意匠ではないので。

## 🔴 `--text-x-slot-button-size: inherit`

**段ではなく `inherit`。** Button と choice は**今 font-size を持っていない**（＝継承）ので、**ここで段を選ぶと全艦の描画が動きます**。それがこのリリースで唯一やってはいけないこと。

`inherit` は**キットが発明した値ではなく、キットが「意見を持たない」と言っている**だけ——**そして製品はそこに答えられるようになります**。スロット既定の検査には `inherit` **だけ**を例外として通しました。

✅ **実測**: Tailwind preflight が `button` に `font: inherit` を当てている（`preflight.css:244`）ので、**preflight 前提で no-op**。⚠️ preflight を切っている消費者では話が変わります。

## ⚠️ 型スケールに 13px が無い（本PRでは触りません）

vault の本番 Button は **13px**（本文14px に対して）。型スケールは `0.6875 / 0.75 / 0.875 / 1 / 1.125 / 1.5rem` で、**13px は段になっていません**。

🔑 **型スケールは「艦が Tailwind クラスで書いているもの」から測ったので、段が無い値は原理的に見えません。** radius で `border-radius` の直書きを数え落としたのと**同じ形**です。

⇒ **記録だけして、触りません。** 型スケールの変更は**それ自身の判断**で、**それ自身の実測**が要ります。

## 実測

- `npm run check` **全ステップ緑**（46ファイル / **700テスト**）
- ⚠️ **テスト件数は増えていません**。今回はガードの射程拡大と既存アサーションの更新なので
- **陽性対照3種**（コミットには含めず、実行して確認）:
  - 色の直書き → `Spinner.tsx: text-text-muted` で発火
  - 字重の直書き → `PageHeader.tsx: font-semibold` で発火
  - 型段の直書き → `Button.tsx: text-sm` で発火
- 既定の見た目は不変（すべて同じパレット項目への間接参照）

## 別 Issue にしたもの（1PR=1論点）

- **#354** — `Checkbox` / `Radio` だけ `className` の着地先が root でない
- **#355** — `Button` が中の svg の寸法を制御していない（＋`<div>`→`<Stack>` の blockify 注意）

## ⚠️ 副次で見つけたが、数えきれなかったもの

`Badge` が `className` を受け取りません（原則2）。**他にも同様の部品がありそうですが、検査の書き方で数字がぶれたので数を報告しません。** 直接読んで確認できたのは `Badge` だけです。