### PR TITLE
fix(standards) 2.4.0: 測定経路に HTML 埋め込み <style> を足す — postcss-html で中の CSS を測る（#164 タスク2）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -200,6 +200,32 @@ lookup 側が**各ノードで残りを最長から順に1つのキーとして�
 ⇒ **番号は、それを指している文書の側にも属している。** 追加が `./package.json` の1本だけであり、
 **既存の import 経路を1つも変えない**ことから patch を採る。
 
+### `@hideyukimori/nene2-standards` 2.4.0（**minor — fix**・#164 タスク2）
+
+**載せ替える前に読むもの: この節。** 変わるのは **測定経路が HTML 埋め込み `<style>` を読むようになる**こと。
+
+| 変わるもの | 2.3.0 | 2.4.0 |
+| --- | --- | --- |
+| `init --scan` / lint-baseline / `--check` の走査対象 | `.css` のみ | `.css` ＋ **埋め込み `<style>` を持つ `.html`**（postcss-html で中の CSS だけを測る） |
+| `styling.scan-coverage`・台帳登録済みの HTML に埋め込みがある | **unknown**（測れない） | **green**（測れる） |
+| `styling.scan-coverage`・台帳外の HTML に埋め込みがある | red | red（不変） |
+| legacy-manifest の `maxLines` / `maxBytes`（`.html`） | — | **埋め込み CSS の量**（マークアップは数えない） |
+| 依存 | — | `postcss-html` ^2.0.0 が `dependencies` に増える（htmlparser2 / domhandler 等が同伴） |
+| 新 export | — | `enumerateMeasurableStyleSources(cwd)` |
+
+🔴 **機構**: stylelint の `customSyntax` には**モジュール名ではなく Syntax オブジェクト**を渡す。文字列だと消費艦側でモジュール解決され、
+本パッケージの依存へ届かない艦が出る（#189 と同じ経路の摩擦）。`init --scan` の `@layer components` 走査も同じ Document を歩く。
+
+**実測（fleet-tooling・2026-08-26 01:43 JST・`date`・concierge は読み取りのみ）**: `nene-concierge/public_html/admin` に 2.4.0 の `scanLintBaselines` を実走し、
+**07-29 concierge 実測・07-30 fleet 実測と内訳まで一致**: `app.css`（esbuild 生成物）**218** = no-unlayered-css 106 / selector-max-specificity 55 /
+color-no-hex 43 / function-disallowed-list 14 ／ `index.html` の埋め込み **487** = color-no-hex 409 / function-disallowed-list 49 / no-unlayered-css 27 /
+selector-max-id 1 / selector-max-specificity 1。legacy-manifest は `index.html` = 978 行（prettier 整形後）/ 51,292 bytes（埋め込み CSS のみ）。
+
+⚠️ **上げると挙動が変わる艦**: 台帳に `.html` を legacy-manifest 登録している艦は scan-coverage が unknown → green になり、
+**その HTML の (rule,index.html) が lint-baseline に新しく現れる**。登録していなければ `init --check` の ratchet は登録キーしか見ないので落ちない。
+実艦では concierge が該当するが **registries.jsonc 未導入（ゲート未導入）**〔2026-08-26 実測〕なので、いま壊れる艦は無い。
+⚠️ 検出（あるか無いか）は正規表現・測定は postcss-html。コメント内の `<style` は検出側が過検出しうる（fail-closed 側）。
+
 ### `@hideyukimori/nene2-standards` 2.3.0（**minor — feat を含む**・#402）
 
 🔴 **2.2.0 の publish（2026-07-29）以降、版を上げないまま10コミットが入っていた**（#402 で実測）。

--- a/package-lock.json
+++ b/package-lock.json
@@ -3854,6 +3854,73 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5203,6 +5270,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -5757,7 +5855,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -6705,6 +6802,23 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-html": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-2.0.0.tgz",
+      "integrity": "sha512-f2Rvw5FCollEfVj3wfN7JdQb7n2rNIthW+epw2EByio7M6P7RH0BTj8a/ODHrUXd0cmO7ychb6YniymV93182Q==",
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^9.1.0",
+        "js-tokens": "^9.0.0",
+        "postcss-safe-parser": "^7.0.1"
+      },
+      "engines": {
+        "node": "^22.12 || >=24"
+      },
+      "peerDependencies": {
+        "postcss": "^8.5.0"
+      }
+    },
     "node_modules/postcss-resolve-nested-selector": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
@@ -6716,7 +6830,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
       "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
-      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8843,7 +8956,7 @@
     },
     "packages/nene2-standards": {
       "name": "@hideyukimori/nene2-standards",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.7.2",
@@ -8855,6 +8968,7 @@
         "eslint-plugin-testing-library": "^7.6.1",
         "jscodeshift": "^17.3.0",
         "postcss": "^8.5.6",
+        "postcss-html": "^2.0.0",
         "prettier": "3.6.2",
         "typescript-eslint": "^8.35.0"
       },

--- a/packages/nene2-standards/package.json
+++ b/packages/nene2-standards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-standards",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "NeNe fleet frontend standards — distributed ESLint flat config (per-rule merged), Stylelint shared config + custom plugin, known-utility fast path, nene2 custom rules, A1 hooks→model migration codemod",
   "type": "module",
   "license": "MIT",
@@ -42,6 +42,7 @@
     "eslint-plugin-testing-library": "^7.6.1",
     "jscodeshift": "^17.3.0",
     "postcss": "^8.5.6",
+    "postcss-html": "^2.0.0",
     "prettier": "3.6.2",
     "typescript-eslint": "^8.35.0"
   },

--- a/packages/nene2-standards/src/checks/init-scan.test.ts
+++ b/packages/nene2-standards/src/checks/init-scan.test.ts
@@ -39,6 +39,17 @@ const THREE_HEX = `@layer components {
 }
 `;
 
+/** 一時 repo の直下に index.html（埋め込み <style> 1ブロック）を置く（#164 タスク2）。 */
+function makeHtmlRepo(css: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), 'nene2-a4-html-'));
+  dirs.push(dir);
+  writeFileSync(
+    path.join(dir, 'index.html'),
+    `<!doctype html>\n<html><head><title>t</title>\n<style>\n${css}</style>\n</head><body><p>x</p></body></html>\n`,
+  );
+  return dir;
+}
+
 function frozenOf(
   baselines: Awaited<ReturnType<typeof scanLintBaselines>>,
   rule: string,
@@ -72,6 +83,43 @@ describe('scanLintBaselines — (rule,file) 実測（P2-A4）', () => {
     const clean = `@layer components {\n  .ok { opacity: 1; }\n}\n`;
     const baselines = await scanLintBaselines(makeRepo(clean));
     expect(baselines).toEqual([]);
+  });
+});
+
+describe('HTML 埋め込み <style> を測定経路に乗せる（#164 タスク2・postcss-html）', () => {
+  it('index.html の埋め込み CSS を (rule,index.html) で数える（color-no-hex は hex 個数と一致）', async () => {
+    const baselines = await scanLintBaselines(makeHtmlRepo(TWO_HEX));
+    const hex = baselines.find((b) => b.rule === 'color-no-hex');
+    expect(hex?.file).toBe('index.html');
+    expect(hex?.frozenCount).toBe(2);
+  });
+
+  it('空虚合格防止: 埋め込みの hex を1つ増やすと frozenCount が +1', async () => {
+    const two = await scanLintBaselines(makeHtmlRepo(TWO_HEX));
+    const three = await scanLintBaselines(makeHtmlRepo(THREE_HEX));
+    expect(frozenOf(three, 'color-no-hex')).toBe((frozenOf(two, 'color-no-hex') ?? 0) + 1);
+  });
+
+  it('legacy manifest は埋め込み CSS だけを測る（maxBytes はマークアップを含まない）・@layer components も拾う', async () => {
+    const dir = makeHtmlRepo(TWO_HEX);
+    const scan = await initScan(dir);
+    const entry = scan.legacyManifest.find((e) => e.path === 'index.html');
+    expect(entry).toBeDefined();
+    // 埋め込み CSS のバイト数（<style> の外＝<!doctype>…<p>x</p> は数えない）
+    expect(entry?.maxBytes).toBeLessThan(Buffer.byteLength(TWO_HEX) + 8);
+    expect(entry?.maxBytes).toBeGreaterThan(0);
+    expect(entry?.maxLines).toBeGreaterThan(0);
+    expect(scan.allowedClasses).toContain('.foo'); // トークンは `.` 付き（既存の css 経路と同じ形）
+  });
+
+  it('陽性対照: 埋め込みの無い HTML は走査対象にならない（lint-baseline 0 件）', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'nene2-a4-nohtml-'));
+    dirs.push(dir);
+    writeFileSync(
+      path.join(dir, 'index.html'),
+      '<!doctype html>\n<html><head></head><body></body></html>\n',
+    );
+    expect(await scanLintBaselines(dir)).toEqual([]);
   });
 });
 

--- a/packages/nene2-standards/src/checks/init-scan.ts
+++ b/packages/nene2-standards/src/checks/init-scan.ts
@@ -8,9 +8,14 @@
  *   （conformance styling green 条件「再走査で未分類 selector 0」の入力）。
  * - maxLines は pinned prettier 整形後の行数（AM-14/AM-25' — 整形非決定下の行数に正準性はない）・
  *   maxBytes はソース実バイト数。
+ * - 走査対象は `.css` ＋ **埋め込み `<style>` を持つ `.html`**（#164 タスク2）。HTML は postcss-html で
+ *   読み、**中の CSS だけ**を測る（maxLines / maxBytes とも埋め込み CSS の量。マークアップは数えない）。
+ *   lint も同じ経路（stylelint `customSyntax`）で、(rule,file) の file は `.html` のパスになる。
  */
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+
+import type { Document, Root } from 'postcss';
 
 import baseStylelintConfig from '../stylelint/index.js';
 import { classTokens, layerParamsInclude } from '../stylelint/helpers.js';
@@ -21,7 +26,7 @@ import type {
   RegistriesDocument,
   RegistryEntry,
 } from '../registries/schema.js';
-import { enumerateStyleSources } from './scan-coverage.js';
+import { enumerateMeasurableStyleSources } from './scan-coverage.js';
 
 export interface InitScanResult {
   /** @layer components 内の class トークン（完全一致列挙の初期値） */
@@ -54,7 +59,7 @@ const LINT_BASELINE_EXCLUDED_RULES = new Set<string>([
  * frozenCount>0 のもののみ返す（green は entry 0＝AM-14 と一貫・F4）。
  */
 export async function scanLintBaselines(cwd: string): Promise<InitScanResult['lintBaselines']> {
-  const sources = enumerateStyleSources(cwd).filter((p) => p.endsWith('.css'));
+  const sources = enumerateMeasurableStyleSources(cwd);
   if (sources.length === 0) return [];
   const stylelint = (await import('stylelint')).default;
   // plugin.js は `stylelint` を静的 import するので、ここでも遅延読み込みする。
@@ -62,10 +67,28 @@ export async function scanLintBaselines(cwd: string): Promise<InitScanResult['li
   // eslint だけ配線する艦で ERR_MODULE_NOT_FOUND になる（#189 摩擦1）。
   const stylelintPlugins = (await import('../stylelint/plugin.js')).default;
   const runnable = { ...baseStylelintConfig, plugins: stylelintPlugins };
-  const { results } = await stylelint.lint({
-    files: sources.map((rel) => path.join(cwd, rel)),
-    config: runnable,
-  });
+  const abs = (rel: string): string => path.join(cwd, rel);
+  const css = sources.filter((p) => p.endsWith('.css'));
+  const html = sources.filter((p) => p.endsWith('.html'));
+  type LintResult = Awaited<ReturnType<typeof stylelint.lint>>['results'][number];
+  const results: LintResult[] = [];
+  if (css.length > 0) {
+    results.push(...(await stylelint.lint({ files: css.map(abs), config: runnable })).results);
+  }
+  if (html.length > 0) {
+    // HTML 埋め込み <style> は postcss-html で読む（#164 タスク2）。customSyntax にはモジュール名
+    // でなく Syntax オブジェクトを渡す — 文字列だと消費艦側でモジュール解決され、本パッケージの
+    // 依存（postcss-html）へ届かない艦が出る（#189 と同じ経路の摩擦）。
+    const postcssHtml = (await import('postcss-html')).default;
+    results.push(
+      ...(
+        await stylelint.lint({
+          files: html.map(abs),
+          config: { ...runnable, customSyntax: postcssHtml },
+        })
+      ).results,
+    );
+  }
   const counts = new Map<string, number>();
   for (const r of results) {
     const rel = path.relative(cwd, r.source ?? '');
@@ -92,7 +115,7 @@ async function formattedLineCount(source: string): Promise<number> {
 
 export async function initScan(cwd: string): Promise<InitScanResult> {
   const postcss = (await import('postcss')).default;
-  const sources = enumerateStyleSources(cwd).filter((p) => p.endsWith('.css'));
+  const sources = enumerateMeasurableStyleSources(cwd);
   const allowed = new Set<string>();
   const legacyManifest: InitScanResult['legacyManifest'] = [];
   const advisories: string[] = [];
@@ -101,10 +124,25 @@ export async function initScan(cwd: string): Promise<InitScanResult> {
     const abs = path.join(cwd, rel);
     const raw = readFileSync(abs);
     const text = raw.toString('utf8');
+    // 測る CSS 本文。`.css` はファイルそのもの、`.html` は埋め込み <style> の中身だけ（#164 タスク2）。
+    let cssText = text;
+    let cssBytes = raw.byteLength;
 
     // @layer components の class トークン収集（許可リスト初期値）
     try {
-      const root = postcss.parse(text, { from: abs });
+      let root: Root | Document;
+      if (rel.endsWith('.html')) {
+        const postcssHtml = (await import('postcss-html')).default;
+        // Syntax 型では parse が optional。postcss-html は必ず持つが、型どおり無ければ fail-closed に落とす。
+        if (postcssHtml.parse === undefined) throw new Error('postcss-html に parse が無い');
+        root = postcssHtml.parse(text, { from: abs });
+        if (root.type === 'document') {
+          cssText = root.nodes.map((n) => n.toString()).join('\n');
+          cssBytes = Buffer.byteLength(cssText, 'utf8');
+        }
+      } else {
+        root = postcss.parse(text, { from: abs });
+      }
       root.walkAtRules('layer', (at) => {
         if (!layerParamsInclude(at.params, 'components')) return;
         at.walkRules((rule) => {
@@ -118,8 +156,8 @@ export async function initScan(cwd: string): Promise<InitScanResult> {
 
     // legacy manifest 初期値（テーマ正準配置・エントリ css 以外）
     if (!CANONICAL_NON_LEGACY.some((re) => re.test(rel))) {
-      const maxLines = await formattedLineCount(text);
-      const entry = { path: rel, maxLines, maxBytes: raw.byteLength };
+      const maxLines = await formattedLineCount(cssText);
+      const entry = { path: rel, maxLines, maxBytes: cssBytes };
       legacyManifest.push(entry);
       if (maxLines > ADVISORY_LINES) {
         advisories.push(

--- a/packages/nene2-standards/src/checks/scan-coverage.ts
+++ b/packages/nene2-standards/src/checks/scan-coverage.ts
@@ -82,15 +82,16 @@ export function enumerateStyleSources(cwd: string): string[] {
 }
 
 /**
- * HTML 埋め込み `<style>` の実測（#164）。
+ * HTML 埋め込み `<style>` の検出（#164 タスク1）。
  *
- * 現行の**測定経路**（`init --scan` / lint-baseline / run）は `.css` だけを見る。一方 scan-coverage は
+ * 2.3.x までの**測定経路**（`init --scan` / lint-baseline / `--check`）は `.css` だけを見ていた。一方 scan-coverage は
  * `index.html` を `CANONICAL_ALLOWED` で**無条件に allowed** にしていたため、
  * **埋め込み `<style>` が台帳にも lint にも載らないまま green** になっていた
  * （＝不可視領域があるのに green・G-6 の現物）。実在例: concierge
  * `public_html/admin/index.html`（52KB・`<style>` 1ブロック・fleet 実測 2026-07-30）。
  *
- * 依存を増やさずに済む範囲で検出する（走査対象としての抽出＝postcss-html 経路は別作業）。
+ * ここは依存なしの粗い検出（正規表現）で、**あるか無いか**だけを決める。中身の測定は
+ * `enumerateMeasurableStyleSources` が選んだファイルを init-scan が postcss-html で読む（#164 タスク2）。
  * コメント内の `<style` は拾いうるが、**過検出は fail-closed 側に倒れる**ので許容する
  * （見落として green を返すより安全 — 逆向きの誤りは G-6 違反になる）。
  */
@@ -111,6 +112,19 @@ export function htmlEmbeddedStyle(cwd: string, rel: string): { blocks: number; l
     lines += body.split('\n').length;
   }
   return { blocks, lines };
+}
+
+/**
+ * **測定経路**（`init --scan` / lint-baseline / `--check`）の走査対象（#164 タスク2）:
+ * `.css` の全件＋**埋め込み `<style>` を持つ `.html`**。埋め込みの無い HTML は測るものが無いので含めない。
+ * scss/sass/less/styl は scan-coverage が red にする対象で、測定経路には乗せない。
+ * 中身の読み方（postcss-html）は init-scan 側。
+ */
+export function enumerateMeasurableStyleSources(cwd: string): string[] {
+  return enumerateStyleSources(cwd).filter(
+    (rel) =>
+      rel.endsWith('.css') || (rel.endsWith('.html') && htmlEmbeddedStyle(cwd, rel).blocks > 0),
+  );
 }
 
 /** `cwd` 配下の HTML のうち、埋め込み `<style>` を持つもの（#164 の不可視領域の列挙）。 */
@@ -155,10 +169,6 @@ export function checkScanCoverage(options: ScanCoverageOptions): KeyState {
     }
   }
 
-  // 測定経路が `.css` だけを見るため、**台帳に載っていても実測できない**領域（#164）。
-  // 「登録されていない」（= red）と「登録されているが測れない」（= unknown）は別物なので分ける。
-  const unmeasurable: string[] = [];
-
   const sources = enumerateStyleSources(cwd);
   for (const rel of sources) {
     if (BANNED_EXT.test(rel)) {
@@ -167,18 +177,14 @@ export function checkScanCoverage(options: ScanCoverageOptions): KeyState {
     }
     const registered = manifestPaths.includes(rel) || widgetEntryFiles.includes(rel);
     // 🔴 HTML は**埋め込み `<style>` を持つ限り無条件 allowed にしない**（#164）。
-    // 正準配置（index.html）であっても、中の CSS は台帳にも lint にも載らない。
+    // 正準配置（index.html）であっても、中の CSS は台帳（legacy manifest）に載って初めて allowed。
+    // 登録済みなら測定経路（init-scan・postcss-html）が cap と違反数を実測する＝不可視領域ではない。
     const embedded = rel.endsWith('.html') ? htmlEmbeddedStyle(cwd, rel) : { blocks: 0, lines: 0 };
     if (embedded.blocks > 0) {
       if (!registered) {
         details.push(
           `HTML 埋め込み <style> が台帳外（${embedded.blocks}ブロック・約${embedded.lines}行）: ${rel}` +
             ` — 正準配置でも中の CSS は themes / 許可リスト / legacy manifest のいずれにも載らない（#164）`,
-        );
-      } else {
-        // 台帳には載っているが、`.css` しか見ない測定経路では cap も違反数も実測できない。
-        unmeasurable.push(
-          `${rel}（${embedded.blocks}ブロック・約${embedded.lines}行）— 台帳登録済みだが測定経路が .css のみ`,
         );
       }
       continue;
@@ -190,18 +196,5 @@ export function checkScanCoverage(options: ScanCoverageOptions): KeyState {
   }
 
   if (details.length > 0) return { state: 'red', details };
-  // 🔴 不可視領域があるなら green ではなく unknown（fail-closed・G-6）。
-  // 「red が無い」を「全部見えた」と読ませない。
-  if (unmeasurable.length > 0) {
-    return {
-      state: 'unknown',
-      reason: 'not-installed',
-      details: [
-        'HTML 埋め込み <style> を実測できる走査経路が未実装のため green を返さない（#164・G-6）:',
-        ...unmeasurable,
-        '解消条件: postcss-html 経由の抽出を測定経路（init --scan / lint-baseline）に追加すること。',
-      ],
-    };
-  }
   return { state: 'green' };
 }

--- a/packages/nene2-standards/src/index.ts
+++ b/packages/nene2-standards/src/index.ts
@@ -107,6 +107,7 @@ export { detectTailwind, TAILWIND_DEPENDENT_RULES } from './checks/tailwind-pres
 export type { TailwindPresence } from './checks/tailwind-presence.js';
 export {
   checkScanCoverage,
+  enumerateMeasurableStyleSources,
   htmlEmbeddedStyle,
   htmlEmbeddedStyleSources,
 } from './checks/scan-coverage.js';

--- a/packages/nene2-standards/tests/html-embedded-style.test.ts
+++ b/packages/nene2-standards/tests/html-embedded-style.test.ts
@@ -6,8 +6,9 @@
  * 載らないまま green** ＝ G-6 の現物（不可視領域があるのに緑）。
  * 実在例: concierge `public_html/admin/index.html`（52KB・`<style>` 1ブロック・fleet 実測）。
  *
- * 「登録されていない（red）」と「登録されているが測れない（unknown）」を分けることが本体なので、
- * 3状態それぞれを陽性対照つきで固定する。
+ * 「登録されていない（red）」と「登録されている（測定経路が postcss-html で測る＝green）」を分けることが
+ * 本体なので、3状態それぞれを陽性対照つきで固定する。2.3.x では登録済みでも「測れない」ので unknown
+ * だったが、#164 タスク2 で測定経路が HTML を読むようになり green になった。
  */
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -15,7 +16,12 @@ import path from 'node:path';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { checkScanCoverage, htmlEmbeddedStyle, htmlEmbeddedStyleSources } from '../src/index.js';
+import {
+  checkScanCoverage,
+  enumerateMeasurableStyleSources,
+  htmlEmbeddedStyle,
+  htmlEmbeddedStyleSources,
+} from '../src/index.js';
 import type { RegistriesDocument } from '../src/registries/schema.js';
 
 const REPO = 'nene-probe';
@@ -76,6 +82,15 @@ describe('htmlEmbeddedStyle — 不可視領域の実測', () => {
     const list = htmlEmbeddedStyleSources(dir);
     expect(list.map((e) => e.path)).toEqual(['index.html']);
   });
+
+  it('測定経路の対象 = .css 全件 ＋ 埋め込みを持つ .html（埋め込みの無い HTML は含めない・#164 タスク2）', () => {
+    const dir = mkdtempSync(path.join(root, 'c2-'));
+    writeFileSync(path.join(dir, 'index.html'), html('<style>.a{}</style>'));
+    writeFileSync(path.join(dir, 'plain.html'), html('<link rel="stylesheet" href="a.css">'));
+    writeFileSync(path.join(dir, 'a.css'), '.x{}\n');
+    writeFileSync(path.join(dir, 'b.scss'), '.y{}\n'); // scan-coverage が red にする側・測定経路には乗せない
+    expect(enumerateMeasurableStyleSources(dir)).toEqual(['a.css', 'index.html']);
+  });
 });
 
 describe('checkScanCoverage — 埋め込み <style> を持つ HTML は無条件 allowed にしない（#164）', () => {
@@ -89,15 +104,11 @@ describe('checkScanCoverage — 埋め込み <style> を持つ HTML は無条件
     }
   });
 
-  it('🔴 台帳登録済みでも「測れない」ので green ではなく unknown（G-6）', () => {
+  it('台帳登録済みなら green — 測定経路が postcss-html で中の CSS を測るので不可視領域ではない（#164 タスク2）', () => {
     const dir = mkdtempSync(path.join(root, 'e-'));
     writeFileSync(path.join(dir, 'index.html'), html('<style>.a{color:red}</style>'));
     const r = checkScanCoverage({ cwd: dir, repo: REPO, registries: withManifest('index.html') });
-    expect(r.state).toBe('unknown');
-    if (r.state === 'unknown') {
-      expect(r.details?.some((d) => d.includes('green を返さない'))).toBe(true);
-      expect(r.details?.some((d) => d.includes('解消条件'))).toBe(true);
-    }
+    expect(r.state).toBe('green');
   });
 
   it('🔴 陽性対照: 埋め込みが無ければ従来どおり green（免除が壊れていない）', () => {


### PR DESCRIPTION
Refs #164（タスク2）。タスク3（Wave 表の訂正）は xi-workspace 側の PR で。

## 何を
- **`enumerateMeasurableStyleSources(cwd)`**（新 export）: `.css` 全件 ＋ 埋め込み `<style>` を持つ `.html`
- `scanLintBaselines`: `.html` は stylelint `customSyntax` に **postcss-html の Syntax オブジェクト**を渡して lint（モジュール名文字列は消費艦側で解決される＝届かない艦が出るので渡さない・#189 と同型）
- `initScan`: `.html` は postcss-html の Document を歩いて `@layer components` を拾い、legacy-manifest の `maxLines` / `maxBytes` は**埋め込み CSS の量だけ**を測る
- `checkScanCoverage`: 台帳登録済み HTML は **unknown → green**（測れるようになった）。台帳外は red のまま。「解消条件」の文言は本体ごと削除
- `dependencies` に `postcss-html` ^2.0.0。lock: 追加 = postcss-html / htmlparser2 / domhandler / domutils / dom-serializer / domelementtype / entities（×2）・`js-tokens` と `postcss-safe-parser` は dev → prod フラグ変更のみ
- 版 **2.4.0**（minor: 依存追加＋新 export＋挙動変更）・`docs/publish.md` に節

## 実測〔すべて自艦・2026-08-26 01:43 JST〕
| 何を | 結果 |
| --- | --- |
| `nene-concierge/public_html/admin` に 2.4.0 の `scanLintBaselines` を実走（**読み取りのみ**・作業木差分 0） | `app.css`（esbuild 生成物）**218** = no-unlayered-css 106 / selector-max-specificity 55 / color-no-hex 43 / function-disallowed-list 14 ／ `index.html` 埋め込み **487** = color-no-hex 409 / function-disallowed-list 49 / no-unlayered-css 27 / selector-max-id 1 / selector-max-specificity 1 — **07-29 concierge・07-30 fleet の実測と内訳まで一致** |
| legacy-manifest（`index.html`） | 978 行（prettier 整形後）/ 51,292 bytes（埋め込み CSS のみ・ファイルは 51,973） |
| テスト | +5（html: (rule,index.html) で数える／hex +1 で +1／manifest はマークアップを数えない・`.foo` を拾う／埋め込み無し HTML は対象外／測定対象の列挙）。unknown のテストは green へ書き換え |
| `npm run check` | 🟢 EXIT=0・**802** |

## 上げると挙動が変わる艦
台帳に `.html` を legacy-manifest 登録している艦: scan-coverage が unknown → green・その HTML の (rule,file) が lint-baseline に新しく現れる。実艦で該当しうる concierge は **registries.jsonc 未導入**〔実測〕なので、いま壊れる艦は無い。

## 未実施
- publish（施主 GO 後・`publish.yml`・package=nene2-standards）
- Wave 表の訂正（xi-workspace PR・別途）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV