### PR TITLE
fix(ui) 0.17.1: DataTable collapse の ::before ラベルを alt 構文で accessible name から外す（#439）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -65,6 +65,36 @@ nene2-ui         （未公開）
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
 > 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
 
+### `@hideyukimori/nene2-ui` 0.17.1（**patch — fix**・#439）
+
+**載せ替える前に読むもの: 無し。** 変わるのは1点で、`DataTable collapse="sm"` で**カード化した各セルの `::before` ラベルが
+accessible name に入らなくなる**。見た目は不変。
+
+| 変わるもの | 0.17.0 | 0.17.1 |
+| --- | --- | --- |
+| sm 未満・`collapse="sm"` の cell の accessible name | **"Name x"** — `::before` の `attr(data-label)` が名前に入り、`sr-only` の `th` と**見出しが二重に読まれる**（vault の本番 0.9.2・375px・ariaSnapshot 実測） | **"x"** — 列との対応は残してある `th scope="col"` が担う |
+| 見た目 | — | **不変** |
+
+🔴 **機構**: `content` の代替テキスト構文 `content: attr(data-label) / ""`。`/ ""` で生成テキストの代替テキストを空にすると、
+**描画はされるが支援技術には渡らない**。Tailwind では `max-sm:before:content-[attr(data-label)_/_'']`（`_` ＝空白）。
+`th` を `hidden` にする案は全ブラウザで構造を捨てるので採らない。
+
+**実測（fleet-tooling・2026-08-26 01:1x JST・`date`）**:
+
+- Tailwind **4.3.2** の生成 CSS（`compile` API 直叩き）: `--tw-content: attr(data-label) / ''; content: var(--tw-content);`
+  — `/` と `''` はそのまま通る（「キット側で確認できない」は誤りだった: tailwindcss は自艦の `node_modules` に居る）。
+- vault の `@tailwindcss/oxide` 4.3.2 の scanner を 0.17.1 の `dist` にかけた結果: `max-sm:before:content-[attr(data-label)_/_'']` を
+  抽出する（vault は `@source '…/nene2-ui/dist'` で拾っている）。
+- **Chromium 149（vault の Playwright 1.61.1・375×812・合成 HTML）で陽性対照つき**: 素の `attr(data-label)` → cell `"Name x"` ／
+  `/ ""` → cell `"x"`。`--tw-content` 変数経由でも同じ。`getComputedStyle(td,'::before').content` は `"Name" / ""`。
+
+⚠️ **Firefox は代替テキスト構文を実装していない（2026-08 時点）**ので、Firefox では **0.17.0 と同じく二重のまま**。退行ではなく現状維持。
+⚠️ **上の実測は合成 HTML。vault の本番 build での撮り直しは vault #469 の手順**（`getComputedStyle` と ariaSnapshot）。
+それまで vault 側について「直った」と書かない。
+
+**各艦でやること**: 0.17.0 → 0.17.1 は caret 内（`^0.17.0` が含む）。ただし **lock が止めるので `npm update @hideyukimori/nene2-ui`**
+（0.17.0 の「各艦でやること」と同じ。消費艦は vault の1艦）。
+
 ### `@hideyukimori/nene2-ui` 0.17.0（**minor — feat**・vault W1b の待ち分）
 
 **載せ替える前に読むもの: 「各艦でやること」の節（下）。** 中身はすべて**任意 prop**で、**既定は 0.16.1 までの描画と同じ**。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,7 +8923,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",

--- a/packages/nene2-ui/src/data/DataTable.tsx
+++ b/packages/nene2-ui/src/data/DataTable.tsx
@@ -32,9 +32,17 @@ export interface DataTableProps<Row> {
    * `max-sm:` prefix, so a wide viewport is untouched.
    *
    * ⚠️ The visual header row is hidden (`sr-only`), not removed: the `<th scope="col">` stay
-   * in the document, so assistive tech still pairs a cell with its column. The `::before`
-   * label is presentational and is not read on its own. That the two do not double up is a
-   * live-lane check — jsdom does not lay out, and it is not asserted here.
+   * in the document, so assistive tech still pairs a cell with its column.
+   *
+   * 🔴 The `::before` label is drawn with the alternative-text form of `content`
+   * (`attr(data-label) / ""`) so that it stays out of the cell's accessible name. Without
+   * the `/ ""` the generated text *is* part of the name: every cell is read as "Name x"
+   * while the hidden `<th>` still supplies "Name" — the header twice (#439, vault's
+   * Playwright on production 0.9.2 at 375px). Measured in Chromium 149 for 0.17.1: plain
+   * `attr()` → cell "Name x"; with `/ ""` → cell "x", also through Tailwind's
+   * `--tw-content` indirection. Firefox does not implement the alternative-text form
+   * (2026-08), so there the label is still read twice — the same as 0.17.0, not a
+   * regression. jsdom does not compute pseudo-elements, so the test pins the class literal.
    */
   collapse?: 'sm';
 }
