### PR TITLE
feat(ui) 0.14.0: タッチ端末でのコントロールの高さ下限 — 束に入れてはいけない1本（#368）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/lib/states.ts
+++ b/packages/nene2-ui/src/lib/states.ts
@@ -89,6 +89,24 @@ export const VALIDITY_CLASS = [
   'data-[warn]:bg-x-slot-control-warn-bg',
 ].join(' ');
 
+/**
+ * The minimum a control may be on a touch screen.
+ *
+ * 🔴 Deliberately NOT part of `CONTROL_CLASS`, though everything else here is. This has to
+ * go on the element that *is* the target, and for a checkbox that is the `<label>`, not the
+ * `<input>` — the box is `size-x-slot-choice-box` (16px square), so a minimum height on it
+ * produces a 44×16 rectangle instead of a bigger target. Folding it into the shared bundle
+ * would have applied it there, and the result would have looked like a styling bug rather
+ * than a mis-placed constraint.
+ *
+ * 🔴 It only works at all because the elements that carry it are flex containers. A
+ * `min-height` on an `inline-block` leaves the label at the top of the taller box; with
+ * `items-center` it stays centred. `Button` became one in 0.13.0 for an unrelated reason
+ * (an icon and its label sat on a shared baseline), and that turned out to be a
+ * prerequisite for this.
+ */
+export const TOUCH_CLASS = 'pointer-coarse:min-h-x-slot-control-touch-min';
+
 export const CONTROL_CLASS = `${FOCUS_CLASS} ${DISABLED_CLASS} ${VALIDITY_CLASS}`;
 
 /** Controls that are also clicked: buttons, switches, the toast dismiss. */

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
-import { CLICKABLE_CLASS } from '../lib/states.js';
+import { CLICKABLE_CLASS, TOUCH_CLASS } from '../lib/states.js';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
@@ -59,7 +59,7 @@ const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
 // leaves anything already smaller alone.
 const SVG_BOUND = '[&_svg]:max-h-x-slot-button-icon [&_svg]:max-w-x-slot-button-icon';
 
