### PR TITLE
docs(daily): 2026-08-26 の2回目の上書き — 2.4.0 出荷・#164 close・#410 判定（#452）

### DIFF
--- a/docs/daily/2026-08-26.md
+++ b/docs/daily/2026-08-26.md
@@ -1,6 +1,6 @@
 # 2026-08-26 セッション日報
 
-> **対象期間: 2026-08-26 00:15 〜 01:5x（JST）**〔`date` 実測: 起動直後 00:15:03・本稿 01:47:36〕
+> **対象期間: 2026-08-26 00:15 〜 02:0x（JST）**〔`date` 実測: 起動直後 00:15:03・初稿 01:47:36・2回目の上書き 02:0x（#452）〕
 > `2026-08-25-3.md`（〜00:0x）の後に `/clear` で立ち上げた新セッション。日報は `docs/daily/`（`_work/daily-report-convention.md` §1・自艦の internal-docs 受け皿は未存在）。
 
 hub の正式依頼（施主指示・vault 経由）で `nene2-ui` **0.17.1**（#439・DataTable collapse の読み上げ二重化）を実装し、施主の直接 GO で**同夜に出荷**、vault が本番まで検収した（伝聞）。
@@ -13,7 +13,9 @@ hub の正式依頼（施主指示・vault 経由）で `nene2-ui` **0.17.1**（
 2. 🔴 **「Tailwind の生成結果はキット側で確認できない」は誤りだった**（前セッションの `current.md`）。tailwindcss 4.3.2 は自艦の `node_modules` に居た（standards の eslint plugin 経由）。`compile` API で `--tw-content: attr(data-label) / ''` を実測。Playwright も vault の `node_modules` ＋ `~/.cache/ms-playwright` の Chromium 149 で自艦から回せた（陽性対照つき: 素の `attr()` → cell "Name x"／`/ ''` → "x"）。⇒ `current.md` 型10（#445）。
 3. 🟢 **vault の検収は本番まで返った**（伝聞・原文は #439 のコメント2本）: ローカル build 01:2x → 本番 0.9.2.1 配備 01:32:50・ariaSnapshot ローカルと同一・vault #469 close。**Firefox は未測定＝二重のまま（現状維持）**。
 4. 🟢 **C8 完了**: `seed-all.py` が tracked な `.mcp.json` を書かない＋`--dry-run`（xi-workspace PR #1）。**hub 検収合格・マージ `97d2feb`・板 L96 done**（hub 01:39・伝聞）。
-5. 🟡 **#164 タスク2 = PR #447**（`fix(standards) 2.4.0`・postcss-html で HTML 埋め込み `<style>` を測定経路に）— **CI 緑・未マージ・GO 待ち**。**タスク3 = xi-workspace PR #2**（07-15 CSS 監査の concierge 行 218→487）— **hub 検収待ち**。concierge を 2.4.0 の経路で再実測し **07-29 / 07-30 と内訳まで一致**。
+5. 🟢 **#164 は4タスク着地で close**: タスク2 = PR #447 → `3aa73e7` → **`nene2-standards` 2.4.0 publish**〔01:54:26 `npm view`・shasum `a63bb8dd…`・tag あり〕。タスク3 = xi-workspace PR #2（07-15 CSS 監査の concierge 行 218→487）→ hub 差し戻し1件を直して **合格・マージ `523ab22`**（伝聞）。concierge を 2.4.0 の経路で再実測し **07-29 / 07-30 と内訳まで一致**。
+6. 🟢 **#410 の候補18件を判定して close**: close 4（#136 #302 #391 #410）・理由コメント 5（#176 #289 #389 #393 #394）・触らず 9。**閉じ忘れは 2件**（#302 #391）。open Issue 72 → **67**〔実測〕。
+7. 🔴 **`_work` main への誤コミット `3ca8b8e`**（誤り4）。hub 裁定＝据え置き・構造原因は xi-ws issues #128。
 
 ## 本日の成果（時系列）
 
@@ -33,7 +35,13 @@ hub の正式依頼（施主指示・vault 経由）で `nene2-ui` **0.17.1**（
 | 01:43 | — | concierge `public_html/admin` に 2.4.0 の経路を実走（読み取りのみ・作業木差分 0）: `app.css` **218**（106/55/43/14）・`index.html` **487**（409/49/27/1/1）＝ 07-29 concierge・07-30 fleet と**内訳まで一致** | 01:43:27 |
 | 01:4x | xi-workspace **#2** | 07-15 CSS 監査の concierge 列（55→1 / 43→409 / 106→27 / 14→49・違反合計 218→487）・§2 分布・§7 Wave 行・§8.2 訂正注。合計列は未再計算と明記。**取りこぼし1件**（違反合計行）を自分で見つけて追いコミット `2a3e481`。hub 差し戻し1件（`selector-max-id` 行・埋め込み生行数 949）を直して push `270233c`。**hub 再検収待ち** | 自分 |
 
