### PR TITLE
docs(daily): 2026-08-26 セッション日報 — 0.17.1 出荷・C8・#164 タスク2/3（#448）

### DIFF
--- a/docs/daily/2026-08-26.md
+++ b/docs/daily/2026-08-26.md
@@ -1,0 +1,70 @@
+# 2026-08-26 セッション日報
+
+> **対象期間: 2026-08-26 00:15 〜 01:5x（JST）**〔`date` 実測: 起動直後 00:15:03・本稿 01:47:36〕
+> `2026-08-25-3.md`（〜00:0x）の後に `/clear` で立ち上げた新セッション。日報は `docs/daily/`（`_work/daily-report-convention.md` §1・自艦の internal-docs 受け皿は未存在）。
+
+hub の正式依頼（施主指示・vault 経由）で `nene2-ui` **0.17.1**（#439・DataTable collapse の読み上げ二重化）を実装し、施主の直接 GO で**同夜に出荷**、vault が本番まで検収した（伝聞）。
+続けて `current.md` の「今日の順」どおり **C8**（seed-all.py）と **#164 タスク2/3**（postcss-html・Wave 表訂正）を PR まで出した。
+前セッションの自分が書いた「キット側で確認できない」が**誤り**だったのを見つけ、確認して出した。
+
+## ヘッドライン
+
+1. 🟢 **`nene2-ui` 0.17.1 を publish**（#439・PR #444 → `bd1b8bf`・publish.yml 成功・`npm view` **01:19:56** で 0.17.1 / shasum `374a1eac…`・tarball を pack して sha1 一致と dist 内の `content-[attr(data-label)_/_'']` も実測）。
+2. 🔴 **「Tailwind の生成結果はキット側で確認できない」は誤りだった**（前セッションの `current.md`）。tailwindcss 4.3.2 は自艦の `node_modules` に居た（standards の eslint plugin 経由）。`compile` API で `--tw-content: attr(data-label) / ''` を実測。Playwright も vault の `node_modules` ＋ `~/.cache/ms-playwright` の Chromium 149 で自艦から回せた（陽性対照つき: 素の `attr()` → cell "Name x"／`/ ''` → "x"）。⇒ `current.md` 型10（#445）。
+3. 🟢 **vault の検収は本番まで返った**（伝聞・原文は #439 のコメント2本）: ローカル build 01:2x → 本番 0.9.2.1 配備 01:32:50・ariaSnapshot ローカルと同一・vault #469 close。**Firefox は未測定＝二重のまま（現状維持）**。
+4. 🟢 **C8 完了**: `seed-all.py` が tracked な `.mcp.json` を書かない＋`--dry-run`（xi-workspace PR #1）。**hub 検収合格・マージ `97d2feb`・板 L96 done**（hub 01:39・伝聞）。
+5. 🟡 **#164 タスク2 = PR #447**（`fix(standards) 2.4.0`・postcss-html で HTML 埋め込み `<style>` を測定経路に）— **CI 緑・未マージ・GO 待ち**。**タスク3 = xi-workspace PR #2**（07-15 CSS 監査の concierge 行 218→487）— **hub 検収待ち**。concierge を 2.4.0 の経路で再実測し **07-29 / 07-30 と内訳まで一致**。
+
+## 本日の成果（時系列）
+
+| 時刻 | PR / Issue | 中身 | 実測 |
+| --- | --- | --- | --- |
+| 00:15 | — | `current.md`・板・全艦宛 handoff・在席（vault busy / hub 在席）を読む。`board.sh reconcile`: **自艦の候補 0**・他艦 10 行は誤マッチ／申し送り元の疑いで done せず施主へ一覧提示 | 自分 |
+| 01:10 | — | hub から #439 の正式依頼（0.17.1 → publish まで） | 受信 |
+| 01:1x | — | Tailwind 4.3.2 compile 実測 → Chromium 149 で陽性対照 → vault の oxide scanner で dist から抽出を確認 | 自分 |
+| 01:14 | **#444** / #439 | `CARD_CELL` を alt 構文へ・doc・テスト +1・版 0.17.1（lock 1行）・publish.md 節。`npm run check` EXIT=0 **797** | vitest 01:14:08 |
+| 01:1x | #444 | CI `check` pass 47s・CLEAN → **施主 GO → squash マージ `bd1b8bf`** | gh |
+| 01:19 | — | `publish.yml`（nene2-ui・dry_run=false）成功 → `npm view` 0.17.1 / `374a1eac…`・tag `nene2-ui-v0.17.1` | 01:19:56 |
+| 01:2x | #445 → **#446** | `current.md` を 0.17.1 後へ（版表・#439 は出た・訂正を型10・今日の順）。vault ローカル検収（伝聞）を反映して1コミット追加 → CI 緑 → **施主 GO → マージ `370263a`** | gh |
+| 01:2x〜01:33 | #439 コメント ×2 | vault のローカル検収・本番検収の原文を引用して記録（伝聞の札） | 自分 |
+| 01:3x | xi-workspace **#1** | C8: `seed-all.py` に tracked 判定（`git ls-files --error-unmatch`）＋`--dry-run`・README 1段落。**dry-run のみ**: 49 entries／skip = hub・vault（`vault.mcp.json` あり）／would seed 47。枝は `_work` の HEAD を動かさず origin/main から別 worktree | 自分 |
+| 01:39 | xi-workspace #1 | **hub 検収合格・squash マージ `97d2feb`・板 L96 done**（hub 実走でも同じ 49/2/47・`~/.claude.json` 無書込） | 伝聞（hub） |
+| 01:4x | **#447** / #164 | `enumerateMeasurableStyleSources`・stylelint `customSyntax` に postcss-html の Syntax オブジェクト・initScan は Document を歩き manifest は埋め込み CSS だけ測る・scan-coverage 登録済み HTML unknown→green・postcss-html ^2.0.0・版 2.4.0・publish.md 節・テスト +5。`npm run check` EXIT=0 **802**。CI pass 50s・CLEAN・**未マージ** | 自分 |
+| 01:43 | — | concierge `public_html/admin` に 2.4.0 の経路を実走（読み取りのみ・作業木差分 0）: `app.css` **218**（106/55/43/14）・`index.html` **487**（409/49/27/1/1）＝ 07-29 concierge・07-30 fleet と**内訳まで一致** | 01:43:27 |
+| 01:4x | xi-workspace **#2** | 07-15 CSS 監査の concierge 列（55→1 / 43→409 / 106→27 / 14→49・違反合計 218→487）・§2 分布・§7 Wave 行・§8.2 訂正注。合計列は未再計算と明記。**取りこぼし1件**（違反合計行）を自分で見つけて追いコミット `2a3e481`。**hub 検収待ち** | 自分 |
+
+hub へ 4通（#439 受領・publish 完了・C8 検収依頼・#164 検収依頼）／vault へ 1通（検収の礼・#439 に記録）。
+
+## 「無い」を道具を探す前に言った（今日の型）
+
+前セッションの `current.md` は「Tailwind をビルドしないので arbitrary value の生成結果はキット側で確認できない」と書き、検収を vault へ回していた。
+実際は `npm ls tailwindcss` で **4.3.2 が自艦に居る**（`eslint-plugin-better-tailwindcss` の依存）。`compile` API 直叩きで 30 秒。
+hub が「空撃ちしない」を求めていたので、これが無ければ publish は伝聞待ちだった。⇒ `current.md` 型10・memory `absence-needs-the-right-lens` に2件目として追記。
+
+## 自分の誤り（2件・いずれも自分で発見）
+
+| | 何 | どう出た |
+| --- | --- | --- |
+| 1 | 「確認できない」（前セッション由来） | `find node_modules` で道具が在った。上記 |
+| 2 | Wave 表の訂正で **§2 違反合計行の concierge セル（`**218**`）を取りこぼした** | 置換条件を `218` 素の文字列で書いた（太字の `**218**` に合わない）。`grep 218` の残りで発見・追いコミット |
+
+## 📊 本日の数字（このセッション）
+
+| | 値 | 出所 |
+| --- | ---: | --- |
+| 起票した Issue | **2本**（#445・本日報 #448） | 自分 |
+| 出した PR | **5本**（fleet #444 #446 #447／xi-workspace #1 #2）・**マージ 3本**（#444 #446・xi-ws #1 は hub）・**未マージ 2本**（#447・xi-ws #2） | 自分・gh |
+| publish | `nene2-ui` **0.17.1**（shasum `374a1eac…`・tarball sha1 一致） | `npm view` 01:19:56 |
+| テスト | main **796 → 797**（#444）／枝 #447 で **802 / 50 files** | vitest |
+| 実艦の陽性対照 | Chromium 149（合成 HTML）1回／concierge 再実測 1回（読み取りのみ） | 自分 |
+| hub / vault へのメッセージ | **4 / 1** | 自分 |
+| 自分の誤り | **2件** | 上記 |
+
+## 申し送り
+
+- 🟡 **PR #447（standards 2.4.0）は CI 緑・マージと publish は施主 GO 待ち。** 台帳に `.html` を登録している艦は unknown→green＋lint-baseline に (rule,index.html) が現れる。実艦で該当しうる concierge は registries.jsonc 未導入〔実測〕。
+- 🟡 **xi-workspace PR #2 は hub 検収待ち。** 両方入ったら **#164 を close**（タスク1〜4 すべて済）。
+- 🟢 0.17.1 は本番まで検収済み（伝聞）。**`current.md` の「本番は #469 待ち」は古い** → 次の上書きで落とす。
+- 🟢 C8 は閉じた。**vault の作業木に残る `.mcp.json` の 12/1 差分は vault の手**（`git checkout .mcp.json`）。seed-all 本走は hub が「次に handles.tsv を触る時」。
+- 🟡 `board.sh reconcile` の他艦候補 10 行（invoice #38 / contact #411 #435 #229 / NENE2 #1610 / deal #80 / serve #81 / origin #679 / articles #106）は**施主判断待ち**（done していない）。
+- 次: **#410 の18件判定**。その後は `current.md` の未着手（型スケール 13px・契約28色の未定義・`className` 7部品）。

--- a/docs/daily/2026-08-26.md
+++ b/docs/daily/2026-08-26.md
@@ -31,7 +31,7 @@ hub の正式依頼（施主指示・vault 経由）で `nene2-ui` **0.17.1**（
 | 01:39 | xi-workspace #1 | **hub 検収合格・squash マージ `97d2feb`・板 L96 done**（hub 実走でも同じ 49/2/47・`~/.claude.json` 無書込） | 伝聞（hub） |
 | 01:4x | **#447** / #164 | `enumerateMeasurableStyleSources`・stylelint `customSyntax` に postcss-html の Syntax オブジェクト・initScan は Document を歩き manifest は埋め込み CSS だけ測る・scan-coverage 登録済み HTML unknown→green・postcss-html ^2.0.0・版 2.4.0・publish.md 節・テスト +5。`npm run check` EXIT=0 **802**。CI pass 50s・CLEAN・**未マージ** | 自分 |
 | 01:43 | — | concierge `public_html/admin` に 2.4.0 の経路を実走（読み取りのみ・作業木差分 0）: `app.css` **218**（106/55/43/14）・`index.html` **487**（409/49/27/1/1）＝ 07-29 concierge・07-30 fleet と**内訳まで一致** | 01:43:27 |
-| 01:4x | xi-workspace **#2** | 07-15 CSS 監査の concierge 列（55→1 / 43→409 / 106→27 / 14→49・違反合計 218→487）・§2 分布・§7 Wave 行・§8.2 訂正注。合計列は未再計算と明記。**取りこぼし1件**（違反合計行）を自分で見つけて追いコミット `2a3e481`。**hub 検収待ち** | 自分 |
+| 01:4x | xi-workspace **#2** | 07-15 CSS 監査の concierge 列（55→1 / 43→409 / 106→27 / 14→49・違反合計 218→487）・§2 分布・§7 Wave 行・§8.2 訂正注。合計列は未再計算と明記。**取りこぼし1件**（違反合計行）を自分で見つけて追いコミット `2a3e481`。hub 差し戻し1件（`selector-max-id` 行・埋め込み生行数 949）を直して push `270233c`。**hub 再検収待ち** | 自分 |
 
 hub へ 4通（#439 受領・publish 完了・C8 検収依頼・#164 検収依頼）／vault へ 1通（検収の礼・#439 に記録）。
 
