### PR TITLE
feat(ui): Pagination に size / stackOnMobile / statusPlacement（#421）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -74,6 +74,7 @@ nene2-ui         （未公開）
 | --- | --- | --- |
 | #390 | `className` を `Badge` / `FormField` / `DataTable` / `Pagination` の4部品に（root に着地） | 渡さなければ無し |
 | #422 | `Badge` の `tone` に **`success` / `warn` / `info`**（3 → 6値）。パレットに `success` / `info` 系6色を追加（コントラスト実測つき） | `neutral`＝不変 |
+| #421 | `Pagination` に `size`（両 Button へ）/ `stackOnMobile`（`max-sm:` のみ）/ `statusPlacement`（`start` / `center` / `end`） | md・横並び・center＝不変 |
 
 🔴 **`Modal` / `ConfirmDialog` / `ToastProvider` は `className` を受けない（意図）。** オーバーレイ／プロバイダで、
 外から任意クラスを載せると `<dialog>` の margin / top-layer の前提が崩れる——0.16.1（#417）がその実例。

--- a/packages/nene2-ui/src/data/Pagination.tsx
+++ b/packages/nene2-ui/src/data/Pagination.tsx
@@ -1,5 +1,6 @@
 import { Button } from '../primitives/Button.js';
 import { Stack } from '../layout/Stack.js';
+import { cx } from '../lib/cx.js';
 
 interface PaginationBase {
   /** Localized name for the navigation region, e.g. "Invoice pages". */
@@ -17,6 +18,28 @@ interface PaginationBase {
   status: string;
   /** Composed after the kit's own classes (design principle 2). Lands on the `<nav>`. */
   className?: string;
+  /**
+   * Passed to both buttons. `sm` for a dense list footer. Omitted, the buttons keep the
+   * size they had — which is what every caller got before 0.17.0.
+   */
+  size?: 'md' | 'sm';
+  /**
+   * On a narrow viewport, stack the three parts vertically. Off by default: the same rule as
+   * `Modal`'s `sheetOnMobile` — a component that changes shape at a breakpoint is a decision.
+   */
+  stackOnMobile?: boolean;
+  /**
+   * Where the status sentence sits. `center` (default) is between the two buttons — what the
+   * component always drew. `start` puts it before both, `end` after both.
+   *
+   * 🔴 Not a free layout. Three positions is the whole space a row of two buttons and one
+   * sentence has, which makes it structure (design principle 3), not a value.
+   *
+   * There is deliberately no "hide when empty" prop: the kit cannot know a list is empty (the
+   * offset model carries no total), and `{total > 0 && <Pagination … />}` says it in the one
+   * place that does know. A prop would only move that line and pretend the kit decided.
+   */
+  statusPlacement?: 'start' | 'center' | 'end';
 }
 
 interface PagePagination extends PaginationBase {
@@ -63,7 +86,16 @@ export type PaginationProps = PagePagination | OffsetPagination;
  * the row jump, and moves the next-page button under the cursor that just clicked it.
  */
 export function Pagination(props: PaginationProps) {
-  const { label, previousLabel, nextLabel, status, className } = props;
+  const {
+    label,
+    previousLabel,
+    nextLabel,
+    status,
+    className,
+    size = 'md',
+    stackOnMobile,
+    statusPlacement = 'center',
+  } = props;
 
   const atStart = props.page === undefined ? !props.canPrev : props.page <= 1;
   const atEnd = props.page === undefined ? !props.canNext : props.page >= props.pageCount;
@@ -73,18 +105,52 @@ export function Pagination(props: PaginationProps) {
   const goNext = () =>
     props.page === undefined ? props.onNext() : props.onPageChange(props.page + 1);
 
+  const prev = (
+    <Button
+      key="prev"
+      variant="secondary"
+      size={size}
+      disabled={atStart}
+      onClick={goPrev}
+      aria-label={previousLabel}
+    >
+      {previousLabel}
+    </Button>
+  );
+  const current = (
+    <span key="status" aria-current="page" className="font-sans text-x-slot-pagination-fg">
+      {status}
+    </span>
+  );
+  const next = (
+    <Button
+      key="next"
+      variant="secondary"
+      size={size}
+      disabled={atEnd}
+      onClick={goNext}
+      aria-label={nextLabel}
+    >
+      {nextLabel}
+    </Button>
+  );
+  const order =
+    statusPlacement === 'start'
+      ? [current, prev, next]
+      : statusPlacement === 'end'
+        ? [prev, next, current]
+        : [prev, current, next];
+
   return (
     <nav aria-label={label} className={className}>
-      <Stack direction="horizontal" gap="2xs" align="center">
-        <Button variant="secondary" disabled={atStart} onClick={goPrev} aria-label={previousLabel}>
-          {previousLabel}
-        </Button>
-        <span aria-current="page" className="font-sans text-x-slot-pagination-fg">
-          {status}
-        </span>
-        <Button variant="secondary" disabled={atEnd} onClick={goNext} aria-label={nextLabel}>
-          {nextLabel}
-        </Button>
+      <Stack
+        direction="horizontal"
+        gap="2xs"
+        align="center"
+        // Every class carries the `max-sm:` prefix, so a wide viewport is untouched.
+        className={cx(stackOnMobile === true && 'max-sm:flex-col max-sm:items-stretch')}
+      >
+        {order}
       </Stack>
     </nav>
   );

--- a/packages/nene2-ui/src/data/table.test.tsx
+++ b/packages/nene2-ui/src/data/table.test.tsx
@@ -289,3 +289,55 @@ describe('Pagination offset model', () => {
     expect(onPageChange).toHaveBeenCalledWith(3);
   });
 });
+
+describe('Pagination — size / stackOnMobile / statusPlacement（#421・0.17.0）', () => {
+  const base = {
+    label: 'p',
+    previousLabel: 'prev',
+    nextLabel: 'next',
+    status: '1 / 3',
+    page: 1,
+    pageCount: 3,
+    onPageChange: () => {},
+  };
+  const texts = (c: HTMLElement) =>
+    [...(c.querySelector('nav > div')?.children ?? [])].map((el) => el.textContent);
+
+  it('既定は 0.16.1 までと同じ — 中央に status・縦積みなし・Button は md のまま', () => {
+    const { container } = render(<Pagination {...base} />);
+    expect(texts(container)).toEqual(['prev', '1 / 3', 'next']);
+    const row = container.querySelector('nav > div')?.getAttribute('class') ?? '';
+    expect(row).not.toContain('max-sm:');
+    const btn = container.querySelector('button')?.getAttribute('class') ?? '';
+    expect(btn).toContain('px-x-slot-button-pad-x');
+    expect(btn).not.toContain('button-sm');
+  });
+
+  it('size は両方の Button へ届く', () => {
+    const { container } = render(<Pagination {...base} size="sm" />);
+    const buttons = [...container.querySelectorAll('button')];
+    expect(buttons).toHaveLength(2);
+    for (const b of buttons) expect(b.getAttribute('class')).toContain('px-x-slot-button-sm-pad-x');
+  });
+
+  it('stackOnMobile は max-sm: 接頭辞のクラスだけを足す', () => {
+    const { container } = render(<Pagination {...base} stackOnMobile />);
+    const added = (container.querySelector('nav > div')?.getAttribute('class') ?? '')
+      .split(/\s+/)
+      .filter((c) => c.includes('flex-col') || c.includes('items-stretch'));
+    expect(added.length).toBeGreaterThan(0);
+    for (const c of added) expect(c.startsWith('max-sm:')).toBe(true);
+  });
+
+  it.each([
+    ['start', ['1 / 3', 'prev', 'next']],
+    ['end', ['prev', 'next', '1 / 3']],
+  ] as const)(
+    'statusPlacement=%s は順序を変え、status は aria-current のまま',
+    (placement, expected) => {
+      const { container } = render(<Pagination {...base} statusPlacement={placement} />);
+      expect(texts(container)).toEqual([...expected]);
+      expect(container.querySelector('[aria-current="page"]')?.textContent).toBe('1 / 3');
+    },
+  );
+});


### PR DESCRIPTION
Closes #421

**積み上げ PR（base = #430 の枝）。**

## 何を（任意 prop 3つ・既定は 0.16.1 までの描画）

| prop | 既定 | 渡すと |
|---|---|---|
| `size` | md | 両方の `Button` へ委譲（`sm`） |
| `stackOnMobile` | 横並び | `max-sm:flex-col max-sm:items-stretch`（**全クラス `max-sm:` 接頭辞**・広い画面は不変） |
| `statusPlacement` | `center` | `start` / `end`。2ボタン＋1文の並びは3通りしか無い＝構造（原則3） |

## 入れなかったもの（#421 の4項目目）

**「`total === 0` の非描画」は prop にしない。** キットは空を知り得ない（offset モデルは総数を持たない）。それを知っている呼び出し側の `{total > 0 && <Pagination … />}` が正しい場所で、prop はその1行を移すだけで「キットが決めた」ふりをする。JSDoc に理由を書いた。

## テスト（5本）

既定の固定（順序・`max-sm:` 無し・Button は md）／`size` が両 Button へ届く／`stackOnMobile` が足すクラスはすべて `max-sm:`／`start` `end` で順序が変わり `aria-current` は status のまま。

## 実測

- vitest（nene2-ui）: 250 passed / 14 files
- `npm run check`: EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
