### PR TITLE
chore(fleet-baseline): nene2-ui の floor を ^0.14.0 へ — 描画が変わる4点の周知つき（#374）

### DIFF
--- a/docs/todo/current.md
+++ b/docs/todo/current.md
@@ -10,17 +10,17 @@
 |                  | 値〔すべて自艦で実測〕                                    |
 | ---------------- | --------------------------------------------------------- |
 | `main` の版      | **0.14.0**                                                |
-| npm の latest    | **0.11.0**（provenance 署名つき・`dist.shasum 9689f802`） |
-| `fleet-baseline` | `^0.11.0`                                                 |
+| npm の latest    | **0.14.0**（provenance 署名つき・`dist.shasum c2f273c5`） |
+| `fleet-baseline` | `^0.14.0`（PR #375 で追随）                               |
 | テスト           | **736** / 46ファイル                                      |
-| open な PR       | **0本**                                                   |
+| open な PR       | **1本（#375・baseline 追随）**                            |
 | `npm run check`  | 🟢 全ステップ緑                                           |
 
 ## 🔴 いちばん上にあること
 
-1. 🔴 **0.14.0 が未 publish。** リリースノート（#371）は**マージ済み**、dry-run は**緑2回・実行済み**。⇒ **`gh workflow run publish.yml -f package=nene2-ui -f dry_run=false` が次の一手**（施主の手番）。
-2. **publish 後、`fleet-baseline` を `^0.14.0` へ**。⚠️ **pre-1.0 の caret は minor を固定する**ので `^0.11.0` は 0.14.0 を**積極的に除外する**。上げないと vault に届かない。
-3. ⚠️ **0.12.0〜0.14.0 は描画が変わる**（下記）。艦への周知が要る。
+1. 🔴 **艦への周知**。**0.11.0 → 0.14.0 で描画が変わる4点**（下表）＋**0.11.0 の破壊的変更**。⇒ **`docs/publish.md` の 0.14.0 節先頭の表**を指せば足りる。**hub 経由の周知は未実施**（hub のセッションが終了しているため）。
+2. **PR #375**（`fleet-baseline` を `^0.14.0` へ）が施主のマージ待ち。⚠️ **pre-1.0 の caret は minor を固定する**ので `^0.11.0` は 0.14.0 を**積極的に除外する**。
+3. **vault が 0.14.0 に載れば W1 が閉じる。** 必要なトークンは `--color-x-slot-control-fg`（本番の `--color-x-ink-deep` へ）／`--text-x-slot-{button,choice}-size`（13px）／`--text-x-slot-button-sm-size`（12px）。
 
 ## ⚠️ 0.11.0 → 0.14.0 で見た目が変わる4点
 

--- a/fleet-baseline.json
+++ b/fleet-baseline.json
@@ -6,6 +6,6 @@
     "@hideyukimori/nene2-tokens": "^1.1.0",
     "@hideyukimori/nene2-standards": "^2.1.1",
     "@hideyukimori/nene2-i18n": "^0.3.0",
-    "@hideyukimori/nene2-ui": "^0.11.0"
+    "@hideyukimori/nene2-ui": "^0.14.0"
   }
 }


### PR DESCRIPTION
Closes #374

## publish 実測

```
npm view @hideyukimori/nene2-ui version   →  0.14.0
dist-tags                                  →  { latest: '0.14.0' }
dist.shasum                                →  c2f273c545f9502f862dd07b4161ae07b488f7af
provenance                                 →  署名済み（sigstore logIndex 2576174141）
版一覧  0.2.0 0.3.0 0.4.0 0.6.0 0.7.0 0.8.0 0.11.0 0.14.0
```

欠番 **0.5.0 / 0.9.0 / 0.10.0 / 0.12.0 / 0.13.0** はすべて `docs/publish.md` に理由つきで記録済み。

## 上げないと届かない

**pre-1.0 の caret は minor を固定する**ので `^0.11.0` ≡ `>=0.11.0 <0.12.0` ⇒ **0.14.0 を積極的に除外する。**

## 🔴 今回は周知が要る

**これまでの版は「既定の見た目は不変」で通せましたが、0.12.0〜0.14.0 は違います。**

| 変わるもの | 版 | 影響 |
|---|---|---|
| 警告が error 色 → warn 色 | 0.12.0 | **これまで警告が赤で描かれていた** |
| コントロールが妥当性を塗る | 0.12.0 | **これまで無塗装** ⇒ 新たに枠と背景が付く |
| `Button` が `inline-flex` | 0.13.0 | **文章の途中に置いたボタン**のみ |
| タッチ端末で最低 44px | 0.14.0 | **スマホ・タブレットのみ** |

🔴 **0.11.0 の破壊的変更も含みます**（`Checkbox` / `Radio` の `className` が `<label>` へ・箱は `inputClassName`）。⚠️ **実測では艦10箇所すべて `className` を渡していない**ので、**今のところ壊れる艦はありません**。

⇒ **`docs/publish.md` の 0.14.0 節先頭の表**（「載せ替える前に、これだけ読めば足りる」）を指せば足ります。

⚠️ **hub 経由の周知は未実施**です — **hub のセッションが終了しています**（`ListAgents` に行が無く、8790 も refused。2経路とも不在を示しています）。

## 実測

- 差分は `fleet-baseline.json` 1行＋`current.md` の上書き
- `npm run check` 緑（46ファイル / 736テスト）
- **#362 の floor 検査が効いている**（floor `0.14.0` ≤ ワークスペースの `0.14.0`）
- 🔴 **floor を上げる前に npm の実在を実測**（上記 shasum）