### PR TITLE
fix(ui) 0.11.0: Button が中の svg に上界を与える — size-* ではなく max-*（#355）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -295,6 +295,25 @@ a missing component — open an issue, so every product gets the answer.
 **Products: apply the same check to your own theme.** The kit can only police its own file;
 the rule is the same one, and the regular expression above is the whole implementation.
 
+## 🔴 Migrating a screen to the kit
+
+**`<div>` → `<Stack>` is not a no-op.** The wrapper changes from block flow to flex, and
+inline-level children — `Button`, `<label>`, `<span>` — change size because of it:
+
+| what you see                                 | why                                                                                     |
+| -------------------------------------------- | --------------------------------------------------------------------------------------- |
+| a button suddenly spans the row              | `Stack` is `align-items: stretch`, so an inline-block child is stretched                |
+| a choice label goes from 112px wide to 582px | the same stretch                                                                        |
+| an icon becomes a tall rectangle             | an `<svg>` with no width/height attribute has no intrinsic size and lays out at 300×150 |
+
+The first two are flexbox working as specified; reach for `self-start` (which now lands on
+the root — see above) or `items-start` on the `Stack`. The third was the kit's fault and is
+bounded from 0.10.0, but only inside `Button` — **use `Icon` for artwork anywhere else**, or
+give the `<svg>` a size of its own.
+
+🔑 Three regressions in one migration, all from one wrapper swap, all of them visible only
+on screen: **nothing in a diff says that a child used to be inline** (nene-vault, 2026-08-23).
+
 ## What is in scope
 
 **In:** admin console and business-screen UI, page layout scaffolding, form field structure, the

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -34,7 +34,19 @@ const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
 // taller than the others. nene-vault puts a primary and a secondary side by side in seven
 // modal footers, where that shows up as a step (measured 2026-08-23); its own Button carries
 // the same transparent border for the same reason.
-const BASE_CLASS = `rounded-x-slot-button border border-transparent font-sans text-x-slot-button-size font-x-slot-button ${CLICKABLE_CLASS}`;
+// 🔴 `[&_svg]:max-*` bounds a raw `<svg>` child without sizing it. An svg with no width or
+// height attribute lays out at the replaced-element default of 300x150; a `max-height` pulls
+// it back and, because a `viewBox` gives the element an intrinsic ratio, the width follows.
+// `max-width` covers the svg that has no viewBox either.
+//
+// 🔴 Not `[&_svg]:size-*`. That would outrank the plain `h-5 w-5` an `Icon` sets on itself
+// — an arbitrary variant compiles to a descendant selector, which is more specific than a
+// single class — so `<Icon size="sm">` inside a button would render at the button's size
+// instead of its own. A maximum cannot collide with a height: different property, and it
+// leaves anything already smaller alone.
+const SVG_BOUND = '[&_svg]:max-h-x-slot-button-icon [&_svg]:max-w-x-slot-button-icon';
+
+const BASE_CLASS = `rounded-x-slot-button border border-transparent font-sans text-x-slot-button-size font-x-slot-button ${SVG_BOUND} ${CLICKABLE_CLASS}`;
 
 export function Button({
   variant = 'primary',

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -16,6 +16,7 @@ import { Textarea } from './Textarea.js';
 import { Checkbox } from './Checkbox.js';
 import { Radio } from './Radio.js';
 import { Switch } from './Switch.js';
+import { Icon } from './Icon.js';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -151,5 +152,41 @@ describe('className lands on the root', () => {
     expect(container.firstElementChild?.getAttribute('class')).not.toContain('ONBOX');
     expect(container.querySelector('input')?.getAttribute('class')).toContain('ONBOX');
     expect(container.querySelector('input')?.getAttribute('class')).not.toContain('ONLABEL');
+  });
+});
+
+describe('a raw <svg> inside a Button', () => {
+  // 🔴 vault の載せ替えで、アップロードボタンが縦230pxの矩形になった（2026-08-23）。
+  // width/height 属性も CSS 寸法も無い <svg> は置換要素の既定 300×150 まで広がる。
+  // <div> → <Stack> でブロックフローから flex へ変わった瞬間に出た。
+  it('is bounded, so it cannot lay out at the replaced-element default', () => {
+    const { container } = render(<Button>x</Button>);
+    const cls = classesOf(container.firstElementChild);
+    expect(cls).toContain('[&_svg]:max-h-x-slot-button-icon');
+    expect(cls).toContain('[&_svg]:max-w-x-slot-button-icon');
+  });
+
+  it('🔴 is bounded and never sized — Icon’s own size must survive', () => {
+    // 任意バリアント由来のセレクタは子孫セレクタへ落ちるので、Icon が自分に付ける
+    // 素のクラス（h-5 w-5）より詳細度が高い。⇒ [&_svg]:size-* を当てると
+    // <Icon size="sm"> がボタン側の寸法で描かれる。max-* なら衝突しない（別プロパティ・
+    // 既に小さいものは触らない）。この区別が消えると、退行は目視でしか出ない。
+    const cls = classesOf(render(<Button>x</Button>).container.firstElementChild);
+    for (const c of cls) {
+      expect(c, `Button must bound its svg, not size it: ${c}`).not.toMatch(
+        /^\[&_svg\]:(size|h|w)-/,
+      );
+    }
+  });
+
+  it('leaves an Icon’s own size class untouched', () => {
+    const { container } = render(
+      <Button>
+        <Icon size="sm" decorative>
+          <path d="M0 0h24v24H0z" />
+        </Icon>
+      </Button>,
+    );
+    expect(classesOf(container.querySelector('svg'))).toContain('h-4');
   });
 });

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -244,6 +244,23 @@
   --color-x-slot-error-state-fg: var(--color-danger);
   --color-x-slot-field-error-fg: var(--color-danger);
 