-const BASE_CLASS = `rounded-x-slot-button border border-transparent inline-flex items-center justify-center gap-x-slot-button-gap font-sans font-x-slot-button ${SVG_BOUND} ${CLICKABLE_CLASS}`;
+const BASE_CLASS = `rounded-x-slot-button border border-transparent inline-flex items-center justify-center gap-x-slot-button-gap font-sans font-x-slot-button ${SVG_BOUND} ${TOUCH_CLASS} ${CLICKABLE_CLASS}`;
 
 export function Button({
   variant = 'primary',

--- a/packages/nene2-ui/src/primitives/Checkbox.tsx
+++ b/packages/nene2-ui/src/primitives/Checkbox.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CONTROL_CLASS, TOUCH_CLASS } from '../lib/states.js';
 import { useFieldWiring } from '../forms/field-context.js';
 
 export interface CheckboxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
@@ -58,6 +58,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Che
   return (
     <label
       className={cx(
+        TOUCH_CLASS,
         'inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg',
         className,
       )}

--- a/packages/nene2-ui/src/primitives/Input.tsx
+++ b/packages/nene2-ui/src/primitives/Input.tsx
@@ -1,11 +1,11 @@
 import { forwardRef, type InputHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CONTROL_CLASS, TOUCH_CLASS } from '../lib/states.js';
 import { useFieldWiring } from '../forms/field-context.js';
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg placeholder:text-x-slot-control-placeholder ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg placeholder:text-x-slot-control-placeholder ${CONTROL_CLASS} ${TOUCH_CLASS}`;
 
 /**
  * Text input primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Radio.tsx
+++ b/packages/nene2-ui/src/primitives/Radio.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CONTROL_CLASS, TOUCH_CLASS } from '../lib/states.js';
 
 export interface RadioProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   /** Localized label. Rendered inside the control's own `<label>`. */
@@ -47,6 +47,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   return (
     <label
       className={cx(
+        TOUCH_CLASS,
         'inline-flex cursor-pointer items-center gap-x-slot-choice-gap font-sans text-x-slot-choice-size text-x-slot-choice-fg',
         className,
       )}

--- a/packages/nene2-ui/src/primitives/Select.tsx
+++ b/packages/nene2-ui/src/primitives/Select.tsx
@@ -1,13 +1,13 @@
 import { forwardRef, type ReactNode, type SelectHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CONTROL_CLASS, TOUCH_CLASS } from '../lib/states.js';
 import { useFieldWiring } from '../forms/field-context.js';
 
 export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
   children: ReactNode;
 }
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg ${CONTROL_CLASS} ${TOUCH_CLASS}`;
 
 /**
  * Select primitive. forwardRef so it works directly with react-hook-form `register`.

--- a/packages/nene2-ui/src/primitives/Switch.tsx
+++ b/packages/nene2-ui/src/primitives/Switch.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, type ButtonHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
-import { CLICKABLE_CLASS } from '../lib/states.js';
+import { CLICKABLE_CLASS, TOUCH_CLASS } from '../lib/states.js';
 
 export interface SwitchProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange' | 'type'> {
@@ -34,6 +34,7 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(function Switch
       aria-label={label}
       onClick={() => onCheckedChange(!checked)}
       className={cx(
+        TOUCH_CLASS,
         'inline-flex items-center rounded-x-slot-switch border border-x-slot-switch-border px-x-slot-switch-pad-x py-x-slot-switch-pad-y font-sans',
         checked
           ? 'bg-x-slot-switch-on-bg text-x-slot-switch-on-fg'

--- a/packages/nene2-ui/src/primitives/Textarea.tsx
+++ b/packages/nene2-ui/src/primitives/Textarea.tsx
@@ -1,11 +1,11 @@
 import { forwardRef, type TextareaHTMLAttributes } from 'react';
 import { cx } from '../lib/cx.js';
-import { CONTROL_CLASS } from '../lib/states.js';
+import { CONTROL_CLASS, TOUCH_CLASS } from '../lib/states.js';
 import { useFieldWiring } from '../forms/field-context.js';
 
 export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
 
-const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg placeholder:text-x-slot-control-placeholder ${CONTROL_CLASS}`;
+const BASE_CLASS = `w-full rounded-x-slot-control border border-x-slot-control-border bg-x-slot-control-bg px-x-slot-control-pad-x py-x-slot-control-pad-y font-sans text-x-slot-control-size pointer-coarse:text-x-slot-control-touch-size text-x-slot-control-fg placeholder:text-x-slot-control-placeholder ${CONTROL_CLASS} ${TOUCH_CLASS}`;
 
 /**
  * Multi-line text input. Deliberately identical to `Input` apart from the element, so the

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -228,3 +228,50 @@ describe('Button が自分の中身を並べる（#366）', () => {
     expect(cls).not.toContain('flex ');
   });
 });
+
+describe('タッチ端末の下限（#368）', () => {
+  const TOUCH = 'pointer-coarse:min-h-x-slot-control-touch-min';
+
+  it.each([
+    ['Button md', <Button key="b">x</Button>],
+    [
+      'Button sm',
+      <Button key="bs" size="sm">
+        x
+      </Button>,
+    ],
+    ['Input', <Input key="i" />],
+    [
+      'Select',
+      <Select key="s">
+        <option>a</option>
+      </Select>,
+    ],
+    ['Textarea', <Textarea key="t" />],
+    ['Checkbox', <Checkbox key="c" label="x" />],
+    ['Radio', <Radio key="r" label="x" name="g" />],
+    ['Switch', <Switch key="w" label="x" checked={false} onCheckedChange={() => {}} />],
+  ])('%s は下限を root（＝タップされる要素）に持つ', (_n, node) => {
+    const { container } = render(node);
+    expect(classesOf(container.firstElementChild)).toContain(TOUCH);
+  });
+
+  it('🔴 Checkbox の下限は箱ではなくラベルに付く', () => {
+    // 箱は size-x-slot-choice-box（16px 四方）なので、そこに min-height を当てると
+    // 44×16 の縦長になるだけで、対象は大きくならない。タップされるのはラベル。
+    // ⇒ CONTROL_CLASS（全コントロール共通の束）に入れると箱にも付いてしまうので、
+    //    この1本だけ束から外してある。その判断が消えないよう固定する。
+    const { container } = render(<Checkbox label="x" />);
+    expect(classesOf(container.querySelector('input'))).not.toContain(TOUCH);
+    expect(classesOf(container.firstElementChild)).toContain(TOUCH);
+  });
+
+  it('🔴 下限を持つ要素は flex — inline-block だと中身が上に寄るだけ', () => {
+    // min-height は箱を高くするが、中身は動かさない。items-center が要る。
+    for (const node of [<Button key="b">x</Button>, <Checkbox key="c" label="x" />]) {
+      const cls = classesOf(render(node).container.firstElementChild);
+      expect(cls).toContain('inline-flex');
+      expect(cls).toContain('items-center');
+    }
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -78,6 +78,21 @@
   --text-x-xl: 1.5rem;
   --text-x-ios-floor: 16px;
 
+  /* The smallest a control may be on a touch screen. Not a design step, for the same reason
+   * `--text-x-ios-floor` is not: it is what the platform requires, and a product lowering it
+   * is not expressing a preference, it is making targets people miss.
+   *
+   * 🔴 44px, which is what WCAG 2.5.5 (AAA) and Apple's HIG both ask for — the smallest
+   * value that satisfies the standards rather than the fleet's average. Two ships already
+   * set 48px (nene-profile, nene-deal), Material's number; a product that wants it raises
+   * the slot. Picking the higher one here would be the kit imposing a size, and picking a
+   * median would make a device constraint look like a preference.
+   *
+   * ⚠️ The kit's own `sm` button computes to about 31px against a 14px body — above the
+   * 24px WCAG 2.5.8 (AA) asks for, and well under this. The `md` button is already ~47px,
+   * so this changes nothing there. */
+  --spacing-x-touch-floor: 44px;
+
   /* ─────────────────────────────────────────────────────────────────────────
    * ② SLOTS — a product may redefine these.
    *
@@ -192,6 +207,11 @@
    * only because the kit cannot know a product's rem base — not because it is yours to tune. */
   --text-x-slot-control-size: var(--text-x-md);
   --text-x-slot-control-touch-size: var(--text-x-ios-floor);
+  /* The other half of the same constraint: the first says a focused control must not be
+   * small enough to make iOS zoom, this says it must not be small enough to miss. Applied
+   * only under `@media (pointer: coarse)` — pointer, not width, for the reason recorded
+   * above (an iPad in landscape is wide and still has fingers). */
+  --spacing-x-slot-control-touch-min: var(--spacing-x-touch-floor);
 
   /* ── Colour slots ─────────────────────────────────────────────────────────────
    * Every colour a component paints comes from here.


### PR DESCRIPTION
Closes #368

## 実測

| | 高さ（本文14px・line-height 1.5） | |
|---|---:|---|
| `Button` md | 約 47px | 🟢 |
| **`Button` sm** | **約 31px** | 🟡 WCAG 2.5.8（AA）の 24px は満たす／2.5.5（AAA）と iOS HIG の **44px には届かない** |

## 値は 44px（艦の中央値ではなく）

キットには先例があります——**`--text-x-ios-floor: 16px`**。「意匠の段ではなく、端末が課す制約」。**同じ扱いにしました。**

⚠️ **艦の先例は 48px が2艦**（nene-profile / nene-deal・Material の値）。**それでも 44px を採ります**:

- **44px は WCAG 2.5.5（AAA）と Apple HIG が求める値**＝**規格を満たす最小値**
- **48 を焼き込むとキットが大きさを押し付ける**
- **中央値を採ると、端末の制約が好みのように見える**

⇒ **48 が欲しい艦はスロットを上げます。**

## 🔴 束に入れてはいけない1本

**`CONTROL_CLASS`（全コントロール共通の束）には入れていません。**

**`Checkbox` の `<input>` は `size-x-slot-choice-box`（16px 四方）**なので、そこに `min-height: 44px` を当てると **44×16 の縦長になるだけで、対象は大きくなりません**。**タップされるのはラベル**です。

🔑 **束に入れると、置き場所を間違えた制約が「見た目のバグ」として現れます。** ⇒ **要素が対象そのものである場所にだけ**当てました。

⚠️ そして **`min-height` は箱を高くするが中身は動かさない** ⇒ **`items-center` が要ります**。**`Button` が 0.13.0 で flex コンテナになった（#366）のは別の理由**（アイコンとの整列）でしたが、**結果的にこの前提条件でした**。

## テスト（+10・陽性対照つき）

| | 陽性対照 |
|---|---|
| 8部品すべてが root に下限を持つ | 🟢 Button から外すと2件落ちる |
| 🔴 **`Checkbox` は箱ではなくラベル** | 🟢 **`CONTROL_CLASS` に戻すと落ちる**（＝束に入れる誤りを捕まえる） |
| 🔴 下限を持つ要素は flex | — |

## ⚠️ タッチ端末では描画が変わります

**それがこの変更の目的**です。デスクトップ（`pointer: fine`）では何も変わりません。**幅ではなくポインタ**で分けているので、**横向きの iPad のような「広いタッチ端末」も拾います**。

## 実測

- `npm run check` 全ステップ緑（46ファイル / **736テスト**・+10）
- **AM-2 ゲート PASS**