@@ -57,8 +65,10 @@ const CARD_TABLE = 'max-sm:block';
 const CARD_THEAD = 'max-sm:sr-only';
 const CARD_TBODY = 'max-sm:block';
 const CARD_ROW = 'max-sm:block max-sm:border-b max-sm:border-x-slot-table-border';
+// `content-[attr(data-label)_/_'']` — Tailwind's `_` is a space, so this is
+// `content: attr(data-label) / ''`: the label is drawn but has empty alternative text (#439).
 const CARD_CELL =
-  'max-sm:block max-sm:border-b-0 max-sm:text-left max-sm:before:block max-sm:before:content-[attr(data-label)] max-sm:before:font-x-slot-table-header max-sm:before:text-x-slot-table-header-fg';
+  "max-sm:block max-sm:border-b-0 max-sm:text-left max-sm:before:block max-sm:before:content-[attr(data-label)_/_''] max-sm:before:font-x-slot-table-header max-sm:before:text-x-slot-table-header-fg";
 
 export function DataTable<Row>({
   columns,

--- a/packages/nene2-ui/src/data/table.test.tsx
+++ b/packages/nene2-ui/src/data/table.test.tsx
@@ -391,6 +391,16 @@ describe('DataTable — collapse: "sm"（#423・0.17.0）', () => {
     for (const c of added) expect(c.startsWith('max-sm:')).toBe(true);
   });
 
+  it("::before のラベルは alt 構文（`/ ''`）で accessible name から外す（#439・0.17.1）", () => {
+    const { container } = render(
+      <DataTable caption="c" columns={columns} rows={rows} rowKey={(r) => r.a} collapse="sm" />,
+    );
+    const cls = container.querySelector('td')?.getAttribute('class') ?? '';
+    expect(cls).toContain("max-sm:before:content-[attr(data-label)_/_'']");
+    // 素の attr() は生成テキストが名前に入る（0.17.0 の二重読みの原因）。戻らないこと。
+    expect(cls).not.toContain('content-[attr(data-label)]');
+  });
+
   it('見出し行は隠すだけで消さない — th の scope は残る', () => {
     const { container } = render(
       <DataTable caption="c" columns={columns} rows={rows} rowKey={(r) => r.a} collapse="sm" />,


### PR DESCRIPTION
Closes #439

## 何を
`DataTable collapse="sm"` でカード化した cell の `::before` ラベルを **`content` の代替テキスト構文**にする:
`max-sm:before:content-[attr(data-label)]` → `max-sm:before:content-[attr(data-label)_/_'']`（= `content: attr(data-label) / ''`）。
描画は不変・`th scope="col"` は残す。版は **0.17.1（patch）**・同一コミットで bump（lock は workspace 版の1行のみ・0.16.1 #418 と同形）。

## なぜ
0.17.0 は生成テキストが cell の accessible name に入り、`sr-only` の見出し行と**二重に読まれていた**（vault の本番 0.9.2・375px・ariaSnapshot 実測・#439）。

## 実測〔すべて自艦・2026-08-26 01:1x JST〕
| 何を | 結果 |
| --- | --- |
| Tailwind **4.3.2** `compile` API（自艦 node_modules） | `--tw-content: attr(data-label) / ''; content: var(--tw-content);` — `/` と `''` は通る |
| vault の `@tailwindcss/oxide` 4.3.2 scanner を 0.17.1 の `dist` にかけた | `max-sm:before:content-[attr(data-label)_/_'']` を抽出 |
| **Chromium 149**（vault の Playwright 1.61.1・375×812・合成 HTML・**陽性対照つき**） | 素の `attr()` → cell **"Name x"** ／ `/ ''` → cell **"x"**（`--tw-content` 変数経由でも同じ）。`getComputedStyle(td,'::before').content` = `"Name" / ""` |
| `npm run check` | 🟢 EXIT=0・**797** テスト（+1） |

⚠️ **Firefox は代替テキスト構文未実装**（2026-08）→ Firefox は 0.17.0 と同じく二重のまま。退行ではなく現状維持。
⚠️ 上の Chromium 実測は**合成 HTML**。vault の本番 build での撮り直しは **vault #469**。それまで vault 側は「直った」と書かない。
⚠️ jsdom は擬似要素を計算しないので、テストはクラス文字列を固定し `content-[attr(data-label)]` への戻りを禁じるだけ。

## 未実施
- publish（施主 GO 後・`publish.yml` workflow_dispatch・package=nene2-ui）
- vault 本番 build での検収（vault #469）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV
