### PR TITLE
feat(ui): DataTable に collapse: 'sm' — sm 未満で行をカード化（#423）＋ 配布メモの消費側の節（#428）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -76,6 +76,17 @@ nene2-ui         （未公開）
 | #422 | `Badge` の `tone` に **`success` / `warn` / `info`**（3 → 6値）。パレットに `success` / `info` 系6色を追加（コントラスト実測つき） | `neutral`＝不変 |
 | #421 | `Pagination` に `size`（両 Button へ）/ `stackOnMobile`（`max-sm:` のみ）/ `statusPlacement`（`start` / `center` / `end`） | md・横並び・center＝不変 |
 | #424 | `DetailList` に `layout: 'stack' \| 'columns'`。`columns` は **md 未満で自動的に1列**（利用側は書かない） | `stack`＝不変 |
+| #423 | `DataTable` に `collapse: 'sm'`。sm 未満で行をカード化（各 `td` に `data-label`＝列見出し・`::before` で描く・**全クラス `max-sm:`**）。見出し行は `sr-only` で隠すだけ＝`th scope` は残る | 無し＝不変 |
+
+⚠️ **`collapse` の読み上げが二重にならないか**（`th` scope ＋ `::before`）は jsdom では測れない。**vault の live で確認するまで「a11y は問題なし」と書かない。**
+
+#### 各艦でやること — 宣言を上げるだけでは入らない（#428・hub 実測 2026-08-25: 14艦中13艦が caret 内で lock 停止）
+
+1. **宣言を上げる**。0.x の caret は minor を固定する: `^0.16.0` は 0.17.0 を**含まない** ⇒ `^0.17.0` へ。
+2. **`npm update @hideyukimori/nene2-ui`**（`npm install` は lock 優先で上がらない。tokens / standards / i18n / client も同じ形で止まっている艦が13艦）。
+3. **`npm ls @hideyukimori/nene2-ui @hideyukimori/nene2-tokens @hideyukimori/nene2-standards @hideyukimori/nene2-i18n`** で**実インストール版**を見る（宣言ではなく）。
+4. **実ブラウザ**まで確かめる — `docker compose` の名前付きボリューム・`node_modules/.vite/deps` の古いプリバンドル（`_work/issues.md` #119）。
+5. 🔴 **`npm ci` は lock を尊重する** ⇒ 宣言だけ上げた PR は CI が緑でも**何も入っていない**。**lock の diff が PR に無ければ上がっていない。**
 
 🔴 **`Modal` / `ConfirmDialog` / `ToastProvider` は `className` を受けない（意図）。** オーバーレイ／プロバイダで、
 外から任意クラスを載せると `<dialog>` の margin / top-layer の前提が崩れる——0.16.1（#417）がその実例。

--- a/packages/nene2-ui/src/data/DataTable.tsx
+++ b/packages/nene2-ui/src/data/DataTable.tsx
@@ -21,6 +21,22 @@ export interface DataTableProps<Row> {
   caption: string;
   /** Composed after the kit's own classes (design principle 2). Lands on the `<table>`. */
   className?: string;
+  /**
+   * Below `sm`, draw each row as a card: every cell becomes a block headed by its column's
+   * name. Off by default — a table that changes shape at a breakpoint is a decision, the
+   * same rule as `Modal`'s `sheetOnMobile`.
+   *
+   * 🔴 Four ships already do this by hand (`<td data-label>` + `content: attr(data-label)`;
+   * invoice / profile / records / vault, measured 2026-08-25), which is why it is here and
+   * not left to them (#423). The kit does it with utilities, every one carrying the
+   * `max-sm:` prefix, so a wide viewport is untouched.
+   *
+   * ⚠️ The visual header row is hidden (`sr-only`), not removed: the `<th scope="col">` stay
+   * in the document, so assistive tech still pairs a cell with its column. The `::before`
+   * label is presentational and is not read on its own. That the two do not double up is a
+   * live-lane check — jsdom does not lay out, and it is not asserted here.
+   */
+  collapse?: 'sm';
 }
 
 /**
@@ -35,11 +51,34 @@ export interface DataTableProps<Row> {
  * invoice list") is not obvious to someone arriving at it by keyboard from elsewhere on the
  * page. It is visually hidden, not absent.
  */