+  /* An upper bound for an `<svg>` written directly inside a `Button`.
+   *
+   * 🔴 `max-*`, deliberately not `size-*`. An `<svg>` with no width/height attributes and no
+   * CSS size is a replaced element with no intrinsic size, so it lays out at 300x150 — which
+   * is how a nene-vault upload button became a 230px-tall rectangle the moment its wrapper
+   * changed from a `<div>` to a `<Stack>` (2026-08-23).
+   *
+   * Sizing it outright would fix that and break something else: a class produced by an
+   * arbitrary variant (`[&_svg]:size-6`) outranks the plain `h-6 w-6` that `Icon` puts on
+   * itself, so `<Icon size="sm">` inside a button would silently render at the button's
+   * size. A maximum has no such conflict — it constrains nothing that is already smaller,
+   * and there is no specificity contest because the two properties are different.
+   *
+   * The bound is `--spacing-x-lg`, which is 1.5rem — `Icon size="lg"` exactly — so no icon
+   * the kit ships is clamped by it. */
+  --spacing-x-slot-button-icon: var(--spacing-x-lg);
+
   /* ── Weight slots ─────────────────────────────────────────────────────────────
    * `font-medium` appeared inline in four components. Same rule, same reason as colour. */
   --font-weight-x-slot-button: var(--font-weight-medium);


### PR DESCRIPTION
Closes #355

vault の載せ替えで顕在化（2026-08-23・vault 側では回避済み）:

> アップロードボタンが**縦230pxの矩形**になった。

## 原因

width/height 属性も CSS 寸法も無い `<svg>` は、**置換要素の既定 300×150** まで広がります。`Button` はそれを一切拘束していませんでした。

**`<div>` → `<Stack>` でブロックフローから flex へ変わった瞬間**に出ています。

## 🔴 `max-*` であって `size-*` ではない

**単純に `[&_svg]:size-*` を当ててはいけません。**

任意バリアント（`[&_svg]:`）は**子孫セレクタ**へ落ちるので、**`Icon` が自分に付ける素のクラス（`h-5 w-5`）より詳細度が高い**。⇒ **`<Icon size="sm">` がボタン側の寸法で描かれます。**

**`max-*` なら衝突しません** — **別プロパティ**なので詳細度の争いが起きず、**既に小さいものには触らない**。

```
[&_svg]:max-h-x-slot-button-icon [&_svg]:max-w-x-slot-button-icon
```

`viewBox` があれば固有アスペクト比を持つので **max-height だけで幅も比例して縮み**、`max-width` は viewBox すら無い svg を拾います。

上界は **`--spacing-x-lg`（1.5rem）＝ `Icon size="lg"` ちょうど**。⇒ **キットが出す icon はどれも clamp されません。**

⚠️ 最初は `1.5rem` とリテラルで書いて、**#348 で入れたスロット検査に落とされました**。スケール参照へ是正。

## テスト（+3・陽性対照つき）

| テスト | 陽性対照 |
|---|---|
| svg に上界がある | 🟢 `size-*` へ変えると発火 |
| 🔴 **上界であって寸法ではない**（`[&_svg]:(size\|h\|w)-` を禁止） | 🟢 発火 |
| `Icon` 自身のサイズクラスが残る | — |

🔑 **詳細度の退行は目視でしか出ない**ので、区別そのものをテストにしました。

⚠️ **jsdom は Tailwind の CSS を持たない**ので、これらはクラスの検査であって**計算済みスタイルの検査ではありません**。実際の詳細度は**別プロパティを選んだこと**で構造的に回避しており、テストはその選択が消えないことを守っています。

## README — `<div>` → `<Stack>` は無害ではない

vault は**1回の載せ替えで3件**踏んでいます:

| 症状 | 原因 |
|---|---|
| ボタンが全幅 | **`Stack` は `align-items: stretch`** ⇒ inline-block が伸びる |
| 選択肢ラベルが 112px → 582px | 同じ |
| icon が縦長の矩形 | **本PRで塞いだ分** |

**上2件はキットの欠陥ではなく flexbox の仕様どおり**ですが、**踏む人が続く**ので載せ替え節に書きました。

🔑 **どれも diff には出ません** — **「この子は inline だった」と書いてある行が無い。**

## 実測

- `npm run check` 全ステップ緑（46ファイル / **710テスト**・+3）