### PR TITLE
chore(fleet-baseline): nene2-ui の floor を ^0.11.0 へ — vault は 0.11.0 でないと本番と一致できない（#361）

### DIFF
--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -6,6 +6,6 @@
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.1.1",
     "@hideyukimori/nene2-i18n": "^0.3.0",
-    "@hideyukimori/nene2-ui": "^0.8.0"
+    "@hideyukimori/nene2-ui": "^0.11.0"
   }
 }


### PR DESCRIPTION
Closes #361

## publish 実測

```
npm view @hideyukimori/nene2-ui version        →  0.11.0
dist-tags                                      →  { latest: '0.11.0' }
dist.shasum                                    →  9689f8024eb5a24ea58eacf27568d10241b1387a
provenance                                     →  署名済み（sigstore logIndex 2573674607）
版一覧  0.2.0 0.3.0 0.4.0 0.6.0 0.7.0 0.8.0 0.11.0
```

**欠番は 0.5.0 / 0.9.0 / 0.10.0** で、いずれも `docs/publish.md` に理由つきで記録済み（#359 / #360）。

## 🔴 今回は必須

**pre-1.0 の caret は minor を固定する**ので `^0.8.0` ≡ `>=0.8.0 <0.9.0` ⇒ **0.11.0 を積極的に除外する。**

そして **vault は 0.11.0 でないと本番と一致できません**——必要なものが3版に分散しています:

| vault の差分 | 必要なもの | 入った版 |
|---|---|---|
| 入力欄の文字色 | `--color-x-slot-control-fg` | 0.9.0 |
| choice ラベル 13px | `--text-x-slot-choice-size` | 0.9.0 |
| Button 13px | `--text-x-slot-button-size` | 0.9.0 |
| choice を flex 行で `self-start` | `className` が root へ | 0.10.0 |
| Button 内の生 svg | `[&_svg]:max-*` | 0.11.0 |

## 🔴 艦への周知（今回だけ）

**0.11.0 は破壊的変更を含みます** — `Checkbox` / `Radio` の `className` が `<label>`（root）へ着地。箱は `inputClassName`。

⚠️ **実測では艦の使用箇所10件すべて `className` を渡していない**ので、**今のところ壊れる艦はありません**。ただし **floor を上げた後に書かれるコードは、旧挙動を前提にできない**ので、この PR に明記しています。

## 実測

- 差分は1行（`^0.8.0` → `^0.11.0`）
- `npm run check` 緑（46ファイル / 710テスト）
- 🔴 **floor を上げる前に npm の実在を実測**（上記 shasum）

## 関連

⚠️ **#362 が open**（floor が実在する版を指しているか検査する）。**この PR はその穴の上を通っています** — #362 が入れば、次からは機械が見ます。ただし #362 が覆うのは「**切った版より上を要求していないか**」までで、**npm の実在はネット無しでは問えません**。⇒ **この実測は今後も手番に残ります。**