### PR TITLE
feat(ui) 0.13.0: Button のスロットを対称にし、中身を自分で並べる（#366）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -25,10 +25,23 @@ const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
 };
 
 const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
-  md: 'px-x-slot-button-pad-x py-x-slot-button-pad-y',
-  sm: 'px-x-slot-button-sm-pad-x py-x-slot-button-sm-pad-y',
+  md: 'px-x-slot-button-pad-x py-x-slot-button-pad-y text-x-slot-button-size',
+  sm: 'px-x-slot-button-sm-pad-x py-x-slot-button-sm-pad-y text-x-slot-button-sm-size',
 };
 
+// 🔴 `inline-flex`, so the button places what is inside it. A `<button>` is `inline-block`
+// by default, which leaves an icon and its label on a shared baseline rather than centred —
+// visible as a half-pixel of drift on every icon button, and invisible in a diff. The kit
+// already takes responsibility for the size of an `<svg>` in here (`SVG_BOUND`); taking
+// responsibility for where it sits is the other half of the same job, and leaving one to the
+// caller while doing the other is the asymmetry nene-vault had to work around by writing
+// `inline-flex` at the call site.
+//
+// ⚠️ This changes rendering. A text-only button is laid out by flex rather than by inline
+// flow, so it no longer sits on the surrounding text's baseline the way an inline-block does.
+// Inside a paragraph that is visible; in the button rows and toolbars these are actually used
+// in, it is not. `inline-flex` rather than `flex` keeps the element from claiming a line.
+//
 // 🔴 `border border-transparent` is load-bearing. Height comes from the padding, so the
 // `secondary` variant — the only one with a visible border — would otherwise stand 2px
 // taller than the others. nene-vault puts a primary and a secondary side by side in seven
@@ -46,7 +59,7 @@ const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
 // leaves anything already smaller alone.
 const SVG_BOUND = '[&_svg]:max-h-x-slot-button-icon [&_svg]:max-w-x-slot-button-icon';
 
-const BASE_CLASS = `rounded-x-slot-button border border-transparent font-sans text-x-slot-button-size font-x-slot-button ${SVG_BOUND} ${CLICKABLE_CLASS}`;
+const BASE_CLASS = `rounded-x-slot-button border border-transparent inline-flex items-center justify-center gap-x-slot-button-gap font-sans font-x-slot-button ${SVG_BOUND} ${CLICKABLE_CLASS}`;
 
 export function Button({
   variant = 'primary',

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -190,3 +190,41 @@ describe('a raw <svg> inside a Button', () => {
     expect(classesOf(container.querySelector('svg'))).toContain('h-4');
   });
 });
