### PR TITLE
feat(ui): Badge の tone に success / warn / info — パレットに6色を足す（#422）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -73,6 +73,7 @@ nene2-ui         （未公開）
 | Issue | 入るもの | 既定 |
 | --- | --- | --- |
 | #390 | `className` を `Badge` / `FormField` / `DataTable` / `Pagination` の4部品に（root に着地） | 渡さなければ無し |
+| #422 | `Badge` の `tone` に **`success` / `warn` / `info`**（3 → 6値）。パレットに `success` / `info` 系6色を追加（コントラスト実測つき） | `neutral`＝不変 |
 
 🔴 **`Modal` / `ConfirmDialog` / `ToastProvider` は `className` を受けない（意図）。** オーバーレイ／プロバイダで、
 外から任意クラスを載せると `<dialog>` の margin / top-layer の前提が崩れる——0.16.1（#417）がその実例。

--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -266,9 +266,9 @@ undo the margin and top-layer assumptions the kit relies on (0.16.1 is the case 
 
 ### 🔴 A palette that is missing a meaning
 
-The kit's theme defines **8 of the 28 colours** in the frozen Core Token Contract v1. That
+The kit's theme defines **14 of the 28 colours** in the frozen Core Token Contract v1. That
 is a legal theme — the contract says what a name means, not that every name must be used —
-but it stops being harmless the moment a component needs one of the twenty.
+but it stops being harmless the moment a component needs one of the fourteen.
 
 `warn` was one. Six ships define `--color-warn`; nene-payout, the product this theme was
 promoted from, does not. So `--color-x-slot-alert-warn-*` pointed at `--color-danger` and a
@@ -279,10 +279,11 @@ listening and no one looking**.
 resolve to one value cannot express the distinction it is named for.** Both are now checked
 — radius by step count, colour by whether two meanings resolve to the same value.
 
-Still undefined: `surface-overlay`, `surface-sunken`, `text-faint`, `text-inverse`,
-`border-strong`, `accent-hover`, `accent-soft`, `on-danger`, `success`, `success-soft`,
-`on-success`, `info`, `info-soft`, `on-info`, `focus-ring`, `scrim`. Two of those —
-`focus-ring` and `scrim` — already have component slots pointing at substitutes.
+`success` / `success-soft` / `on-success` and `info` / `info-soft` / `on-info` were added in
+0.17.0 because `Badge` needed them (#422) — defined when a component needs them, not all at
+once. Still undefined: `surface-overlay`, `surface-sunken`, `text-faint`, `text-inverse`,
+`border-strong`, `accent-hover`, `accent-soft`, `on-danger`, `focus-ring`, `scrim`. Two of
+those — `focus-ring` and `scrim` — already have component slots pointing at substitutes.
 
 ### 🔴 Two validity states, and only one of them is invalid
 

--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -2,8 +2,16 @@ import type { ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
 
 export interface BadgeProps {
-  /** What the badge means, not what colour it is. */
-  tone?: 'neutral' | 'accent' | 'danger';
+  /**
+   * What the badge means, not what colour it is.
+   *
+   * 🔴 `success` / `warn` / `info` — not `ok` / `warning`. Five ships carry a success and a
+   * warning tone in their own badge and they do not agree on the words (clear and invoice
+   * say `ok`, origin says `warning`); the contract bans both synonyms, and `InlineAlert`
+   * already says `warn`. One vocabulary across the kit, so a tone means the same thing in a
+   * badge as it does in an alert (0.17.0, #422).
+   */
+  tone?: 'neutral' | 'accent' | 'danger' | 'success' | 'warn' | 'info';
   /** Composed after the kit's own classes (design principle 2). */
   className?: string;
   children: ReactNode;
@@ -14,6 +22,10 @@ const TONE_CLASS: Record<NonNullable<BadgeProps['tone']>, string> = {
     'bg-x-slot-badge-neutral-bg text-x-slot-badge-neutral-fg border-x-slot-badge-neutral-border',
   accent: 'bg-x-slot-badge-accent-bg text-x-slot-badge-accent-fg border-x-slot-badge-accent-border',
   danger: 'bg-x-slot-badge-danger-bg text-x-slot-badge-danger-fg border-x-slot-badge-danger-border',
+  success:
+    'bg-x-slot-badge-success-bg text-x-slot-badge-success-fg border-x-slot-badge-success-border',
+  warn: 'bg-x-slot-badge-warn-bg text-x-slot-badge-warn-fg border-x-slot-badge-warn-border',
+  info: 'bg-x-slot-badge-info-bg text-x-slot-badge-info-fg border-x-slot-badge-info-border',
 };
 
 /**

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -8,6 +8,9 @@
 import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Badge } from './Badge.js';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { InlineAlert } from './InlineAlert.js';
 import { ConfirmDialog } from '../overlay/ConfirmDialog.js';
 import { Modal } from '../overlay/Modal.js';
@@ -172,5 +175,35 @@ describe('InlineAlert', () => {
     expect(
       render(<InlineAlert>x</InlineAlert>).container.firstElementChild?.getAttribute('role'),
     ).toBe('status');
+  });
+});
+
+describe('Badge — success / warn / info（#422・0.17.0）', () => {
+  it.each(['success', 'warn', 'info'] as const)(
+    '%s reads its own slots, not another tone’s',
+    (tone) => {
+      const { container } = render(<Badge tone={tone}>x</Badge>);
+      const cls = container.firstElementChild?.getAttribute('class') ?? '';
+      expect(cls).toContain(`bg-x-slot-badge-${tone}-bg`);
+      expect(cls).toContain(`text-x-slot-badge-${tone}-fg`);
+      expect(cls).toContain(`border-x-slot-badge-${tone}-border`);
+      // 他のトーンのスロットを借りていない（warn が danger を指していた 0.11 以前の alert の型）
+      for (const other of ['neutral', 'accent', 'danger', 'success', 'warn', 'info'].filter(
+        (t) => t !== tone,
+      )) {
+        expect(cls).not.toContain(`x-slot-badge-${other}-`);
+      }
+    },
+  );
+
+  it('each new tone resolves to a palette colour of its own meaning in the theme', () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const theme = readFileSync(path.join(here, '../../themes/default.css'), 'utf8');
+    for (const tone of ['success', 'warn', 'info']) {
+      const m = new RegExp(`--color-x-slot-badge-${tone}-bg:\\s*var\\(--color-([a-z-]+)\\);`).exec(
+        theme,
+      );
+      expect(m?.[1], `badge ${tone} bg`).toBe(tone);
+    }
   });
 });

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -43,6 +43,22 @@
   --color-on-warn: oklch(21% 0.04 75);
   --color-danger-soft: oklch(95% 0.03 30);
 
+  /* 🔴 Six more contract colours, added in 0.17.0 for `Badge` (#422). Five ships carry a
+   * success tone and a warning tone in their own badge (clear / field / invoice / origin /
+   * vault) and four carry `info`, so a kit badge with three tones could not say what their
+   * screens already say. Hues follow the contract's reference theme; lightness is measured:
+   * white on this `success` is 5.35:1 and on this `info` 5.78:1 (both clear 4.5:1 for text),
+   * the fills are 5.51:1 / 5.95:1 against `surface-raised`, and `text-primary` on either
+   * soft is ≥ 13.8:1 — computed with the same OKLCH→sRGB pipeline that reproduces the
+   * `warn` figures above (3.48 / 3.58 / 4.97), so the calculator has a positive control.
+   * Fourteen contract colours are still undefined — see the README. */
+  --color-success: oklch(50% 0.14 155);
+  --color-success-soft: oklch(95% 0.03 155);
+  --color-on-success: oklch(99% 0 0);
+  --color-info: oklch(50% 0.12 245);
+  --color-info-soft: oklch(95% 0.03 245);
+  --color-on-info: oklch(99% 0 0);
+
   /* The shadow scale. Three steps, chosen the way the spacing and radius scales were —
    * measured from what the fleet already ships, not invented here (#386).
    *
@@ -303,6 +319,17 @@
   --color-x-slot-badge-danger-bg: var(--color-danger);
   --color-x-slot-badge-danger-fg: var(--color-on-accent);
   --color-x-slot-badge-danger-border: var(--color-danger);
+  /* 0.17.0 (#422). Filled, like `accent` and `danger`: a status badge is read at a glance
+   * and an outlined success next to a filled danger would weigh the two unequally. */
+  --color-x-slot-badge-success-bg: var(--color-success);
+  --color-x-slot-badge-success-fg: var(--color-on-success);
+  --color-x-slot-badge-success-border: var(--color-success);
+  --color-x-slot-badge-warn-bg: var(--color-warn);
+  --color-x-slot-badge-warn-fg: var(--color-on-warn);
+  --color-x-slot-badge-warn-border: var(--color-warn);
+  --color-x-slot-badge-info-bg: var(--color-info);
+  --color-x-slot-badge-info-fg: var(--color-on-info);
+  --color-x-slot-badge-info-border: var(--color-info);
 
   --color-x-slot-toast-bg: var(--color-surface-raised);
   --color-x-slot-toast-fg: var(--color-text-primary);


### PR DESCRIPTION
Closes #422

**積み上げ PR（base = #429 の枝）。** #429 のマージ後に自動で main へ付け替わる。

## 何を

`Badge` の `tone` に **`success` / `warn` / `info`**（3 → 6値）。既定 `neutral` は不変。塗りは `accent` / `danger` と同じ「塗る」形（並んだとき重さが揃う）。

## 語彙

`success` / `warn` / `info`。他艦は `ok`（clear / invoice）と `warning`（origin）で割れているが、契約は両方 synonym ban（`ok→success` / `warning→warn`）、`InlineAlert` は既に `warn`。

## パレット（契約 28 色のうち 8 → 14）

`success` / `success-soft` / `on-success` / `info` / `info-soft` / `on-info`。色相は tokens の参照テーマ、明度は**実測**:

| ペア | 比 |
|---|---:|
| 白 on `success` | **5.35** |
| 白 on `info` | **5.78** |
| `success` / `info` vs `surface-raised` | 5.51 / 5.95 |
| `text-primary` on `success-soft` / `info-soft` | 13.98 / 13.85 |

計算器は既存 `warn` の記載値（3.48 / 3.58 / 4.97）を再現＝**陽性対照つき**。

## テスト（4本）

各トーンが自分のスロットだけを読む（他トーンのスロットを借りない＝0.11 以前の alert の型を塞ぐ）／各スロットの bg がテーマで同名のパレット色を指す。

## 実測

- vitest（nene2-ui）: 245 passed / 14 files
- `npm run check`: EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
