### PR TITLE
fix(ui) 0.16.1: Modal の dialog に m-auto — preflight が消す UA の margin:auto をキットが自分で言う（#417）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -65,6 +65,26 @@ nene2-ui         （未公開）
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
 > 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
 
+### `@hideyukimori/nene2-ui` 0.16.1（**patch — fix**・#417）
+
+**載せ替える前に読むもの: 無し。** 変わるのは1点で、**Tailwind preflight の艦で dialog が中央に来る**ようになる。
+
+| 変わるもの | 0.16.0 まで | 0.16.1 |
+| --- | --- | --- |
+| `Modal` の dialog の位置（desktop） | **左上 (0,0)** に張り付く（vault の本番・1280px で実測） | 中央 |
+
+🔴 **機構**: UA の `dialog { margin: auto }` を Tailwind v4 の preflight（`* { margin: 0 }`・author origin）が消す。
+キットの dialog は margin を自分で言っておらず、`sheetOnMobile` の `max-sm:mt-auto max-sm:mb-0` は
+**その margin:auto が在る前提**で書かれていた。⇒ dialog のクラス列に **`m-auto`** を足した。
+`max-sm:` 側は変えていない（狭い画面では `max-sm:mb-0` が勝つ）。
+
+⚠️ **jsdom は `showModal` を実装しない**ので、位置そのものはテストで固定できない。固定したのは
+「dialog が `m-auto` を自分で持つ」「sheet でも `m-auto` が残り、素の `m-0` 系を持たない」の2本。
+**中央に戻ったかは vault の live レーン**（nene-vault #441）**で 0.16.1 を当てて測る。** それまで「直った」と書かない。
+
+⚠️ **0.16.0 で `Modal` を載せた艦は上げること**（`^0.16.0` は 0.16.1 を含む。`npm update @hideyukimori/nene2-ui`）。
+上流が出るまでの橋渡し（vault の base 層の `dialog { margin: auto }` 1行）は **0.16.1 適用時に消す**（hub 裁定 08-25）。
+
 ### `@hideyukimori/nene2-ui` 0.16.0（**minor — feat**・#392）
 
 **載せ替える前に読むもの: 無し。描画は変わらない。**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/overlay/Modal.tsx
+++ b/packages/nene2-ui/src/overlay/Modal.tsx
@@ -126,7 +126,14 @@ export function Modal(props: ModalProps) {
       onClose={onClose}
       onCancel={onClose}
       className={cx(
-        'bg-x-slot-modal-bg text-x-slot-modal-fg border border-x-slot-modal-border rounded-x-slot-modal',
+        // 🔴 `m-auto` is what centres a `showModal()` dialog. The UA stylesheet already says
+        // `dialog { margin: auto }`, but Tailwind's preflight (`* { margin: 0 }`, author origin)
+        // erases it, so on every Tailwind ship the dialog sat at (0,0) — measured in nene-vault's
+        // production at 1280px, where the old hand-written modal had been at (380,119) (#417).
+        // The sheet classes below (`max-sm:mt-auto max-sm:mb-0`) always assumed this margin was
+        // there; saying it explicitly is the kit owning an assumption it had been borrowing.
+        // jsdom does not implement `showModal`, so the position itself is a live-lane check.
+        'm-auto bg-x-slot-modal-bg text-x-slot-modal-fg border border-x-slot-modal-border rounded-x-slot-modal',
         'p-x-slot-modal-pad font-sans backdrop:bg-x-slot-modal-scrim/50',
         size !== undefined && SIZE_CLASS[size],
         sheetOnMobile === true && SHEET_CLASS,

--- a/packages/nene2-ui/src/overlay/modal.test.tsx
+++ b/packages/nene2-ui/src/overlay/modal.test.tsx
@@ -56,6 +56,34 @@ describe('Modal — 既定は 0.15.0 までと同じ（#392）', () => {
   });
 });
 
+describe('Modal — 位置は UA に借りない（#417）', () => {
+  // vault の本番で dialog が (0,0) に張り付いた。UA の `dialog { margin: auto }` を Tailwind の
+  // preflight（`* { margin: 0 }`）が消すため。jsdom は showModal を実装しないので座標は測れない
+  // ——ここで固定できるのは「キットが margin を自分で言っているか」だけ。
+  it('dialog は m-auto を自分で持つ（preflight が UA の margin:auto を消しても中央に残る）', () => {
+    const { container } = render(
+      <Modal open title="t" onClose={() => {}}>
+        b
+      </Modal>,
+    );
+    expect(classesOf(dialogOf(container)).split(/\s+/)).toContain('m-auto');
+  });
+
+  it('sheetOnMobile でも m-auto は残り、下端寄せは max-sm: 側だけが上書きする', () => {
+    const { container } = render(
+      <Modal open title="t" sheetOnMobile onClose={() => {}}>
+        b
+      </Modal>,
+    );
+    const cls = classesOf(dialogOf(container)).split(/\s+/);
+    expect(cls).toContain('m-auto');
+    expect(cls).toContain('max-sm:mb-0');
+    expect(cls).toContain('max-sm:mt-auto');
+    // 🔴 広い画面の margin を消す素のクラス（mb-0 / mt-0 / m-0）を持たない
+    expect(cls.filter((c) => /^m[tbxy]?-0$/.test(c))).toEqual([]);
+  });
+});
+
 describe('Modal — 可視ヘッダ（#392①）', () => {
   it('題を見出しとして描き、dialog はその見出しで名前を得る', () => {
     const { container } = render(


### PR DESCRIPTION
Closes #417

## 何が起きていたか（vault の本番・hub が origin/main で裏取り）

Tailwind v4（preflight 込み）の艦でキットの `Modal` を `showModal()` すると、**desktop で dialog が左上 (0,0) に張り付く**。
UA の `dialog { margin: auto }` を preflight の `* { margin: 0 }`（author origin）が消すため。vault の変異テスト
（`dialog { margin: auto !important }` 注入）で 1280 → (380, 90)・375 → (10.5, 26.7) と中央へ戻ることが確認されている。

🔑 **キットは margin:auto を借りていた。** `sheetOnMobile` の `max-sm:mt-auto max-sm:mb-0` は
「広い画面では UA の margin:auto が効いている」前提で書かれており、preflight 艦ではその前提が最初から無かった。
#411 のテストが緑のまま出荷されたのは、jsdom が `showModal` を実装せず**位置が射程外**だから。

## 変更（1点）

dialog のクラス列に **`m-auto`** を足した。`max-sm:` 側は変えていない（狭い画面では `max-sm:mb-0` が `m-auto` に勝つ）。
`default.css` に `dialog { margin: auto }` を置く案は**キット外の dialog にも効く**ので採らない（hub 裁定 08-25）。

## テスト（2本・jsdom で固定できる範囲だけ）

- dialog が `m-auto` を自分で持つ
- `sheetOnMobile` でも `m-auto` が残り、`max-sm:mb-0` / `max-sm:mt-auto` と共存し、素の `m-0` 系を持たない

⚠️ **中央に戻ったかは、このリポでは測れない。** vault の live レーン（nene-vault #441）で 0.16.1 を当てて測るまで「直った」と書かない。

## 版

`nene2-ui` **0.16.1**（patch）。`package.json` / `package-lock.json`（workspace 行1つ・`npm install --package-lock-only` で同期、diff は当該1行のみ）/ `docs/publish.md` の版節。

## 実測

- `npx vitest run`: **766 passed / 49 files**（Start at 18:4x）※ 新規2本を含む
- `npm run check`: **EXIT=0**（8ステップ）

publish は施主の手。マージ後に hub へ版番号を返す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
