### PR TITLE
chore(release) nene2-tokens 1.3.0: 34日ぶんの未 publish 変更に版を与える（#402）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -65,6 +65,24 @@ nene2-ui         （未公開）
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
 > 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
 
+### `@hideyukimori/nene2-tokens` 1.3.0（**minor — feat を含む**・#402）
+
+🔴 **1.2.0 の publish（2026-07-21）以降、版を上げないまま4コミットが入っていた**（#402 で実測）。
+**`npm view` と `package.json` は 1.2.0 で一致していた**ので、版だけを見る確認はこの形を通す。
+**34日ぶん**の変更がここで出る。
+
+| | 出所 |
+| --- | --- |
+| **feat: 取り残される `var(--old)` 参照を開示する** | #132 |
+| fix: 複合キーを拡張トークンと認識し、自分の生成物を壊さない | #134 / #88 |
+| fix: `exports` に `./package.json` を追加 | #182 |
+| test: 置換境界の不変条件を固定（#135 は再現せず） | #135 |
+
+触れた出荷物: `src/cli.ts` / `src/codemod.ts` / `src/codemod-map.ts` / `src/contract.ts` / `src/index.ts`。
+
+⚠️ **契約（`COLOR_KEYS` / `SHADOW_KEYS`）は変えていない。** AM-2 release gate は凍結記録と一致したままで、
+publish 経路でも `check:am2-gate` が fail-closed で見張る。
+
 ### `@hideyukimori/nene2-standards` 1.2.0（minor — feat を含む）✅ publish 済み（2026-07-18・#85 束）
 
 - feat: registries に **components-allowlist kind** 新設（#77）・**stylelintConfigFor** — 台帳由来 secondary の合成（#78・arm 実効部）・**init --scan が components-allowlist を emit**＋T-3/initCheck 追随（#79）

--- a/package-lock.json
+++ b/package-lock.json
@@ -8909,7 +8909,7 @@
     },
     "packages/nene2-tokens": {
       "name": "@hideyukimori/nene2-tokens",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "jscodeshift": "^17.3.0"

--- a/packages/nene2-tokens/package.json
+++ b/packages/nene2-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-tokens",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "NeNe Core Token Contract v1 — contract types, CONTRACT_TOKENS, validate:themes CLI, themegen, codemod mapping table v1 + jscodeshift codemod runner, reference theme",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
`#402` の1本目（1パッケージ = 1PR）。

## 🔴 1.2.0 の publish 以降、版を上げないまま4コミットが入っていた

| | |
| --- | --- |
| npm の publish | **2026-07-21** |
| 最後の未リリース変更 | **2026-08-05** |
| 放置 | **34日** |
| タグ以降に `version` 行へ触れたコミット | **0件** |

🔑 **`npm view` と `package.json` はどちらも 1.2.0 で一致していた。** 版だけを見る確認は**この形を通す**。
`docs/publish.md` の「**同値でもタグ以降にコミットがあれば未リリースの変更がある**」に従って初めて出た。

## 入っているもの（すべて出荷物のソース）

| | 出所 |
| --- | --- |
| **feat: 取り残される `var(--old)` 参照を開示する** | #132 |
| fix: 複合キーを拡張トークンと認識し、自分の生成物を壊さない | #134 / #88 |
| fix: `exports` に `./package.json` を追加 | #182 |
| test: 置換境界の不変条件を固定（#135 は再現せず） | #135 |

**feat を含むので minor**（1.2.0 → **1.3.0**）。
触れた出荷物: `src/cli.ts` / `src/codemod.ts` / `src/codemod-map.ts` / `src/contract.ts` / `src/index.ts`

⚠️ **契約（`COLOR_KEYS` / `SHADOW_KEYS`）は変えていない。** AM-2 release gate は凍結記録と一致したままで、
publish 経路でも `check:am2-gate` が fail-closed で見張る。

## publish.md

版節を足した。🔴 **見出しに状態（`✅ publish 済み` / 準備中）は書いていない**——
`#313` の「**見出しに状態を書くとそこが腐る**」に従う。

## lockfile

`check:lock` に備えて追随させ、**前後比較**した:

```
差分: 1行（"version": "1.2.0" → "1.3.0"）
```

## 検証〔実測〕

```
npm run check   → EXIT=0（8ステップ）
実行時刻          2026-08-25 00:06:45 JST（date 実測）
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS48CKX2yZD6GmAwpt4knt