-hub へ 4通（#439 受領・publish 完了・C8 検収依頼・#164 検収依頼）／vault へ 1通（検収の礼・#439 に記録）。
+| 01:5x | #447 → `3aa73e7` / #449 → `a47036d` | **施主 GO** → squash マージ。#449 は「main より遅れ」で一度弾かれ、枝更新 → CI 51s → マージ | gh |
+| 01:54 | — | `publish.yml`（nene2-standards）成功 → `npm view` **2.4.0** / `a63bb8dd…`・tag `nene2-standards-v2.4.0` | 01:54:26 |
+| 01:5x | #164 | 4タスクの着地表を書いて **close** | 自分 |
+| 01:5x | #450 → **#451** | `current.md` を 2.4.0 後へ（版表・#439 本番済・2.4.0 の影響艦・C8 完了・3ca8b8e 据え置き・型11）。#410 判定後にもう1コミット。**未マージ・GO 待ち** | 自分 |
+| 01:57〜02:0x | #410 | 候補18件を自艦で取り直し（14日窓 merged PR 82本 × 本文/題の `#N` × open）＝ **18件・hub の数と一致**。各件を実測して判定 → close 4・理由コメント 5・触らず 9。#410 を判定表つきで close | 自分 |
+
+hub へ 6通（#439 受領・publish 完了・C8 検収依頼・#164 検収依頼・差し戻し対応＋事故報告・2.4.0 完了）／vault へ 1通（検収の礼・#439 に記録）。
 
 ## 「無い」を道具を探す前に言った（今日の型）
 
@@ -54,20 +62,21 @@ hub が「空撃ちしない」を求めていたので、これが無ければ 
 
 | | 値 | 出所 |
 | --- | ---: | --- |
-| 起票した Issue | **2本**（#445・本日報 #448） | 自分 |
-| 出した PR | **5本**（fleet #444 #446 #447／xi-workspace #1 #2）・**マージ 3本**（#444 #446・xi-ws #1 は hub）・**未マージ 2本**（#447・xi-ws #2） | 自分・gh |
-| publish | `nene2-ui` **0.17.1**（shasum `374a1eac…`・tarball sha1 一致） | `npm view` 01:19:56 |
-| テスト | main **796 → 797**（#444）／枝 #447 で **802 / 50 files** | vitest |
+| 起票した Issue | **4本**（#445・#448・#450・#452） | 自分 |
+| 出した PR | **8本**（fleet #444 #446 #447 #449 #451 ＋本日報2回目／xi-workspace #1 #2）・**マージ 6本**（#444 #446 #447 #449・xi-ws #1 #2 は hub）・**未マージ 2本**（#451・本日報2回目） | 自分・gh |
+| publish | **2本**: `nene2-ui` **0.17.1**（`374a1eac…`・tarball sha1 一致）／`nene2-standards` **2.4.0**（`a63bb8dd…`） | `npm view` 01:19:56 / 01:54:26 |
+| テスト | main **796 → 802 / 50 files**（#444 +1・#447 +5） | vitest |
 | 実艦の陽性対照 | Chromium 149（合成 HTML）1回／concierge 再実測 1回（読み取りのみ） | 自分 |
-| hub / vault へのメッセージ | **4 / 1** | 自分 |
+| hub / vault へのメッセージ | **6 / 1** | 自分 |
+| Issue の整理 | close **6**（#136 #164 #302 #391 #410 ＋ #448 は PR で）・理由コメント **5** ・open **72 → 67** | 自分・gh |
 | 自分の誤り | **4件**（うち1件は他艦の作業木への実害） | 上記 |
 
 ## 申し送り
 
-- 🟡 **PR #447（standards 2.4.0）は CI 緑・マージと publish は施主 GO 待ち。** 台帳に `.html` を登録している艦は unknown→green＋lint-baseline に (rule,index.html) が現れる。実艦で該当しうる concierge は registries.jsonc 未導入〔実測〕。
-- 🟡 **xi-workspace PR #2 は hub 検収待ち。** 両方入ったら **#164 を close**（タスク1〜4 すべて済）。
-- 🟢 0.17.1 は本番まで検収済み（伝聞）。**`current.md` の「本番は #469 待ち」は古い** → 次の上書きで落とす。
+- 🟢 **standards 2.4.0 は出ている。** 台帳に `.html` を登録している艦は unknown→green＋lint-baseline に (rule,index.html) が現れる。実艦で該当しうる concierge は registries.jsonc 未導入〔実測〕。**#164 は close。**
+- 🟢 0.17.1 は本番まで検収済み（伝聞）。`current.md` は PR #451 で追随（未マージ）。
+- 🟡 **#410 の残り物**: #289 の陽性対照4項目（notify-failure・Issue が1本立つ）／#389 の README 旗艦例（存在しないスロット）。次の順は `current.md`。
 - 🟢 C8 は閉じた。**vault の作業木に残る `.mcp.json` の 12/1 差分は vault の手**（`git checkout .mcp.json`）。seed-all 本走は hub が「次に handles.tsv を触る時」。
 - 🟡 `board.sh reconcile` の他艦候補 10 行（invoice #38 / contact #411 #435 #229 / NENE2 #1610 / deal #80 / serve #81 / origin #679 / articles #106）は**施主判断待ち**（done していない）。
 - 🔴 **`_work` main の `3ca8b8e` 問題**: 誤り4の commit（`3ca8b8e`）の扱い（メッセージ amend＋force-with-lease か、据え置きか）は **hub / 施主の判断**。自分では触らない。
-- 次: **#410 の18件判定**。その後は `current.md` の未着手（型スケール 13px・契約28色の未定義・`className` 7部品）。
+- 次: **#289 の陽性対照 → #389 の README**（`current.md` の順）。その後は `current.md` の未着手（型スケール 13px・契約28色の未定義・`className` 7部品）。


### PR DESCRIPTION
Closes #452

対象期間を 00:15〜02:0x へ。ヘッドライン 5〜7・時系列 5行・📊（Issue 4 / PR 8・マージ 6 / publish 2 / テスト 802 / close 6・open 72→67）・申し送りを更新。マージ有無・実測/伝聞は書き分け。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPh6y1tc7V19d2H7NaVPV