### PR TITLE
feat(ui): Button の `danger` に border スロットを足す（#455）

### DIFF
--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -18,7 +18,8 @@ const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
   primary: 'bg-x-slot-button-primary-bg text-x-slot-button-primary-fg shadow-x-slot-button-primary',
   secondary:
     'bg-x-slot-button-secondary-bg text-x-slot-button-secondary-fg border-x-slot-button-secondary-border',
-  danger: 'bg-x-slot-button-danger-bg text-x-slot-button-danger-fg',
+  danger:
+    'bg-x-slot-button-danger-bg text-x-slot-button-danger-fg border-x-slot-button-danger-border',
   // No fill and no border: for the third action in a row, where two framed buttons would
   // compete with each other. nene-vault ships this variant already.
   ghost: 'bg-transparent text-x-slot-button-ghost-fg',

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -7,6 +7,9 @@
  * 補いを lint で禁じる（順序③）前にここが埋まっていないと、
  * **押せないことが見えないボタン**が本番に出る。
  */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { Button } from './Button.js';
@@ -116,6 +119,29 @@ describe('Button', () => {
     const cls = classesOf(container.firstElementChild);
     expect(cls).toContain('bg-x-slot-button-danger-bg');
     expect(cls).toContain('disabled:cursor-not-allowed');
+  });
+
+  // #455 — `danger` は border 系のクラスを1つも出しておらず、BASE_CLASS の
+  // `border-transparent` が最後まで残っていた。⇒ 塗りではなく**輪郭**で danger を
+  // 表す艦（nene-deal）は、スロット値をいくら上書きしても枠を出せなかった。
+  it('reaches a slot for its border, like secondary does', () => {
+    const cls = classesOf(render(<Button variant="danger">x</Button>).container.firstElementChild);
+    expect(cls).toContain('border-x-slot-button-danger-border');
+  });
+
+  // 🔴 この PR が「他艦の見た目を変えない」ことの実測。既定の枠色は塗りと**同じ変数**を
+  // 指すので、塗りの上に同色の枠が乗る＝`border-transparent` が塗りの上で描いていたのと
+  // 同じ結果になる。列挙で書かず theme の現物から読む（型1: 列挙で書いた検査は、
+  // 列挙に無いものを緑にする）。
+  it('defaults that border to the fill, so a filled danger button is unchanged', () => {
+    const css = readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '../../themes/default.css'),
+      'utf8',
+    );
+    const valueOf = (name: string) => css.match(new RegExp(`--${name}:\\s*([^;]+);`))?.[1]?.trim();
+    const bg = valueOf('color-x-slot-button-danger-bg');
+    expect(bg).toBeTruthy(); // 陽性対照: 読めていないのに一致と言わない
+    expect(valueOf('color-x-slot-button-danger-border')).toBe(bg);
   });
 });
 

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -273,6 +273,13 @@
   --color-x-slot-button-secondary-border: var(--color-border);
   --color-x-slot-button-danger-bg: var(--color-danger);
   --color-x-slot-button-danger-fg: var(--color-on-accent);
+  /* 🔴 Defaults to the fill, so a filled danger button looks exactly as it did: the border
+   * and the background are the same colour, which is what `border-transparent` over a filled
+   * background already rendered. The slot exists for the ships whose danger button is an
+   * outline rather than a fill — nene-deal's is `background: transparent` with a tinted
+   * border (#455), and it could not express that: the variant emitted no border class at
+   * all, so `border-transparent` from BASE_CLASS won and no slot value could reach it. */
+  --color-x-slot-button-danger-border: var(--color-danger);
   --color-x-slot-button-ghost-fg: var(--color-text-primary);
 
   /* Shared by Input, Select and Textarea — they are one control with three shapes, and a


### PR DESCRIPTION
塗りではなく**輪郭**で danger を表す艦が、その意匠を表現できなかった。

`VARIANT_CLASS.danger` は `bg-…-danger-bg text-…-danger-fg` の2本だけで、border 系の
クラスを1つも出していない。`BASE_CLASS` の `border border-transparent` が最後まで残るので、
**艦側でスロット値をどう上書きしても枠は出せない**（`secondary` は
`border-x-slot-button-secondary-border` を持っており、同じ土台を使えている）。

nene-deal の `.btn-danger` は実測で:

```css
.btn-danger {
  background: transparent;
  color: var(--danger);
  border-color: color-mix(in oklch, var(--danger) 40%, var(--line));
}
```

`bg` と `fg` はスロットで寄せられるが、**枠だけが残る**。画面側に `className` の特例を
書けばできるが、それは受入ゲート③が禁じている形。

## 生成クラス文字列 before / after

```
before  bg-x-slot-button-danger-bg text-x-slot-button-danger-fg
after   bg-x-slot-button-danger-bg text-x-slot-button-danger-fg border-x-slot-button-danger-border
```

既定値は**塗りと同じ変数**を指す（スケール参照のみ・直値なし）:

```css
--color-x-slot-button-danger-bg: var(--color-danger);
--color-x-slot-button-danger-border: var(--color-danger);   /* ← 追加 */
```

## 🔬 描画差の実測（画素比較・pixelmatch）

クラス文字列は変わるので「一致」では通せない。**実際に塗られた画素**で測った。
塗り danger の 120×40 ボタン相当を、`border-transparent`（before）と
`border: 塗りと同色`（after）で描画して比較:

| | 差分画素 | |
|---|---:|---|
| `border-radius: 0` | **0 / 4800** | **完全一致** |
| `border-radius: 8px`（実際の `rounded-x-slot-button` 相当） | **3 / 4800（0.06%）** | 四隅の反射防止処理のみ |
| 陽性対照（枠だけ淡色にした場合） | **278 / 4800** | 装置は差を検出できる |

⚠️ **「完全に不変」ではない。** 角丸があると四隅で 3 画素だけアンチエイリアスの結果が変わる
（背景は `background-clip: border-box` で枠の下まで塗られているため、色そのものは同じ）。
起草時は「同じ結果」と書いたが、測ったら 0 ではなかったので訂正した。

## 検査

`states.test.tsx` に2件足した。どちらも**外すと落ちること**を確認済み:

- `danger` が border スロットへ到達すること → **クラスを外すと exit 1**
- **既定の枠色が塗りと同じ変数を指すこと**（＝本 PR の主張そのもの）
  → **既定値をズラすと exit 1**

後者は `themes/default.css` の**現物から読む**（値を列挙で書かない＝列挙に無いものを
緑にする型を避ける）。読めなかった場合に一致と言わないよう、`bg` が truthy であることを
先に確かめる陽性対照つき。

全体 804 tests / 50 files 緑。

Closes #455

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KrzuAuYHcJxN9kV4PHynAr