### PR TITLE
docs(daily): 2026-08-25 セッション3本目の日報（#435）

### DIFF
--- a/docs/daily/2026-08-25-3.md
+++ b/docs/daily/2026-08-25-3.md
@@ -1,0 +1,58 @@
+# 2026-08-25 セッション日報（同日3本目）
+
+> **対象期間: 2026-08-25 22:1x 〜 23:2x（JST）**〔`date` 実測: 本文執筆 23:17:49。機械の起動は `uptime -s` = 14:22:32〕
+> 2本目（`2026-08-25-2.md`）の hub 店じまい宣言（21:5x）の後、**施主指示「fleet に対応するように伝えて」＝0.17.0 の実装**で再開したので新セッション（hub 裁定 08-05・#241）。
+
+hub 経由の施主指示で `nene2-ui` **0.17.0** を実装し、施主の直接 GO（マージ→publish）で**同夜に出荷**した。
+PR 5本を積み上げ式で出したが、**squash マージと積み上げは相性が悪く**、復旧に1手間かかった。
+
+## ヘッドライン
+
+1. 🟢 **`nene2-ui` 0.17.0 を publish**（shasum dry run＝本番 `d01a18f4…`・`npm view` latest 0.17.0・23:16）。中身 = #390 + #422 + #421 + #424 + #423 + #428。
+2. 🔴 **積み上げ PR × squash の衝突**: #429 を squash した瞬間に後続4枝が main と衝突、base 枝の削除で #430 が自動 CLOSE（reopen 不可）。cherry-pick で作り直し、#430 は #434 として立て直した。
+3. 自分の誤り **4件**（下記）。
+
+## 本日の成果（時系列）
+
+| 時刻 | PR | Issue | 中身 | 実測 |
+| --- | --- | --- | --- | --- |
+| 22:4x | #429 | #390 | `className` を Badge / FormField / DataTable / Pagination（Modal は意図して除外・README に明記）。版 0.17.0・publish.md 版節 | 241 passed |
+| 22:5x | #430→**#434** | #422 | Badge に `success` / `warn` / `info`。パレット6色（白 on success **5.35** / on info **5.78**・計算器は既存 warn の 3.48/3.58/4.97 を再現＝陽性対照） | 245 |
+| 23:0x | #431 | #421 | Pagination に `size` / `stackOnMobile` / `statusPlacement`。「空で非描画」は **prop にしない**（キットは空を知り得ない） | 250 |
+| 23:0x | #432 | #424 | DetailList に `layout: 'stack' \| 'columns'`（md 未満で自動1列・`rows[].span` 不採用） | 254 |
+| 23:1x | #433 | #423 + #428 | DataTable に `collapse: 'sm'`（`data-label`・全クラス `max-sm:`・thead は `sr-only` で `th scope` を残す）＋ 版節に「各艦でやること」 | 258 |
+
+- マージ（施主 GO 23:01）: #429 → #434 → #431 → #432 → #433。main `cb44cca`。**main で vitest 796 / 50・check EXIT=0**（23:12）。
+- publish（施主 GO 23:1x）: dry run → 本番。provenance 署名・tag `nene2-ui-v0.17.0`。
+- hub へ 2通（PR 番号・完了報告）。
+
+## 積み上げ PR と squash（次回のために）
+
+各 PR の base を前の枝にした。**#429 を squash した瞬間**、後続の枝に残る「#429 の元コミット」が main の squash コミットと同じ変更・別コミットになり、`update-branch` が衝突。さらに `--delete-branch` で base 枝が消えた #430 を **GitHub が自動 CLOSE**（retarget されず・reopen も API で拒否）。
+復旧: 各枝を `git checkout -B <枝> main` → 先端1コミットを `cherry-pick` → force-push → base を main へ → CI → マージ。#430 だけ新 PR #434。
+⇒ **次回は 1本ずつ main 直下で出す**（前の PR がマージされてから次を切る）。積み上げは squash と組み合わせない。
+
+## 自分の誤り（4件）
+
+1. #431 を `;` で繋いだため **type-check 赤のまま commit・PR** まで走った（`exactOptionalPropertyTypes`）→ amend・force-push。以降 `&&`。
+2. #433 の既定側で `cx(false)` が `class=""` を撒いた → 自分のテストが捕まえた → `undefined` に。
+3. 復旧ループで `git cherry-pick -q`（無効オプション）→ 全ステップが最初で止まった。**push 前だったので実害なし**。
+4. 積み上げ PR を選んだ判断そのもの（上記）。hub の「1 PR 群」を「積み上げ」と読んだが、squash 前提のリポでは 1本ずつが正しかった。
+
+## 📊 本日の数字（このセッション）
+
+| | 値 | 出所 |
+| --- | ---: | --- |
+| 起票した Issue | **2本**（#435 #436・実装5本は前セッション起票） | 自分 |
+| 出した PR | **6本**（#429 #430 #431 #432 #433 #434）・**マージ 5本** | 自分 |
+| publish | `nene2-ui` **0.17.0**（shasum `d01a18f4…`・dry run と一致） | 自分・`npm view` |
+| テスト | main **774 → 796 / 49 → 50 files** | vitest 23:12:02 |
+| hub へ送ったメッセージ | **2通** | 自分 |
+| 自分の誤り | **4件** | 上記 |
+
+## 申し送り
+
+- 🟢 **0.17.0 は npm に出ている。** vault は `^0.17.0` → `npm update` → `npm ls` → 実ブラウザ（publish.md「各艦でやること」）。
+- 🔴 **jsdom で測れない2点は vault の live で**: #423 の `::before` ラベルと `th` の読み上げ二重化／#431 の縦積みの見た目。確認まで「問題なし」と書かない。
+- floor は据え置き（#271）。
+- 明日: C8（seed-all.py・xi-workspace の枝→PR）→ #164 タスク2/3 → #410 の18件判定。


### PR DESCRIPTION
Closes #435

店じまい後の再開＝3本目。0.17.0 の実装5本・積み上げ PR と squash の衝突・publish・誤り4件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