@@ -41,12 +41,14 @@ hub へ 4通（#439 受領・publish 完了・C8 検収依頼・#164 検収依�
 実際は `npm ls tailwindcss` で **4.3.2 が自艦に居る**（`eslint-plugin-better-tailwindcss` の依存）。`compile` API 直叩きで 30 秒。
 hub が「空撃ちしない」を求めていたので、これが無ければ publish は伝聞待ちだった。⇒ `current.md` 型10・memory `absence-needs-the-right-lens` に2件目として追記。
 
-## 自分の誤り（2件・いずれも自分で発見）
+## 自分の誤り（4件・3件は自分で・1件は hub の検収で発見）
 
 | | 何 | どう出た |
 | --- | --- | --- |
 | 1 | 「確認できない」（前セッション由来） | `find node_modules` で道具が在った。上記 |
 | 2 | Wave 表の訂正で **§2 違反合計行の concierge セル（`**218**`）を取りこぼした** | 置換条件を `218` 素の文字列で書いた（太字の `**218**` に合わない）。`grep 218` の残りで発見・追いコミット |
+| 3 | §8.2 の訂正注に「`selector-max-id` は元表に行が無い」と書いた | **在った**（§2 L84・分布 L110・concierge 列 0 のまま）。**hub の検収で発見**（縦に足すと 486 ≠ 487）。0→1 に訂正・追いコミット `270233c`。ルール別合計の表（L96-108）だけ見て「無い」と言った＝道具の窓を狭く切った（型4） |
+| 4 | 🔴 **`_work`（hub の共有作業木）の main に、hub の未コミット変更を私の日報メッセージで commit・push した**（`3ca8b8e`・01:49:47・`.reconcile-nudge-last` / `advice.md` +10 / `board.txt` −1 / `done.txt` +2） | 1つの Bash で `cd $S/xi-ws-164 … ; cd /home/xi/docker/_work && git worktree remove …; python3 …（相対パスで失敗）; git commit -qam …; git push` と連ねたため、python の失敗後も **cwd が `_work` のまま** `git commit -a` / `push` が走った。中身は hub の実作業で失われていない。**履歴の書き換え（amend + force-push）は共有 main なので自分ではやらず、hub と施主へ事実を渡した。** 再発防止: `_work` では `git -C` ＋絶対パスだけ・`git commit -a` を打たない・worktree の後片付けは単独の Bash で |
 
 ## 📊 本日の数字（このセッション）
 
@@ -58,7 +60,7 @@ hub が「空撃ちしない」を求めていたので、これが無ければ 
 | テスト | main **796 → 797**（#444）／枝 #447 で **802 / 50 files** | vitest |
 | 実艦の陽性対照 | Chromium 149（合成 HTML）1回／concierge 再実測 1回（読み取りのみ） | 自分 |
 | hub / vault へのメッセージ | **4 / 1** | 自分 |
-| 自分の誤り | **2件** | 上記 |
+| 自分の誤り | **4件**（うち1件は他艦の作業木への実害） | 上記 |
 
 ## 申し送り
 
@@ -67,4 +69,5 @@ hub が「空撃ちしない」を求めていたので、これが無ければ 
 - 🟢 0.17.1 は本番まで検収済み（伝聞）。**`current.md` の「本番は #469 待ち」は古い** → 次の上書きで落とす。
 - 🟢 C8 は閉じた。**vault の作業木に残る `.mcp.json` の 12/1 差分は vault の手**（`git checkout .mcp.json`）。seed-all 本走は hub が「次に handles.tsv を触る時」。
 - 🟡 `board.sh reconcile` の他艦候補 10 行（invoice #38 / contact #411 #435 #229 / NENE2 #1610 / deal #80 / serve #81 / origin #679 / articles #106）は**施主判断待ち**（done していない）。
+- 🔴 **`_work` main の `3ca8b8e` 問題**: 誤り4の commit（`3ca8b8e`）の扱い（メッセージ amend＋force-with-lease か、据え置きか）は **hub / 施主の判断**。自分では触らない。
 - 次: **#410 の18件判定**。その後は `current.md` の未着手（型スケール 13px・契約28色の未定義・`className` 7部品）。


### PR DESCRIPTION
Closes #448

対象期間 00:15〜01:5x JST。マージ済み（#444 #446・xi-ws #1）と未マージ（#447・xi-ws #2）を書き分け、vault の検収は伝聞の札つき。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV