### PR TITLE
feat(ui) 0.17.0: className を Badge / FormField / DataTable / Pagination に（#390）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -65,6 +65,18 @@ nene2-ui         （未公開）
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
 > 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
 
+### `@hideyukimori/nene2-ui` 0.17.0（**minor — feat**・vault W1b の待ち分）
+
+**載せ替える前に読むもの: 「各艦でやること」の節（下）。** 中身はすべて**任意 prop**で、**既定は 0.16.1 までの描画と同じ**。
+何も渡さない呼び出し側は1文字も変わらない。
+
+| Issue | 入るもの | 既定 |
+| --- | --- | --- |
+| #390 | `className` を `Badge` / `FormField` / `DataTable` / `Pagination` の4部品に（root に着地） | 渡さなければ無し |
+
+🔴 **`Modal` / `ConfirmDialog` / `ToastProvider` は `className` を受けない（意図）。** オーバーレイ／プロバイダで、
+外から任意クラスを載せると `<dialog>` の margin / top-layer の前提が崩れる——0.16.1（#417）がその実例。
+
 ### `@hideyukimori/nene2-ui` 0.16.1（**patch — fix**・#417）
 
 **載せ替える前に読むもの: 無し。** 変わるのは1点で、**Tailwind preflight の艦で dialog が中央に来る**ようになる。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.16.1",
+      "version": "0.17.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -258,6 +258,12 @@ wrap every choice in a `<div>` to say them.
 label, so the kit carries it). That was right and it left the reason in place. **Fixing what
 a report names is not the same as fixing what it is about.**
 
+Until 0.17.0 seven components accepted no `className` at all. Four of them now do — `Badge`,
+`FormField`, `DataTable`, `Pagination` — because a caller could not add a margin or a width
+without wrapping them. **Three still do not, on purpose**: `Modal`, `ConfirmDialog` and
+`ToastProvider` are overlays and a provider; a class landed on a `<dialog>` from outside can
+undo the margin and top-layer assumptions the kit relies on (0.16.1 is the case in point).
+
 ### 🔴 A palette that is missing a meaning
 
 The kit's theme defines **8 of the 28 colours** in the frozen Core Token Contract v1. That

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/data/DataTable.tsx
+++ b/packages/nene2-ui/src/data/DataTable.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { cx } from '../lib/cx.js';
 
 export interface DataColumn<Row> {
   /** Stable key, also used as the React key. */
@@ -18,6 +19,8 @@ export interface DataTableProps<Row> {
   rowKey: (row: Row) => string;
   /** Localized description of what the table contains. Becomes the table's caption. */
   caption: string;
+  /** Composed after the kit's own classes (design principle 2). Lands on the `<table>`. */
+  className?: string;
 }
 
 /**
@@ -32,9 +35,9 @@ export interface DataTableProps<Row> {
  * invoice list") is not obvious to someone arriving at it by keyboard from elsewhere on the
  * page. It is visually hidden, not absent.
  */
-export function DataTable<Row>({ columns, rows, rowKey, caption }: DataTableProps<Row>) {
+export function DataTable<Row>({ columns, rows, rowKey, caption, className }: DataTableProps<Row>) {
   return (
-    <table className="w-full border-collapse font-sans text-x-slot-table-fg">
+    <table className={cx('w-full border-collapse font-sans text-x-slot-table-fg', className)}>
       <caption className="sr-only">{caption}</caption>
       <thead>
         <tr>

--- a/packages/nene2-ui/src/data/Pagination.tsx
+++ b/packages/nene2-ui/src/data/Pagination.tsx
@@ -15,6 +15,8 @@ interface PaginationBase {
    * component that only knew about pages could not produce the sentence the product needs.
    */
   status: string;
+  /** Composed after the kit's own classes (design principle 2). Lands on the `<nav>`. */
+  className?: string;
 }
 
 interface PagePagination extends PaginationBase {
@@ -61,7 +63,7 @@ export type PaginationProps = PagePagination | OffsetPagination;
  * the row jump, and moves the next-page button under the cursor that just clicked it.
  */
 export function Pagination(props: PaginationProps) {
-  const { label, previousLabel, nextLabel, status } = props;
+  const { label, previousLabel, nextLabel, status, className } = props;
 
   const atStart = props.page === undefined ? !props.canPrev : props.page <= 1;
   const atEnd = props.page === undefined ? !props.canNext : props.page >= props.pageCount;
@@ -72,7 +74,7 @@ export function Pagination(props: PaginationProps) {
     props.page === undefined ? props.onNext() : props.onPageChange(props.page + 1);
 
   return (
-    <nav aria-label={label}>
+    <nav aria-label={label} className={className}>
       <Stack direction="horizontal" gap="2xs" align="center">
         <Button variant="secondary" disabled={atStart} onClick={goPrev} aria-label={previousLabel}>
           {previousLabel}

--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -4,6 +4,8 @@ import { cx } from '../lib/cx.js';
 export interface BadgeProps {
   /** What the badge means, not what colour it is. */
   tone?: 'neutral' | 'accent' | 'danger';
+  /** Composed after the kit's own classes (design principle 2). */
+  className?: string;
   children: ReactNode;
 }
 
@@ -21,12 +23,13 @@ const TONE_CLASS: Record<NonNullable<BadgeProps['tone']>, string> = {
  * `<Badge color="red">` becomes a lie the moment the theme changes, and there is no way to
  * find every such lie afterwards except by reading every screen.
  */
-export function Badge({ tone = 'neutral', children }: BadgeProps) {
+export function Badge({ tone = 'neutral', className, children }: BadgeProps) {
   return (
     <span
       className={cx(
         'inline-flex items-center rounded-x-slot-badge border px-x-slot-badge-pad-x py-x-slot-badge-pad-y font-sans',
         TONE_CLASS[tone],
+        className,
       )}
     >
       {children}

--- a/packages/nene2-ui/src/forms/FormField.tsx
+++ b/packages/nene2-ui/src/forms/FormField.tsx
@@ -1,5 +1,6 @@
 import { useMemo, type ReactNode } from 'react';
 import { FieldContext } from './field-context.js';
+import { cx } from '../lib/cx.js';
 
 export interface FormFieldProps {
   /** id of the control this field labels; the control picks it up automatically. */
@@ -39,6 +40,8 @@ export interface FormFieldProps {
    * Folding the two together would mean the kit picking "*" for every locale.
    */
   requiredMarker?: ReactNode;
+  /** Composed after the kit's own classes (design principle 2). Lands on the outer `<div>`. */
+  className?: string;
   children: ReactNode;
 }
 
@@ -66,6 +69,7 @@ export function FormField({
   labelAdornment,
   required = false,
   requiredMarker,
+  className,
   children,
 }: FormFieldProps) {
   const errorId = error === null ? null : `${id}-error`;
@@ -78,7 +82,7 @@ export function FormField({
 
   return (
     <FieldContext.Provider value={value}>
-      <div className="flex flex-col gap-x-slot-field-gap">
+      <div className={cx('flex flex-col gap-x-slot-field-gap', className)}>
         <label
           htmlFor={id}
           className="font-sans font-x-slot-field-label text-x-slot-field-label-size text-x-slot-field-label"

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -17,6 +17,10 @@ import { Checkbox } from './Checkbox.js';
 import { Radio } from './Radio.js';
 import { Switch } from './Switch.js';
 import { Icon } from './Icon.js';
+import { Badge } from '../feedback/Badge.js';
+import { FormField } from '../forms/FormField.js';
+import { DataTable } from '../data/DataTable.js';
+import { Pagination } from '../data/Pagination.js';
 
 afterEach(() => {
   document.body.innerHTML = '';
@@ -144,6 +148,73 @@ describe('className lands on the root', () => {
     const { container } = render(node);
     const root = container.firstElementChild;
     expect(root?.getAttribute('class') ?? '').toContain('MARK');
+  });
+
+  // #390 — 0.16.1 まで className を受けなかった7部品のうち、受けるべき4つ。
+  // Modal / ConfirmDialog / ToastProvider は受けない側に置く（オーバーレイ／プロバイダ。
+  // dialog に外から任意クラスを載せると margin / top-layer の前提が崩れる——#417 がその実例）。
+  const LATE_CASES = [
+    [
+      'Badge',
+      <Badge key="bd" className="MARK">
+        x
+      </Badge>,
+    ],
+    [
+      'FormField',
+      <FormField key="ff" id="f" label="x" className="MARK">
+        <input id="f" />
+      </FormField>,
+    ],
+    [
+      'DataTable',
+      <DataTable
+        key="dt"
+        caption="c"
+        className="MARK"
+        columns={[{ key: 'a', header: 'A', cell: (r: { a: string }) => r.a }]}
+        rows={[{ a: '1' }]}
+        rowKey={(r) => r.a}
+      />,
+    ],
+    [
+      'Pagination',
+      <Pagination
+        key="pg"
+        label="p"
+        previousLabel="prev"
+        nextLabel="next"
+        status="1 / 1"
+        page={1}
+        pageCount={1}
+        onPageChange={() => {}}
+        className="MARK"
+      />,
+    ],
+  ] as const;
+
+  it.each(LATE_CASES)(
+    '%s (0.17.0) puts the caller’s class on its outermost element',
+    (_n, node) => {
+      const { container } = render(node);
+      const root = container.firstElementChild;
+      expect(root?.getAttribute('class') ?? '').toContain('MARK');
+    },
+  );
+
+  it('Pagination without className renders no empty class attribute', () => {
+    const { container } = render(
+      <Pagination
+        label="p"
+        previousLabel="prev"
+        nextLabel="next"
+        status="1 / 1"
+        page={1}
+        pageCount={1}
+        onPageChange={() => {}}
+      />,
+    );
+    expect(container.firstElementChild?.hasAttribute('class')).toBe(false);
   });
 
   it('Checkbox still lets the box itself be reached, separately', () => {


### PR DESCRIPTION
Closes #390

## 何を

`className` を **`Badge` / `FormField` / `DataTable` / `Pagination`** の4部品に。root に着地（span / div / table / nav）。任意 prop・既定は不変。

## 受けないもの（意図・README に明記）

`Modal` / `ConfirmDialog` / `ToastProvider`。オーバーレイ／プロバイダで、`<dialog>` に外から任意クラスを載せると margin / top-layer の前提が崩れる——0.16.1（#417）がその実例。vault の回答（hub 経由）「Modal に className で足したいものは今は無い」で確定。

## テスト

`states.test.tsx` の「className lands on the root」に4部品を追加（`MARK` が root の class に在る）＋ Pagination は `className` 省略時に空の `class=""` を出さない。

## 版

**0.17.0 の1本目**なので `package.json` / lock を 0.17.0 に上げ、`docs/publish.md` に 0.17.0 の版節を立てた。**積み上げ PR 群の base**——続く #422 / #421 / #424 / #423 はこの枝を base にし、同じ節を育てる。

## 実測

- vitest（nene2-ui）: 241 passed / 14 files（+5）
- `npm run check`: EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
