### PR TITLE
fix(ui) 0.10.0: Checkbox / Radio の className を root へ — 欠落ではなく不整合だった（#354）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -243,6 +243,21 @@ it can be checked with a regular expression exactly as written.
 | `--color-*`                           | scale (palette) references   | same                                                                                                                                                                                  |
 | `--brightness-*` `--opacity-*`        | literals are fine            | **there is no scale to reference.** A hover darkening of 95% is not a step in a series; inventing a "brightness scale" so the rule could cover it would be a scale with one real user |
 
+### 🔴 `className` lands on the root
+
+Every component puts the caller's `className` on its **outermost** element. For `Checkbox`
+and `Radio` that root is the `<label>`, not the `<input>` — use `inputClassName` to reach
+the box itself.
+
+Until 0.10.0 those two were the exception, and the exception was invisible: `className` was
+accepted, applied, and landed somewhere the caller could not have wanted. Layout properties
+— `self-start` in a flex row, a width, a margin — belong to the root, so a product had to
+wrap every choice in a `<div>` to say them.
+
+🔑 The kit had already answered a symptom of this in wave 2 (`cursor-pointer` belongs to the
+label, so the kit carries it). That was right and it left the reason in place. **Fixing what
+a report names is not the same as fixing what it is about.**
+
 ### 🔴 What a slot check must cover
 
 The rule above — _every design value a component uses comes from a slot_ — was false in 26 of

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/primitives/Checkbox.tsx
+++ b/packages/nene2-ui/src/primitives/Checkbox.tsx
@@ -6,6 +6,11 @@ import { useFieldWiring } from '../forms/field-context.js';
 export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   /** Localized label. Rendered inside the control's own `<label>`. */
   label: ReactNode;
+  /**
+   * Classes for the `<input>` itself. `className` goes to the `<label>`, which is this
+   * part's root — see the note below.
+   */
+  inputClassName?: string;
 }
 
 const BOX_CLASS = `size-x-slot-choice-box shrink-0 rounded-x-slot-control border border-x-slot-choice-border accent-x-slot-choice-accent ${CONTROL_CLASS}`;
@@ -18,17 +23,28 @@ const BOX_CLASS = `size-x-slot-choice-box shrink-0 rounded-x-slot-control border
  * visible, and loses the ability to click the text to toggle the box, plus the name the
  * control is announced by. Making the label a prop means it cannot be forgotten.
  *
- * 🔴 `cursor-pointer` and the gap live here rather than being left to the caller, because
- * the caller cannot reach them: `className` is forwarded to the `<input>`, and both belong
- * to the `<label>` that wraps it. nene-vault carries them on the label in its own
- * implementation (measured 2026-08-23, checking Tailwind classes and CSS both), so a
- * migration that could not set them would lose the pointer cursor on every choice in the
- * product — visible to a mouse user, invisible in a diff.
+ * 🔴 `className` lands on the `<label>`, which is this part's root — the same place it
+ * lands in every other component the kit ships. Until 0.10.0 it went to the `<input>`
+ * instead, so nothing the caller wrote could reach the root: `self-start` inside a flex
+ * row, a width, a margin. nene-vault had to wrap each choice in a `<div>` to say them
+ * (found while migrating, 2026-08-23). Use `inputClassName` for the box itself.
+ *
+ * 🔑 This is the cause behind a symptom the kit already answered once. In wave 2 the
+ * report was that `cursor-pointer` could not be set, because it belongs to the label; the
+ * kit took `cursor-pointer` and the gap on itself. That was right as far as it went, and
+ * it left the reason intact — every other label-level property stayed unreachable.
+ * Fixing what a report names is not the same as fixing what it is about.
+ *
+ * `cursor-pointer` and the gap still live here: they are not decisions a product should
+ * have to repeat at every call site. nene-vault carries them on the label in its own
+ * implementation (measured 2026-08-23), so a migration that could not set them would lose
+ * the pointer cursor on every choice — visible to a mouse user, invisible in a diff.
  */
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
   {
     label,
     className,
+    inputClassName,
     id,
     'aria-invalid': ariaInvalid,
     'aria-describedby': ariaDescribedBy,
@@ -40,8 +56,19 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
   const wiring = useFieldWiring({ id, ariaInvalid, ariaDescribedBy, ariaRequired });
 
   return (
-    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg">
-      <input ref={ref} type="checkbox" className={cx(BOX_CLASS, className)} {...wiring} {...rest} />
+    <label
+      className={cx(
+        'inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg',
+        className,
+      )}
+    >
+      <input
+        ref={ref}
+        type="checkbox"
+        className={cx(BOX_CLASS, inputClassName)}
+        {...wiring}
+        {...rest}
+      />
       {label}
     </label>
   );

--- a/packages/nene2-ui/src/primitives/Radio.tsx
+++ b/packages/nene2-ui/src/primitives/Radio.tsx
@@ -5,6 +5,11 @@ import { CONTROL_CLASS } from '../lib/states.js';
 export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   /** Localized label. Rendered inside the control's own `<label>`. */
   label: ReactNode;
+  /**
+   * Classes for the `<input>` itself. `className` goes to the `<label>`, which is this
+   * part's root — see the note below.
+   */
+  inputClassName?: string;
   /** Radios only mean anything in a group; `name` is what makes them one. */
   name: string;
 }
@@ -18,21 +23,41 @@ const DOT_CLASS = `size-x-slot-choice-box shrink-0 border border-x-slot-choice-b
  * its own group of one: it can be checked but never unchecked, and arrow keys do not move
  * between the options. Nothing about the rendered page shows this, so it survives review.
  *
- * 🔴 `cursor-pointer`, the gap and the box size are the component's, for the same reason as
- * on `Checkbox`: `className` reaches the `<input>`, and those belong to the `<label>`.
- * nene-vault's radios share one label style with its checkboxes, so the same hole was here.
+ * 🔴 `className` lands on the `<label>`, which is this part's root — the same place it
+ * lands in every other component the kit ships. Until 0.10.0 it went to the `<input>`
+ * instead, so nothing the caller wrote could reach the root: `self-start` inside a flex
+ * row, a width, a margin. nene-vault had to wrap each choice in a `<div>` to say them
+ * (found while migrating, 2026-08-23). Use `inputClassName` for the box itself.
  *
- * 🔴 This does not take the `FormField` wiring. A group of radios shares one label and one
- * error, so the id and `aria-describedby` belong on a `<fieldset>` around the group, not on
- * each option — putting them here would give every option the same id.
+ * 🔑 This is the cause behind a symptom the kit already answered once. In wave 2 the
+ * report was that `cursor-pointer` could not be set, because it belongs to the label; the
+ * kit took `cursor-pointer` and the gap on itself. That was right as far as it went, and
+ * it left the reason intact — every other label-level property stayed unreachable.
+ * Fixing what a report names is not the same as fixing what it is about.
+ *
+ * `cursor-pointer` and the gap still live here: they are not decisions a product should
+ * have to repeat at every call site. nene-vault carries them on the label in its own
+ * implementation (measured 2026-08-23), so a migration that could not set them would lose
+ * the pointer cursor on every choice — visible to a mouse user, invisible in a diff.
  */
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
-  { label, name, className, ...rest },
+  { label, name, className, inputClassName, ...rest },
   ref,
 ) {
   return (
-    <label className="inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg">
-      <input ref={ref} type="radio" name={name} className={cx(DOT_CLASS, className)} {...rest} />
+    <label
+      className={cx(
+        'inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg',
+        className,
+      )}
+    >
+      <input
+        ref={ref}
+        type="radio"
+        name={name}
+        className={cx(DOT_CLASS, inputClassName)}
+        {...rest}
+      />
       {label}
     </label>
   );

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -12,6 +12,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Button } from './Button.js';
 import { Input } from './Input.js';
 import { Select } from './Select.js';
+import { Textarea } from './Textarea.js';
+import { Checkbox } from './Checkbox.js';
+import { Radio } from './Radio.js';
+import { Switch } from './Switch.js';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -107,5 +111,45 @@ describe('Button', () => {
     const cls = classesOf(container.firstElementChild);
     expect(cls).toContain('bg-x-slot-button-danger-bg');
     expect(cls).toContain('disabled:cursor-not-allowed');
+  });
+});
+
+describe('className lands on the root', () => {
+  // 🔴 `Checkbox` と `Radio` だけ root が <label> なのに className が子の <input> へ
+  // 行っていた（〜0.10.0）。⇒ 呼び出し側は root を指定する手段が無く、flex 行の中で
+  // self-start も幅も margin も言えず、div で包むしか無かった（vault・2026-08-23）。
+  //
+  // 🔑 これは波2 で一度答えた症状の、原因の側。あのときは cursor-pointer を
+  // キットが持つ形で解いたが、「className が root に届かない」ことは残っていた。
+  // 報告された症状を直すことと、報告が指している原因を直すことは別。
+  const CASES = [
+    [
+      'Button',
+      <Button key="b" className="MARK">
+        x
+      </Button>,
+    ],
+    ['Input', <Input key="i" className="MARK" />],
+    ['Textarea', <Textarea key="t" className="MARK" />],
+    ['Checkbox', <Checkbox key="c" label="x" className="MARK" />],
+    ['Radio', <Radio key="r" label="x" name="g" className="MARK" />],
+    [
+      'Switch',
+      <Switch key="s" label="x" checked={false} onCheckedChange={() => {}} className="MARK" />,
+    ],
+  ] as const;
+
+  it.each(CASES)('%s puts the caller’s class on its outermost element', (_n, node) => {
+    const { container } = render(node);
+    const root = container.firstElementChild;
+    expect(root?.getAttribute('class') ?? '').toContain('MARK');
+  });
+
+  it('Checkbox still lets the box itself be reached, separately', () => {
+    const { container } = render(<Checkbox label="x" className="ONLABEL" inputClassName="ONBOX" />);
+    expect(container.firstElementChild?.getAttribute('class')).toContain('ONLABEL');
+    expect(container.firstElementChild?.getAttribute('class')).not.toContain('ONBOX');
+    expect(container.querySelector('input')?.getAttribute('class')).toContain('ONBOX');
+    expect(container.querySelector('input')?.getAttribute('class')).not.toContain('ONLABEL');
   });
 });


### PR DESCRIPTION
Closes #354

vault が載せ替えで踏みました:

> `Checkbox` はラベルの className がハードコードで、呼び出し側の className は `<input>` へ行く。⇒ **flex コンテナ内で `self-start` を言う手段が無く、ブロックで包む以外に手が無かった。**

## 🔴 欠落ではなく不整合

キットの全部品で `className` は **root 要素**へ着地します。**`Checkbox` / `Radio` だけ root が `<label>` なのに、`className` が子の `<input>` へ行っていました。**

⇒ **`className` は受け取られ、適用され、呼び出し側が望みようのない場所へ着地していた。** レイアウト（`self-start`・幅・margin）は root にしか効かないので、**div で包むしか無い。**

## 🔑 これは波2 で一度答えた症状の、原因の側

波2 の報告は「**`cursor-pointer` はラベル側なので届かない**」で、キットは **`cursor-pointer` と `gap` を自分が持つ形**で解きました。**それは正しかった**——値の重複を製品に強いない。

**そして「className が root に届かない」ことは、そのまま残りました。** ラベル側の他のプロパティは全部、依然として届かない。

🔑 **報告された症状を直すことと、報告が指している原因を直すことは別です。**

## 破壊的変更 — 艦の使用実態を測ってから

| 艦 | `Checkbox`/`Radio` 使用 | うち `className` 付き |
|---|---:|---:|
| vault（キット由来） | 3 | **0** |
| field | 2 | **0** |
| records | 5 | **0** |

⚠️ **最初の grep は開始タグと同じ行しか見ていませんでした。** ⇒ **タグの終端（`>`）まで追う形**で測り直して同じ結果。**複数行 JSX を跨げない grep で「0件」と言うと、vault の `-A3` と同じ穴に落ちます。**

⇒ **今なら無コスト。**

## 入ったもの

```tsx
<Checkbox label="…" className="self-start" inputClassName="…" />
       ↑ <label>（root）        ↑ <input>
```

## テスト（+7・陽性対照つき）

**全部品で `className` が root に着地すること**を固定（Button / Input / Textarea / Checkbox / Radio / Switch）。⇒ **例外がまた1つだけ生えることを止めます。**

🟢 **陽性対照**: `className` を `<input>` へ戻すと2件落ちる（実行確認）。

⚠️ doc コメントが**逆のことを言ったまま**残っていたので直しました（「`className` is forwarded to the `<input>`」）。**living doc が自分を否定する**のは今日3件目です。

## 実測

- `npm run check` 全ステップ緑（46ファイル / **707テスト**・+7）

## 残り

**#355**（`Button` の svg・`<div>`→`<Stack>` の blockify 注意）は次に出します。