### PR TITLE
feat(ui) 0.12.0: warn 状態と、妥当性の塗り — キットは error も塗っていなかった（#364）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -258,6 +258,47 @@ wrap every choice in a `<div>` to say them.
 label, so the kit carries it). That was right and it left the reason in place. **Fixing what
 a report names is not the same as fixing what it is about.**
 
+### 🔴 A palette that is missing a meaning
+
+The kit's theme defines **8 of the 28 colours** in the frozen Core Token Contract v1. That
+is a legal theme — the contract says what a name means, not that every name must be used —
+but it stops being harmless the moment a component needs one of the twenty.
+
+`warn` was one. Six ships define `--color-warn`; nene-payout, the product this theme was
+promoted from, does not. So `--color-x-slot-alert-warn-*` pointed at `--color-danger` and a
+warning rendered as an error — as nene-vault put it, **the difference reached someone
+listening and no one looking**.
+
+🔑 Same root cause as the radius scale, and the same shape as it: **a set whose members all
+resolve to one value cannot express the distinction it is named for.** Both are now checked
+— radius by step count, colour by whether two meanings resolve to the same value.
+
+Still undefined: `surface-overlay`, `surface-sunken`, `text-faint`, `text-inverse`,
+`border-strong`, `accent-hover`, `accent-soft`, `on-danger`, `success`, `success-soft`,
+`on-success`, `info`, `info-soft`, `on-info`, `focus-ring`, `scrim`. Two of those —
+`focus-ring` and `scrim` — already have component slots pointing at substitutes.
+
+### 🔴 Two validity states, and only one of them is invalid
+
+A value can be worth flagging without being wrong. nene-vault marks a retention period under
+ten years, which satisfies every rule its form has.
+
+|           | ARIA                                                  | paints                                          |
+| --------- | ----------------------------------------------------- | ----------------------------------------------- |
+| `error`   | `aria-invalid`                                        | `--color-x-slot-control-invalid-*`              |
+| `warning` | 🔴 **nothing** — announced through `aria-describedby` | `--color-x-slot-control-warn-*` via `data-warn` |
+
+Setting `aria-invalid` on a legal value announces it as an error; leaving it off left the
+field with no signal at all, because **the kit painted neither state** until 0.12.0. Seven of
+nine ships paint validity themselves, so migrating onto the kit removed a signal the product
+already had.
+
+🔑 The test guarding vault's amber border asserted `aria-invalid="true"` — the attribute, not
+the paint — and stayed green through the loss. **A test can check a stand-in for the thing it
+cares about; while both live in the same component that is the same test, and the moment the
+real thing moves upstream the stand-in stays behind and keeps passing.** Moving an
+implementation upstream produces this shape structurally.
+
 ### 🔴 What a slot check must cover
 
 The rule above — _every design value a component uses comes from a slot_ — was false in 26 of

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/feedback/InlineAlert.tsx
+++ b/packages/nene2-ui/src/feedback/InlineAlert.tsx
@@ -4,6 +4,15 @@ import { cx } from '../lib/cx.js';
 export interface InlineAlertProps {
   /** What the message means. `danger` is announced assertively; `info` politely. */
   tone?: 'info' | 'warn' | 'danger';
+  /**
+   * 🔴 Needed to point an `aria-describedby` at this message. Without it a product that
+   * wants the alert read out with a control has nowhere to put an id, and nene-vault
+   * wrapped the alert in a `<div>` to get one (2026-08-23). `FormField`'s `hint` is static
+   * help text, so it does not cover "a warning about the value that is in there now".
+   */
+  id?: string;
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   children: ReactNode;
 }
 