+
+describe('Button が自分の中身を並べる（#366）', () => {
+  it('🔴 md と sm が別の font スロットを持つ — padding と対称', () => {
+    // 🔴 padding は 4本（md/sm × x/y）あるのに font は1本だった。⇒ vault は md=13px /
+    // sm=12px を出荷していたのに、キットでは両方が同じ大きさになる。
+    // ページネーションの Previous が本番12px / ローカル13px（vault 実測 2026-08-23）。
+    const md = classesOf(render(<Button>x</Button>).container.firstElementChild);
+    const sm = classesOf(render(<Button size="sm">x</Button>).container.firstElementChild);
+    expect(md).toContain('text-x-slot-button-size');
+    expect(sm).toContain('text-x-slot-button-sm-size');
+    expect(sm).not.toContain('text-x-slot-button-size');
+  });
+
+  it('🔴 padding と font のスロットが size ごとに揃っている', () => {
+    // 対称性そのものを固定する。片方だけ増える形が、この報告の原因だった。
+    for (const [size, prefix] of [
+      ['md', 'button'],
+      ['sm', 'button-sm'],
+    ] as const) {
+      const cls = classesOf(render(<Button size={size}>x</Button>).container.firstElementChild);
+      expect(cls, `${size} の padding-x`).toContain(`px-x-slot-${prefix}-pad-x`);
+      expect(cls, `${size} の padding-y`).toContain(`py-x-slot-${prefix}-pad-y`);
+      expect(cls, `${size} の font`).toContain(`text-x-slot-${prefix}-size`);
+    }
+  });
+
+  it('中身を並べる — アイコンと文字の配置を呼び出し側に残さない', () => {
+    // svg の寸法は面倒を見ているのに並べ方だけ呼び出し側、という非対称を消す。
+    const cls = classesOf(render(<Button>x</Button>).container.firstElementChild);
+    expect(cls).toContain('inline-flex');
+    expect(cls).toContain('items-center');
+    // flex は子の匿名テキストの前後の空白を落とすので、gap が無いと
+    // <Button><Icon /> Save</Button> のスペースが消える。
+    expect(cls).toContain('gap-x-slot-button-gap');
+    // 🔴 flex ではなく inline-flex。flex にすると行を占有する。
+    expect(cls).not.toContain('flex ');
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -94,6 +94,12 @@
   --spacing-x-slot-button-pad-y: var(--spacing-x-xs);
   --spacing-x-slot-button-sm-pad-x: var(--spacing-x-xs);
   --spacing-x-slot-button-sm-pad-y: var(--spacing-x-3xs);
+  /* 🔴 The gap between an icon and its label. It exists because the button became a flex
+   * container in 0.13.0, and a flex container drops the whitespace that used to separate
+   * them: `<Button><Icon /> Save</Button>` renders the text as an anonymous flex item, and
+   * leading whitespace in one is stripped. `3xs` is 0.25rem, which is about the width of
+   * the space that disappears — so the change of display does not also change the spacing. */
+  --spacing-x-slot-button-gap: var(--spacing-x-3xs);
   --spacing-x-slot-control-pad-x: var(--spacing-x-2xs);
   --spacing-x-slot-control-pad-y: var(--spacing-x-xs);
   --spacing-x-slot-field-gap: var(--spacing-x-2xs);
@@ -334,6 +340,12 @@
    * rather than acted on: changing the type scale is its own decision, with its own
    * measurement, and it is not this release's. */
   --text-x-slot-button-size: inherit;
+  /* 🔴 `sm` gets its own, because padding already has one and the pair was asymmetric:
+   * `--spacing-x-slot-button-{,sm-}pad-{x,y}` is four slots, the font was one. nene-vault
+   * shipped md=13px and sm=12px, and on the kit both came out at the same size — its
+   * pagination "Previous" measured 12px in production against 13px on the migrated build.
+   * Defaults to `inherit` like its sibling, so nothing renders differently today. */
+  --text-x-slot-button-sm-size: inherit;
   --text-x-slot-choice-size: inherit;
 
   /* Sentinel for the consumer's build (#316). Zero-width, so applying it does nothing.


### PR DESCRIPTION
Closes #366

## ① `sm` に font スロットが無かった

```
--spacing-x-slot-button-pad-x / -pad-y
--spacing-x-slot-button-sm-pad-x / -sm-pad-y   ← padding は size ごとに2組
--text-x-slot-button-size                      ← 🔴 font は1本
```

vault は **md=13px / sm=12px の2段**を出荷していたのに、**キットでは両方が同じ大きさ**になっていました。

```
Previous（ページネーション）  本番 73x31 font 12px   ローカル 77x27 font 13px
```

🔑 **スロットが片方の軸だけ size ごとに増えている。** ⇒ **対称性そのものをテストで固定**しました（`px` / `py` / `text` が md と sm の両方に在ること）。**片方だけ増える形を止めます。**

**既定は `inherit` のまま**なので、**描画は動きません**。

## ② BASE に `display` が無かった

`<button>` の UA 既定は `inline-block`（**Tailwind preflight は display を触らない** — `preflight.css` 実測）。⇒ **アイコンと文字がベースライン揃え**になり、中央揃えになりません。

🔴 **`SVG_BOUND` で svg の寸法は面倒を見ているのに、並べ方だけ呼び出し側に残っていました。** vault は呼び出し側で `inline-flex` を書いています。**意匠値ではなく「部品が自分の子をどう並べるか」＝構造**なので、キットの側です。

⚠️ **これは描画が変わります。** 文字だけのボタンも inline flow ではなく flex で配置されるので、**周囲の文章のベースラインには乗らなくなります**。段落の中では見えますが、実際に使われるボタン列やツールバーでは見えません。**`flex` ではなく `inline-flex`** なので、行は占有しません。

⚠️ **flex コンテナは子の匿名テキストの前後の空白を落とす**ので、`<Button><Icon /> Save</Button>` の**スペースが消えます**。⇒ `--spacing-x-slot-button-gap` を **`3xs`（0.25rem ＝ ほぼスペース1つ分）**にして、**display の変更が間隔の変更を兼ねない**ようにしました。

## テスト（+3・陽性対照つき）

| | 陽性対照 |
|---|---|
| md と sm が別の font スロット | 🟢 sm を md と同じスロットへ戻すと発火 |
| 🔴 **padding と font が size ごとに揃っている** | 🟢 同上（2件落ちる） |
| 中身を並べる（`inline-flex` / `items-center` / gap） | 🟢 外すと発火 |

## ⚠️ 測れなかったこと

**「艦の Button が実際にどの `display` を使っているか」は報告しません。** CSS を機械で拾うと**コンテナ側のルールやコメントを一緒に数えてしまい**、出てきた数字が信用できませんでした。⇒ **`inline-flex` の採用は分布ではなく設計判断**（`SVG_BOUND` との対称性）として決めています。

## 実測

- `npm run check` 全ステップ緑（46ファイル / **726テスト**・+3）
- **AM-2 ゲート PASS**