### PR TITLE
feat(ui): DetailList に layout: 'stack' | 'columns' — columns は md 未満で自動的に1列（#424）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -75,6 +75,7 @@ nene2-ui         （未公開）
 | #390 | `className` を `Badge` / `FormField` / `DataTable` / `Pagination` の4部品に（root に着地） | 渡さなければ無し |
 | #422 | `Badge` の `tone` に **`success` / `warn` / `info`**（3 → 6値）。パレットに `success` / `info` 系6色を追加（コントラスト実測つき） | `neutral`＝不変 |
 | #421 | `Pagination` に `size`（両 Button へ）/ `stackOnMobile`（`max-sm:` のみ）/ `statusPlacement`（`start` / `center` / `end`） | md・横並び・center＝不変 |
+| #424 | `DetailList` に `layout: 'stack' \| 'columns'`。`columns` は **md 未満で自動的に1列**（利用側は書かない） | `stack`＝不変 |
 
 🔴 **`Modal` / `ConfirmDialog` / `ToastProvider` は `className` を受けない（意図）。** オーバーレイ／プロバイダで、
 外から任意クラスを載せると `<dialog>` の margin / top-layer の前提が崩れる——0.16.1（#417）がその実例。

--- a/packages/nene2-ui/src/data/DetailList.tsx
+++ b/packages/nene2-ui/src/data/DetailList.tsx
@@ -11,15 +11,38 @@ export interface DetailListProps {
   /** Composed after the kit's own classes (design principle 2). */
   className?: string;
   rows: DetailRow[];
+  /**
+   * `stack` (default) is one row per line — what the component always drew. `columns` lays
+   * the rows out in two columns on a wide viewport and **falls back to one column below
+   * `md` on its own**, so a caller never has to say so (nene-vault's own `<dl>` carries
+   * `max-md:grid-cols-1`, and so do the other four ships' — measured 2026-08-25, #391).
+   *
+   * 🔴 A choice between two arrangements, not a column count. Five ships write a two-column
+   * detail block and none writes three; a `columns: number` would be a value the kit
+   * invented (design principle 3). `rows[].span` was considered and rejected for the same
+   * reason: it brings a column count into every row (#424).
+   *
+   * Only structure lives here. The term's weight and colour are slots
+   * (`--font-weight-x-slot-detail-term`, `--color-x-slot-detail-term-fg`) and reach a
+   * product through the theme, not through a prop.
+   */
+  layout?: 'stack' | 'columns';
 }
 
 /**
  * Read-only key/value display for detail screens. Uses a description list so the
  * label/value relationship is conveyed to assistive technology.
  */
-export function DetailList({ rows, className }: DetailListProps) {
+const LAYOUT_CLASS: Record<NonNullable<DetailListProps['layout']>, string> = {
+  stack: 'flex flex-col',
+  // One gap slot for both axes — the fleet's two-column blocks use one value, and a second
+  // slot would be a step nobody asked for.
+  columns: 'grid grid-cols-2 max-md:grid-cols-1',
+};
+
+export function DetailList({ rows, className, layout = 'stack' }: DetailListProps) {
   return (
-    <dl className={cx('flex flex-col gap-x-slot-detail-gap', className)}>
+    <dl className={cx(LAYOUT_CLASS[layout], 'gap-x-slot-detail-gap', className)}>
       {rows.map((row) => (
         <div
           key={row.label}

--- a/packages/nene2-ui/src/data/detail-list.test.tsx
+++ b/packages/nene2-ui/src/data/detail-list.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DetailList } from './DetailList.js';
+
+/**
+ * #424 — DetailList の layout（stack / columns）。
+ *
+ * 🔴 主眼は「既定が 0.16.1 までの描画と同じ」であること（#392 と同じ型）。
+ * columns は狭い画面で自動的に1列へ落ちる（vault 現物 AuditPage.tsx:248 の max-md:grid-cols-1 に倣う）。
+ */
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const rows = [
+  { label: 'a', value: '1' },
+  { label: 'b', value: '2' },
+];
+const classesOf = (c: HTMLElement) =>
+  (c.querySelector('dl')?.getAttribute('class') ?? '').split(/\s+/);
+
+describe('DetailList — layout', () => {
+  it('既定は flex の縦積みで、grid のクラスを1つも持たない', () => {
+    const cls = classesOf(render(<DetailList rows={rows} />).container);
+    expect(cls).toContain('flex');
+    expect(cls).toContain('flex-col');
+    expect(cls.filter((c) => c.includes('grid'))).toEqual([]);
+  });
+
+  it('columns は2列の grid で、md 未満では自分で1列に落ちる', () => {
+    const cls = classesOf(render(<DetailList rows={rows} layout="columns" />).container);
+    expect(cls).toContain('grid');
+    expect(cls).toContain('grid-cols-2');
+    expect(cls).toContain('max-md:grid-cols-1');
+    expect(cls).not.toContain('flex-col');
+  });
+
+  it('どちらの layout でも gap は同じスロットから読む', () => {
+    for (const layout of ['stack', 'columns'] as const) {
+      expect(classesOf(render(<DetailList rows={rows} layout={layout} />).container)).toContain(
+        'gap-x-slot-detail-gap',
+      );
+    }
+  });
+
+  it('className は layout の後ろに合成される', () => {
+    const cls = classesOf(
+      render(<DetailList rows={rows} layout="columns" className="MARK" />).container,
+    );
+    expect(cls[cls.length - 1]).toBe('MARK');
+  });
+});


### PR DESCRIPTION
Closes #424

**積み上げ PR（base = #431 の枝）。**

## 何を

`DetailList` に `layout?: 'stack' | 'columns'`（既定 `stack`＝従来の flex 縦積み・不変）。
`columns` = `grid grid-cols-2 max-md:grid-cols-1` — **md 未満で自分で1列に落ちる**（vault 現物 `AuditPage.tsx:248` と同じ・利用側は折り返しを書かない）。

## 採らなかったもの

- `rows[].span`（列数の概念を行ごとに持ち込む・hub 裁定）
- `columns: number`（5艦が2列を書き、3列を書く艦は無い＝値の発明）
- `dt` の意匠（太さ・色）— スロットで届く（#391「やらないこと」）
- 列間と行間の別スロット — フリートの2カラム塊は1値で書いている

## 根拠

下限 **5艦 7ファイル**（#391 コメント・tsx 4件を目視、偽陽性1）。

## テスト（4本・新規 `detail-list.test.tsx`）

既定は grid クラスを1つも持たない／`columns` は `grid-cols-2` と `max-md:grid-cols-1` の両方／gap は両 layout とも同じスロット／`className` は最後に合成。

## 実測

- vitest（nene2-ui）: 254 passed / 15 files
- `npm run check`: EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