@@ -17,20 +26,25 @@ const TONE_CLASS: Record<NonNullable<InlineAlertProps['tone']>, string> = {
  * A message attached to the thing it is about, rather than to the page.
  *
  * 🔴 Each tone reads its colours from the theme, so a product can tell "warning" from
- * "failure" by sight. Until it sets them, `warn` and `danger` share this palette's single
- * alert hue and only the announced urgency differs — and as nene-vault put it, that
- * difference reaches someone listening and no one looking.
+ * "failure" by sight. Until 0.12.0 they could not: `warn` pointed at `--color-danger`, so
+ * only the announced urgency differed — and as nene-vault put it, that difference reaches
+ * someone listening and no one looking. The palette now carries `warn` of its own.
  *
  * 🔴 The tone decides the ARIA role, not just the colour. `danger` becomes `role="alert"`,
  * which interrupts a screen reader; `info` becomes `role="status"`, which waits its turn.
  * Six ships wrote this component (three as `InlineAlert`, three as `Alert`) and the choice
  * of role is precisely the part that is easy to get wrong and invisible when you do.
  */
-export function InlineAlert({ tone = 'info', children }: InlineAlertProps) {
+export function InlineAlert({ tone = 'info', id, className, children }: InlineAlertProps) {
   return (
     <div
+      id={id}
       role={tone === 'danger' ? 'alert' : 'status'}
-      className={cx('rounded-x-slot-alert border p-x-slot-alert-pad font-sans', TONE_CLASS[tone])}
+      className={cx(
+        'rounded-x-slot-alert border p-x-slot-alert-pad font-sans',
+        TONE_CLASS[tone],
+        className,
+      )}
     >
       {children}
     </div>

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -9,6 +9,16 @@ export interface FormFieldProps {
   /** Localized error message, or null when valid. */
   error?: string | null;
   /**
+   * Localized warning, or null when there is nothing to flag.
+   *
+   * 🔴 Not a milder `error`. A warning marks a value the form accepts — nene-vault flags a
+   * retention period under ten years, which satisfies every rule the field has. So it does
+   * NOT set `aria-invalid`: announcing a legal value as invalid is worse than saying
+   * nothing. It is announced as a `role="status"` and linked through `aria-describedby`,
+   * and it paints through `data-warn`.
+   */
+  warning?: string | null;
+  /**
    * Localized help text, shown under the control and read out with it.
    *
    * 🔴 Under the control, not beside the label — see `labelAdornment` for that. Three ships
@@ -51,6 +61,7 @@ export function FormField({
   id,
   label,
   error = null,
+  warning = null,
   hint,
   labelAdornment,
   required = false,
@@ -58,8 +69,12 @@ export function FormField({
   children,
 }: FormFieldProps) {
   const errorId = error === null ? null : `${id}-error`;
+  const warningId = warning === null ? null : `${id}-warning`;
   const hintId = hint === undefined || hint === null ? null : `${id}-hint`;
-  const value = useMemo(() => ({ id, errorId, hintId, required }), [id, errorId, hintId, required]);
+  const value = useMemo(
+    () => ({ id, errorId, warningId, hintId, required }),
+    [id, errorId, warningId, hintId, required],
+  );
 
   return (
     <FieldContext.Provider value={value}>
@@ -70,7 +85,7 @@ export function FormField({
         >
           {label}
           {required && requiredMarker !== undefined && requiredMarker !== null ? (
-            <span className="text-x-slot-field-error-fg">{requiredMarker}</span>
+            <span className="text-x-slot-field-required-marker">{requiredMarker}</span>
           ) : null}
           {labelAdornment}
         </label>
@@ -82,6 +97,17 @@ export function FormField({
           >
             {hint}
           </span>
+        )}
+        {warningId === null ? null : (
+          // role="status" ではなく role="alert" にすると、入力の途中で読み上げを割り込む。
+          // 警告は「見直す価値がある」であって「止まれ」ではないので、次の切れ目で読ませる。
+          <p
+            id={warningId}
+            role="status"
+            className="font-sans text-x-slot-field-error-size text-x-slot-field-warning-fg"
+          >
+            {warning}
+          </p>
         )}
         {errorId === null ? null : (
           <p

--- a/packages/nene2-ui/src/forms/field-context.ts
+++ b/packages/nene2-ui/src/forms/field-context.ts
@@ -7,6 +7,13 @@ export interface FieldContextValue {
   errorId: string | null;
   /** id of the rendered hint, or null when there is no hint. */
   hintId: string | null;
+  /**
+   * id of the rendered warning, or null when there is none.
+   *
+   * 🔴 Separate from `errorId`, and deliberately not `aria-invalid`. A warning marks a
+   * value worth a second look, not a value the form rejects.
+   */
+  warningId: string | null;
   /** Whether the field must be filled in. */
   required: boolean;
 }
@@ -20,6 +27,12 @@ export interface FieldWiring {
   'aria-invalid'?: AriaAttributes['aria-invalid'] | undefined;
   'aria-describedby'?: string | undefined;
   'aria-required'?: AriaAttributes['aria-required'] | undefined;
+  /**
+   * Present when the field carries a warning. Not an ARIA attribute — it paints, and says
+   * nothing to assistive technology, because the warning text is already linked through
+   * `aria-describedby`.
+   */
+  'data-warn'?: '' | undefined;
 }
 
 /**
@@ -66,15 +79,20 @@ export function useFieldWiring(explicit: {
       'aria-invalid': explicit.ariaInvalid,
       'aria-describedby': explicit.ariaDescribedBy,
       'aria-required': explicit.ariaRequired,
+      'data-warn': undefined,
     };
   }
 
-  const described = [field.errorId, field.hintId].filter((v): v is string => v !== null).join(' ');
+  // Error first, then warning, then hint — read in the order they matter.
+  const described = [field.errorId, field.warningId, field.hintId]
+    .filter((v): v is string => v !== null)
+    .join(' ');
 
   return {
     id: explicit.id ?? field.id,
     'aria-invalid': explicit.ariaInvalid ?? (field.errorId === null ? undefined : true),
     'aria-describedby': explicit.ariaDescribedBy ?? (described === '' ? undefined : described),
     'aria-required': explicit.ariaRequired ?? (field.required ? true : undefined),
+    'data-warn': field.warningId === null ? undefined : '',
   };
 }

--- a/packages/nene2-ui/src/forms/field-wiring.test.tsx
+++ b/packages/nene2-ui/src/forms/field-wiring.test.tsx
@@ -261,3 +261,67 @@ describe('control font size', () => {
     for (const c of cls) expect(c).not.toMatch(/^max-(sm|md):text-x-slot-control/);
   });
 });
+
+describe('warning — 不正ではないが目を引きたい値（#364）', () => {
+  // 🔴 vault は「保管期間10年未満」に琥珀の枠を出していた。8年は min=7 を満たすので
+  // **正当な値**。⇒ aria-invalid を立てると正当な値を不正と announce し、立てないと
+  // 合図が何も出ない。キットは 0.11.0 まで**どちらの塗りも持っていなかった**。
+  //
+  // 🔑 そして vault のテストは `aria-invalid="true"` を主張していたので**緑のまま**だった。
+  // テストは塗りではなく「塗りの代理」を検査していた。代理と本体が同じ部品に居るあいだは
+  // 等価だが、本体が上流（キット）へ移った瞬間に別物になる。
+  it('warning は aria-invalid を立てない — 正当な値を不正と announce しない', () => {
+    const { container } = render(
+      <FormField id="ret" label="Retention" warning="10年未満です">
+        <Input />
+      </FormField>,
+    );
+    const el = container.querySelector('input');
+    expect(el?.getAttribute('aria-invalid')).toBeNull();
+    expect(el?.getAttribute('data-warn')).toBe('');
+  });
+
+  it('warning は読み上げられる（describedby に載る）', () => {
+    const { container } = render(
+      <FormField id="ret" label="Retention" warning="10年未満です">
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('input')?.getAttribute('aria-describedby')).toBe('ret-warning');
+    // role="alert" にすると入力の途中で割り込む。警告は「止まれ」ではない。
+    expect(container.querySelector('#ret-warning')?.getAttribute('role')).toBe('status');
+  });
+
+  it('error と warning が同時にあるとき、error が先に読まれる', () => {
+    const { container } = render(
+      <FormField id="ret" label="Retention" error="必須です" warning="10年未満です" hint="help">
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('input')?.getAttribute('aria-describedby')).toBe(
+      'ret-error ret-warning ret-hint',
+    );
+  });
+
+  it('🔴 コントロールは妥当性を塗る — 属性だけ立てて見た目が変わらない状態を作らない', () => {
+    // これが vault で消えたもの。属性ではなく**塗りの側**を固定する。
+    const cls = (
+      render(<Input />)
+        .container.querySelector('input')
+        ?.getAttribute('class') ?? ''
+    ).split(/\s+/);
+    expect(cls).toContain('aria-invalid:border-x-slot-control-invalid-border');
+    expect(cls).toContain('aria-invalid:bg-x-slot-control-invalid-bg');
+    expect(cls).toContain('data-[warn]:border-x-slot-control-warn-border');
+    expect(cls).toContain('data-[warn]:bg-x-slot-control-warn-bg');
+  });
+
+  it('warning が無ければ data-warn も無い', () => {
+    const { container } = render(
+      <FormField id="ret" label="Retention">
+        <Input />
+      </FormField>,
+    );
+    expect(container.querySelector('input')?.getAttribute('data-warn')).toBeNull();
+  });
+});

--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -70,7 +70,26 @@ export const HOVER_CLASS =
   'hover:brightness-x-slot-hover active:brightness-x-slot-press disabled:hover:brightness-100 disabled:active:brightness-100';
 
 /** Controls that can be focused and disabled — every interactive primitive in the kit. */
-export const CONTROL_CLASS = `${FOCUS_CLASS} ${DISABLED_CLASS}`;
+/**
+ * Validity, painted.
+ *
+ * 🔴 Two states, and only one of them is `aria-invalid`. A value can be worth flagging
+ * without being wrong: nene-vault marks a retention period under ten years, which satisfies
+ * every rule the form has. Setting `aria-invalid` there would announce a legal value as an
+ * error, and not setting it left the field with no signal at all — the kit painted neither.
+ * So the warning is `data-warn`, an attribute that carries no ARIA meaning; the message
+ * beside it is what a screen reader gets, through `aria-describedby`.
+ *
+ * The error keeps `aria-invalid`, which is what it is for.
+ */
+export const VALIDITY_CLASS = [
+  'aria-invalid:border-x-slot-control-invalid-border',
+  'aria-invalid:bg-x-slot-control-invalid-bg',
+  'data-[warn]:border-x-slot-control-warn-border',
+  'data-[warn]:bg-x-slot-control-warn-bg',
+].join(' ');
+
+export const CONTROL_CLASS = `${FOCUS_CLASS} ${DISABLED_CLASS} ${VALIDITY_CLASS}`;
 
 /** Controls that are also clicked: buttons, switches, the toast dismiss. */
 export const CLICKABLE_CLASS = `${CONTROL_CLASS} ${HOVER_CLASS}`;

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -330,3 +330,38 @@ describe('the radius scale', () => {
     expect(new Set(all.values()).size).toBe(all.size);
   });
 });
+
+describe('meanings that must stay distinguishable', () => {
+  const theme = readFileSync(path.join(root, 'themes/default.css'), 'utf8');
+  const resolve = (name: string): string => {
+    const m = theme.match(new RegExp(`--${name}:\\s*([^;]+);`));
+    if (m === null) return `«${name} is not defined»`;
+    const value = m[1]!.trim();
+    const ref = value.match(/^var\(--([a-z0-9-]+)\)$/);
+    return ref === null ? value : resolve(ref[1]!);
+  };
+
+  it('a warning does not render as an error', () => {
+    // 🔴 Until 0.12.0 `--color-x-slot-alert-warn-*` pointed at `--color-danger`, so the two
+    // tones differed only in the ARIA role they took. As nene-vault put it: that difference
+    // reaches someone listening and no one looking.
+    //
+    // 🔑 Same shape as the radius scale — a slot set whose members all resolve to one value
+    // cannot express the distinction it is named for. Average-error thinking would call
+    // amber-vs-red a small difference; it is not a difference of degree.
+    expect(resolve('color-x-slot-alert-warn-border')).not.toBe(
+      resolve('color-x-slot-alert-danger-border'),
+    );
+    expect(resolve('color-x-slot-control-warn-border')).not.toBe(
+      resolve('color-x-slot-control-invalid-border'),
+    );
+  });
+
+  it('the palette carries the colours those meanings need', () => {
+    // `warn`, `warn-soft`, `on-warn` and `danger-soft` are in the frozen Core Token
+    // Contract v1; this theme simply had not defined them.
+    for (const c of ['color-warn', 'color-warn-soft', 'color-on-warn', 'color-danger-soft']) {
+      expect(resolve(c), `${c} must be defined`).toMatch(/^oklch\(/);
+    }
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -19,6 +19,30 @@
   --color-on-accent: oklch(99% 0 0);
   --color-danger: oklch(55% 0.2 25);
 
+  /* 🔴 Four contract colours the theme did not define. They are not new: `warn`,
+   * `warn-soft`, `on-warn` and `danger-soft` are in the frozen Core Token Contract v1
+   * (28 colours), and this theme defined 8 of them. Twenty are still missing — see the
+   * README — but these four are what a validity state needs.
+   *
+   * Same root cause as the radius scale: the theme was promoted verbatim from nene-payout,
+   * and payout has no warn. Six other ships do (nene-vault, nene-invoice, nene-field,
+   * nene-records, nene-deal, nene-profile), so `--color-x-slot-alert-warn-*` pointed at
+   * `--color-danger` — a warning that renders as an error. Promoting from the product with
+   * the fewest violations exported its missing distinctions along with its consistency.
+   *
+   * Values are the fleet median of the eight `--color-warn` definitions in use
+   * (2026-08-23; nene-field's hex converted to OKLCH to be counted).
+   *
+   * 🔴 `on-warn` is measured, not chosen. Against this `warn` fill: white is 3.48:1 and
+   * `text-primary` is 4.47:1 — which misses the 4.5:1 body-text threshold by 0.03, and is
+   * exactly the kind of near-miss that survives review by eye. The dark amber below is
+   * 4.97:1. The `warn` fill itself is 3.58:1 against `surface-raised`, clearing the 3:1
+   * that WCAG 1.4.11 asks of a non-text boundary. */
+  --color-warn: oklch(63% 0.135 75);
+  --color-warn-soft: oklch(95% 0.035 80);
+  --color-on-warn: oklch(21% 0.04 75);
+  --color-danger-soft: oklch(95% 0.03 30);
+
   --shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.06);
 
   /* Typography. Until 0.3.0 the kit had none of these and the components carried
@@ -126,9 +150,11 @@
   --color-x-slot-alert-info-bg: var(--color-surface);
   --color-x-slot-alert-info-fg: var(--color-text-primary);
   --color-x-slot-alert-info-border: var(--color-border);
+  /* 🔴 Changed in 0.12.0: these pointed at `--color-danger`, so a warning rendered as an
+   * error. Not a shade — a different meaning wearing the wrong one. */
   --color-x-slot-alert-warn-bg: var(--color-surface);
-  --color-x-slot-alert-warn-fg: var(--color-danger);
-  --color-x-slot-alert-warn-border: var(--color-danger);
+  --color-x-slot-alert-warn-fg: var(--color-on-warn);
+  --color-x-slot-alert-warn-border: var(--color-warn);
   --color-x-slot-alert-danger-bg: var(--color-surface);
   --color-x-slot-alert-danger-fg: var(--color-danger);
   --color-x-slot-alert-danger-border: var(--color-danger);
@@ -137,6 +163,10 @@
   --text-x-slot-field-hint-size: var(--text-x-2xs);
   --color-x-slot-field-error: var(--color-danger);
   --text-x-slot-field-error-size: var(--text-x-2xs);
+  /* 🔴 `on-warn`, not `warn`. This text sits on the page, not on a warn fill: `--color-warn`
+   * measures 3.58:1 against `surface-raised`, which clears the 3:1 a border needs and misses
+   * the 4.5:1 body text needs. The dark amber clears both. */
+  --color-x-slot-field-warning-fg: var(--color-on-warn);
   --text-x-slot-field-label-size: var(--text-x-xs);
   /* 🔴 `var(--font-weight-medium)`, not `500`. Identical output — Tailwind defines that
    * step as 500 — but a literal here is a weight the kit invented, and the namespace has a
@@ -192,6 +222,25 @@
   --color-x-slot-control-border: var(--color-border);
   --color-x-slot-control-placeholder: var(--color-text-muted);
 
+  /* 🔴 The kit painted nothing for validity until 0.12.0 — an invalid control looked exactly
+   * like a valid one, while `aria-invalid` was set and announced. Seven of nine ships paint
+   * it themselves (Tailwind `aria-invalid:` variants, CSS selectors, or a class name), so a
+   * migration onto the kit silently removed a signal the product already had. nene-vault
+   * lost an amber border on retention periods under ten years, and the test that guarded it
+   * asserted `aria-invalid="true"` — the attribute, not the paint — so it stayed green.
+   *
+   * 🔑 A test can check a stand-in for the thing it cares about. While both live in the
+   * same component that is the same test; the moment the real thing moves upstream, the
+   * stand-in stays behind and keeps passing.
+   *
+   * Border, not a ring: `ring-*` is a box-shadow and a parent with `overflow: hidden` clips
+   * it — the same reason the focus indicator here is an `outline`. The background carries
+   * the rest, and neither competes with the focus outline. */
+  --color-x-slot-control-invalid-border: var(--color-danger);
+  --color-x-slot-control-invalid-bg: var(--color-danger-soft);
+  --color-x-slot-control-warn-border: var(--color-warn);
+  --color-x-slot-control-warn-bg: var(--color-warn-soft);
+
   --color-x-slot-choice-fg: var(--color-text-primary);
   --color-x-slot-choice-border: var(--color-border);
 
@@ -242,7 +291,10 @@
   --color-x-slot-spinner-fg: var(--color-text-muted);
   --color-x-slot-empty-state-fg: var(--color-text-muted);
   --color-x-slot-error-state-fg: var(--color-danger);
-  --color-x-slot-field-error-fg: var(--color-danger);
+  /* 🔴 The required marker, not the error message — that one is `--color-x-slot-field-error`.
+   * Named `-error-fg` when the colour slots were swept in (0.9.0, same day), which reads as
+   * "the error message's colour" and is not. Renamed before anything consumed it. */
+  --color-x-slot-field-required-marker: var(--color-danger);
 
   /* An upper bound for an `<svg>` written directly inside a `Button`.
    *


### PR DESCRIPTION
Closes #364

## vault が失ったもの（W1 の回帰）

載せ替え前の `Input` は **保管期間10年未満のとき琥珀の枠**を出していました。**キット 0.11.0 は `aria-invalid` を配線にしか使っていません。** ⇒ **塗りが消え、誰も気づきませんでした。**

## 🔴 実測すると、報告より広い

```
CONTROL_CLASS = FOCUS_CLASS + DISABLED_CLASS
```

⇒ **キットは `error` の側も塗っていません。** **不正なフィールドが正常なフィールドとまったく同じ見た目**で、しかも `aria-invalid` は立って announce されます。

**9艦中7艦が自分で塗っています**（Tailwind バリアント / CSS セレクタ / クラス名の3形式で実測）⇒ **キットへの載せ替えは、製品が既に持っていた合図を静かに取り去ります。**

## 🔴 どちらを選んでも間違いだった

| | 意味 | 塗り |
|---|---|---|
| `aria-invalid` を立てる | 🔴 正当な値を不正と announce（8年は `min=7` を満たす） | 🔴 塗られない |
| 立てない | 🟢 正しい | 🔴 塗られない |

⇒ **`data-warn`** — **ARIA の意味を持たない属性**で塗り、**文言は `aria-describedby` で読ませます**。`error` は `aria-invalid` のまま（それがその属性の用途なので）。

## 🔴 warn はパレットに無かった。ただし契約には在った

**`warn` / `warn-soft` / `on-warn` / `danger-soft` は凍結済み Core Token Contract v1 の28色に既にあります。** ⇒ **AM-2 ゲートは PASS のまま**（契約は変えていない・**定義していなかった4色を埋めただけ**）。

```
このテーマが定義していたのは 28色中 8色
🔴 未定義20色: surface-overlay surface-sunken text-faint text-inverse border-strong
   accent-hover accent-soft danger-soft on-danger success success-soft on-success
   warn warn-soft on-warn info info-soft on-info focus-ring scrim
```

⚠️ **`focus-ring` と `scrim` は、今日私がスロット名として発明したもの**でした。**契約には既にパレット項目として在った**ので、README に記録しています。

🔑 **radius とまったく同じ根本原因** — payout からの verbatim 昇格で、**payout に warn が無い**。6艦が `--color-warn` を持っています。

## 値は測って決めました

**8艦の `--color-warn` の中央値**（nene-field の hex は OKLCH へ換算して算入）:

```
--color-warn: oklch(63% 0.135 75)     --color-on-warn: oklch(21% 0.04 75)
--color-warn-soft: oklch(95% 0.035 80) --color-danger-soft: oklch(95% 0.03 30)
```

🔴 **`on-warn` はコントラストを計算して選びました**:

| この warn の上で | 比 | |
|---|---:|---|
| white | 3.48:1 | 🔴 |
| **`text-primary`** | **4.47:1** | 🔴 **4.5 に 0.03 届かない** |
| 採用（濃い琥珀） | 4.97:1 | 🟢 |

**`text-primary` の 0.03 不足は、目視のレビューを通り抜ける類**です。

`warn` 自体は `surface-raised` に対して **3.58:1** で、**WCAG 1.4.11 の非テキスト 3:1 を満たします**。

## 🔴 見た目が変わります

**`--color-x-slot-alert-warn-*` が `danger` → `warn`。** **警告が error として描かれていたのを直したもの**で、色味の調整ではなく**意味の違い**です。

## 🔑 なぜ vault のテストが緑だったか

vault のテストは **`aria-invalid="true"`** を主張していました。

**テストは塗りではなく「塗りの代理」を検査していた。代理と本体が同じ部品に居るあいだは等価だが、本体が上流へ移った瞬間に別物になる。**

⚠️ **`.callout-*` の #337 と同じ形で、同じリポで2件目**。⇒ **実装を上流へ移す作業は、この形の回帰を構造的に作ります。**

## テスト（+7・陽性対照つき）

- `warning` は `aria-invalid` を立てない / `data-warn` が立つ
- `warning` は `role="status"`（`alert` だと**入力の途中で割り込む**——警告は「止まれ」ではない）
- `error` → `warning` → `hint` の順で読まれる
- 🔴 **コントロールが妥当性を塗る**（属性ではなく**塗りの側**を固定）
- 🔴 **2つの意味が同じ値へ潰れない**（radius の判定軸を色へ）— 🟢 `alert-warn` を danger へ戻すと発火

## ついでに直したもの

- `InlineAlert` に **`id`**（警告を `aria-describedby` で紐付ける口が無く、vault は div で包んでいた）と `className`
- `--color-x-slot-field-error-fg` → **`--color-x-slot-field-required-marker`**。実体は必須マーカーで、**「エラーメッセージの色」と読める名前は罠**でした（0.9.0 で私が付けたもの・**消費者ゼロのうちに**改名）

## 実測

- `npm run check` 全ステップ緑（46ファイル / **723テスト**・+7）
- **AM-2 ゲート PASS**（contract 1.0・color 28 + shadow 4 は凍結記録と一致）

## 🟢 hub の `findBy*` の指摘について

**自艦には露出がありません** — `findBy*` / `waitFor` は **0箇所**、`npm run test` は `vitest run`（`--coverage` 無し）。**測りました。**