-export function DataTable<Row>({ columns, rows, rowKey, caption, className }: DataTableProps<Row>) {
+// Every class here carries `max-sm:`. Only structure — the label's weight and colour are
+// the header's own slots, read through `before:`.
+const CARD_TABLE = 'max-sm:block';
+const CARD_THEAD = 'max-sm:sr-only';
+const CARD_TBODY = 'max-sm:block';
+const CARD_ROW = 'max-sm:block max-sm:border-b max-sm:border-x-slot-table-border';
+const CARD_CELL =
+  'max-sm:block max-sm:border-b-0 max-sm:text-left max-sm:before:block max-sm:before:content-[attr(data-label)] max-sm:before:font-x-slot-table-header max-sm:before:text-x-slot-table-header-fg';
+
+export function DataTable<Row>({
+  columns,
+  rows,
+  rowKey,
+  caption,
+  className,
+  collapse,
+}: DataTableProps<Row>) {
+  const cards = collapse === 'sm';
   return (
-    <table className={cx('w-full border-collapse font-sans text-x-slot-table-fg', className)}>
+    <table
+      className={cx(
+        'w-full border-collapse font-sans text-x-slot-table-fg',
+        cards && CARD_TABLE,
+        className,
+      )}
+    >
       <caption className="sr-only">{caption}</caption>
-      <thead>
+      <thead className={cards ? CARD_THEAD : undefined}>
         <tr>
           {columns.map((col) => (
             <th
@@ -54,15 +93,18 @@ export function DataTable<Row>({ columns, rows, rowKey, caption, className }: Da
           ))}
         </tr>
       </thead>
-      <tbody>
+      <tbody className={cards ? CARD_TBODY : undefined}>
         {rows.map((row) => (
-          <tr key={rowKey(row)}>
+          <tr key={rowKey(row)} className={cards ? CARD_ROW : undefined}>
             {columns.map((col) => (
               <td
                 key={col.key}
-                className={`border-b border-x-slot-table-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y ${
-                  col.align === 'end' ? 'text-right' : 'text-left'
-                }`}
+                {...(cards ? { 'data-label': col.header } : {})}
+                className={cx(
+                  'border-b border-x-slot-table-border px-x-slot-table-cell-pad-x py-x-slot-table-cell-pad-y',
+                  col.align === 'end' ? 'text-right' : 'text-left',
+                  cards && CARD_CELL,
+                )}
               >
                 {col.cell(row)}
               </td>

--- a/packages/nene2-ui/src/data/table.test.tsx
+++ b/packages/nene2-ui/src/data/table.test.tsx
@@ -341,3 +341,63 @@ describe('Pagination — size / stackOnMobile / statusPlacement（#421・0.17.0�
     },
   );
 });
+
+describe('DataTable — collapse: "sm"（#423・0.17.0）', () => {
+  const columns = [
+    { key: 'a', header: 'Name', cell: (r: { a: string; b: string }) => r.a },
+    {
+      key: 'b',
+      header: 'Amount',
+      cell: (r: { a: string; b: string }) => r.b,
+      align: 'end' as const,
+    },
+  ];
+  const rows = [{ a: 'x', b: '1' }];
+  const all = (c: HTMLElement) =>
+    [...c.querySelectorAll('table, thead, tbody, tr, td')].flatMap((el) =>
+      (el.getAttribute('class') ?? '').split(/\s+/).filter(Boolean),
+    );
+
+  it('既定は data-label を出さず、max-sm: のクラスを1つも持たない', () => {
+    const { container } = render(
+      <DataTable caption="c" columns={columns} rows={rows} rowKey={(r) => r.a} />,
+    );
+    expect(container.querySelector('[data-label]')).toBeNull();
+    expect(all(container).filter((c) => c.startsWith('max-sm:'))).toEqual([]);
+    // 空の class 属性を撒かない
+    expect(container.querySelector('thead')?.hasAttribute('class')).toBe(false);
+  });
+
+  it('collapse="sm" は各 td に列見出しを data-label で持たせる', () => {
+    const { container } = render(
+      <DataTable caption="c" columns={columns} rows={rows} rowKey={(r) => r.a} collapse="sm" />,
+    );
+    const labels = [...container.querySelectorAll('td')].map((td) => td.getAttribute('data-label'));
+    expect(labels).toEqual(['Name', 'Amount']);
+  });
+
+  it('collapse が足すクラスはすべて max-sm: 接頭辞つき（広い画面は不変）', () => {
+    const plain = all(
+      render(<DataTable caption="c" columns={columns} rows={rows} rowKey={(r) => r.a} />).container,
+    );
+    document.body.innerHTML = '';
+    const cards = all(
+      render(
+        <DataTable caption="c" columns={columns} rows={rows} rowKey={(r) => r.a} collapse="sm" />,
+      ).container,
+    );
+    const added = cards.filter((c) => !plain.includes(c));
+    expect(added.length).toBeGreaterThan(0);
+    for (const c of added) expect(c.startsWith('max-sm:')).toBe(true);
+  });
+
+  it('見出し行は隠すだけで消さない — th の scope は残る', () => {
+    const { container } = render(
+      <DataTable caption="c" columns={columns} rows={rows} rowKey={(r) => r.a} collapse="sm" />,
+    );
+    const ths = [...container.querySelectorAll('th')];
+    expect(ths).toHaveLength(2);
+    for (const th of ths) expect(th.getAttribute('scope')).toBe('col');
+    expect(container.querySelector('thead')?.getAttribute('class')).toContain('max-sm:sr-only');
+  });
+});


### PR DESCRIPTION
Closes #423
Closes #428

**積み上げ PR（base = #432 の枝）・0.17.0 の最終便。**

## #423 — `DataTable` に `collapse?: 'sm'`（既定なし＝不変）

指定時: 各 `<td>` に `data-label={col.header}`（`header` は既に `string`・論点消滅）、行を `max-sm:` の utility でカード化（`table/tbody/tr/td` を block・`td::before { content: attr(data-label) }`・ラベルの太さと色は `table-header` のスロット）。**全クラス `max-sm:` 接頭辞**で広い画面は不変。

見出し行は **`sr-only` で隠すだけで消さない** — `<th scope="col">` は残り、支援技術は列と対にできる。

⚠️ `::before` のラベルと `th` の読み上げが二重にならないかは **jsdom では測れない**。vault の live で確認するまで「a11y は問題なし」と書かない（publish.md にも明記）。

実需: `attr(data-label)` を持つ艦 **4艦**（invoice / profile / records / vault・2026-08-25 実測）。

## #428 — 版節に「各艦でやること」

宣言を上げても **`npm ci` は lock を尊重して何も入らない**（hub 実測: 14艦中13艦が caret 内で lock 停止・伝聞と明記）。`^0.17.0` へ → `npm update` → `npm ls` で実インストール版 → 実ブラウザ（compose ボリューム・`.vite/deps`）。**lock の diff が PR に無ければ上がっていない。**

## テスト（4本）

既定は `data-label` も `max-sm:` も空の `class` も出さない／`collapse` で各 td に列見出し／足すクラスはすべて `max-sm:`／`th scope="col"` は残り thead は `max-sm:sr-only`。

## 実測

- vitest（nene2-ui）: 258 passed / 15 files
- `npm run check`: EXIT=0

## 0.17.0 の全体（積み上げ順）

#429（#390）→ #430（#422）→ #431（#421）→ #432（#424）→ **本 PR**（#423 + #428）。マージは上から順・publish は施主。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
