### PR TITLE
chore(release) nene2-i18n 0.3.1: 34日ぶんの未 publish 変更に版を与える（#402・0.4.0 は #171 に予約済みなので patch）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -65,6 +65,24 @@ nene2-ui         （未公開）
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
 > 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
 
+### `@hideyukimori/nene2-i18n` 0.3.1（**patch**・#402）
+
+🔴 **0.3.0 の publish（2026-07-21）以降、版を上げないまま1コミットが入っていた**（#402 で実測）。
+**34日ぶん。** 中身は1件:
+
+| | 出所 |
+| --- | --- |
+| `exports` に `./package.json` を追加 | #182 |
+
+（`conformance` の provenance が常に null になる欠陥の是正で、4パッケージ横断で `./package.json` を
+公開面に足したもの。消費側が版を読めるようにするため。）
+
+🔴 **patch にした理由。** `exports` の追加は公開面の変更なので minor に見えるが、
+**`0.4.0` は `#171`（`./format` subpath 供給計画 — I18N-14 v1 の5関数）に予約済み**で、
+**先に別の中身で 0.4.0 を消費すると、条文・issue・板の「0.4.0 = `./format`」という参照が全部ずれる。**
+⇒ **番号は、それを指している文書の側にも属している。** 追加が `./package.json` の1本だけであり、
+**既存の import 経路を1つも変えない**ことから patch を採る。
+
 ### `@hideyukimori/nene2-standards` 1.2.0（minor — feat を含む）✅ publish 済み（2026-07-18・#85 束）
 
 - feat: registries に **components-allowlist kind** 新設（#77）・**stylelintConfigFor** — 台帳由来 secondary の合成（#78・arm 実効部）・**init --scan が components-allowlist を emit**＋T-3/initCheck 追随（#79）

--- a/package-lock.json
+++ b/package-lock.json
@@ -8822,7 +8822,7 @@
     },
     "packages/nene2-i18n": {
       "name": "@hideyukimori/nene2-i18n",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "peerDependencies": {
         "@testing-library/react": "^16.0.0",

--- a/packages/nene2-i18n/package.json
+++ b/packages/nene2-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-i18n",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "NeNe fleet typed i18n — typed catalog + parity + runtime translator options + React (I18nProvider). 0.3.0 W0b.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
`#402` の3本目（1パッケージ = 1PR）。

## 🔴 0.3.0 の publish 以降、版を上げないまま1コミットが入っていた

| | |
| --- | --- |
| npm の publish | **2026-07-21** |
| 最後の未リリース変更 | **2026-07-30** |
| 放置 | **34日** |

中身は1件——**`exports` に `./package.json` を追加**（`#182`）。
`conformance` の provenance が常に null になる欠陥の是正で、**4パッケージ横断**で公開面に足したもの
（消費側が版を読めるようにするため）。

## 🔴 patch にした理由（要判断だったところ）

**`exports` の追加は公開面の変更なので minor に見える。** それでも **0.3.1（patch）**を採る:

**`0.4.0` は `#171`（`./format` subpath 供給計画 — I18N-14 v1 の5関数）に予約済み**〔OPEN を実測〕。
**先に別の中身で 0.4.0 を消費すると、条文・issue・板の「0.4.0 = `./format`」という参照が全部ずれる。**

🔑 **番号は、それを指している文書の側にも属している。**
本日 `#396` で「**欠番は実際に起きたことの記号であって、隠蔽に使う記号ではない**」と決めたのと同じ層の話で、
**版番号は自分のためだけの記号ではない。**

追加が **`./package.json` の1本だけ**であり、**既存の import 経路を1つも変えない**ことから patch で足りる。

## ⚠️ 型6 — 他の2本と同じ位置を触る

**`#402` の tokens 1.3.0 / standards 2.3.0 の PR と、`docs/publish.md` の同じ位置に節を足す。**
⇒ **後にマージする側は rebase して緑を取り直すこと。**

## 検証〔実測〕

```
npm run check   → EXIT=0（8ステップ）
実行時刻          2026-08-25 00:09:41 JST（date 実測）
lockfile 差分     1行（"version": "0.3.0" → "0.3.1"）
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS48CKX2yZD6GmAwpt4knt
