### PR TITLE
feat(ui): EmptyState に `description`（二段目）を足す（#456）

### DIFF
--- a/packages/nene2-ui/src/primitives/pointer.test.tsx
+++ b/packages/nene2-ui/src/primitives/pointer.test.tsx
@@ -122,6 +122,27 @@ describe('EmptyState alignment', () => {
       classesOf(render(<EmptyState message="x" align="start" />).container.firstElementChild),
     ).not.toContain('text-center');
   });
+
+  // #456 — 二段目が無いと、艦は文言を落とすしかなかった（nene-deal は4箇所中3箇所が二段）。
+  it('renders a second line when one is given', () => {
+    const { container } = render(<EmptyState message="none yet" description="add one" />);
+    expect(container.firstElementChild?.textContent).toBe('none yetadd one');
+    expect(container.querySelectorAll('p')).toHaveLength(2);
+  });
+
+  // 🔴 本 PR が「既存艦の描画を変えない」ことの実測。description を渡さない場合は
+  // **要素を1つも増やさない**（<p> で包むと、この prop を使わない6艦の DOM が動く）。
+  it('leaves the one-line render exactly as it was — a bare text node, no elements', () => {
+    const { container } = render(<EmptyState message="none yet" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.children).toHaveLength(0); // 陽性対照つき: 下の二段版は 2 を返す
+    expect(root.childNodes).toHaveLength(1);
+    expect(root.childNodes[0]?.nodeType).toBe(3); // Node.TEXT_NODE
+    expect(root.textContent).toBe('none yet');
+    expect(
+      render(<EmptyState message="a" description="b" />).container.firstElementChild?.children,
+    ).toHaveLength(2);
+  });
 });
 
 describe('InlineAlert tones', () => {

--- a/packages/nene2-ui/src/states/EmptyState.tsx
+++ b/packages/nene2-ui/src/states/EmptyState.tsx
@@ -12,9 +12,22 @@ export interface EmptyStateProps {
   align?: 'center' | 'start';
   /** Localized message. The kit never ships strings — see README. */
   message: string;
+  /**
+   * Localized second line: what the empty area would hold, or how to fill it.
+   *
+   * 🔴 Not decoration. nene-deal's empty states carry two lines at three of their four call
+   * sites ("No deals yet" / "Create one from the board"), and folding them into `message`
+   * is not available to it: the two halves are separate catalog keys (`*.empty.title` and
+   * `*.empty.description`), so joining them would put the separator — a string — in the
+   * ship, against principle 4. Without this prop the second line has nowhere to go and the
+   * text is simply dropped (#456).
+   *
+   * Omit it and the render is byte-for-byte what it was before this prop existed.
+   */
+  description?: string;
 }
 
-export function EmptyState({ message, align = 'center', className }: EmptyStateProps) {
+export function EmptyState({ message, description, align = 'center', className }: EmptyStateProps) {
   return (
     <div
       className={cx(
@@ -24,7 +37,19 @@ export function EmptyState({ message, align = 'center', className }: EmptyStateP
       )}
       role="status"
     >
-      {message}
+      {/* 🔴 The one-line case keeps its bare text node. Wrapping `message` in a <p>
+       * unconditionally would change the DOM of every ship already shipping this component
+       * — six of them — for the benefit of a prop they do not pass. */}
+      {description === undefined ? (
+        message
+      ) : (
+        <>
+          <p>{message}</p>
+          <p className="mt-x-slot-empty-state-gap text-x-slot-empty-state-description-fg">
+            {description}
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -173,6 +173,8 @@
   --spacing-x-slot-detail-row-pad-y: var(--spacing-x-xs);
   --spacing-x-slot-state-pad-y: var(--spacing-x-xl);
   --spacing-x-slot-state-action-pad-y: var(--spacing-x-xs);
+  /* Between an EmptyState's two lines (#456). Only read when `description` is passed. */
+  --spacing-x-slot-empty-state-gap: var(--spacing-x-3xs);
   --spacing-x-slot-page-header-pad-y: var(--spacing-x-md);
 
   --radius-x-slot-button: var(--radius-x-md);
@@ -361,6 +363,10 @@
   --color-x-slot-text-muted-fg: var(--color-text-muted);
   --color-x-slot-spinner-fg: var(--color-text-muted);
   --color-x-slot-empty-state-fg: var(--color-text-muted);
+  /* The second line of an EmptyState (#456). Same value as the first by default, so a ship
+   * that adopts `description` gets one uniform block until it decides otherwise; a ship that
+   * wants the hierarchy overrides one of the two. No existing render reads this. */
+  --color-x-slot-empty-state-description-fg: var(--color-text-muted);
   --color-x-slot-error-state-fg: var(--color-danger);
   /* 🔴 The required marker, not the error message — that one is `--color-x-slot-field-error`.
    * Named `-error-fg` when the colour slots were swept in (0.9.0, same day), which reads as


### PR DESCRIPTION
キットの `EmptyState` は `message` 1本しか取らず、**見出し＋説明の二段を持つ艦は
文言を落とすしかなかった**。意匠の差ではなく**情報の欠落**なので、スロット値でも
`className` でも寄せられない。

nene-deal の実測（全4箇所）:

| 箇所 | message | description |
|---|---|---|
| `StageManagementView.tsx:97` | `stages.empty.title` | `stages.empty.description` |
| `KanbanBoardView.tsx:244` | `board.empty.title` | `board.empty.description` |
| `UserManagementView.tsx:142` | `users.empty.title` | `users.empty.description` |
| `DealDetailView.tsx:71` | `detail.notFound` | （なし） |

**4箇所中3箇所が二段。** `action` スロットは 0 箇所だったので足していない。

⚠️ 連結（`${message} — ${description}`）は採れない。二つは別のカタログキー
（`*.empty.title` / `*.empty.description`）なので、**区切り記号を艦が持つ**ことになり
原則(4)「キットは文字列を持たない」と衝突する。

## 既存艦の描画は変わらない — `<p>` で包まない

🔴 **`description` を渡さない場合、要素を1つも増やさない。**

```tsx
{description === undefined ? message : (<><p>{message}</p><p …>{description}</p></>)}
```

`message` を無条件に `<p>` で包む実装のほうが素直だが、それは **この prop を使わない
6艦の DOM を動かす**（テキストノード → 要素）。`ErrorState` は `<p>` で包んでいるので
揃えたくなる形だが、既存の描画を動かさないほうを採った。

**改名はしていない**（`message` はそのまま）。破壊的変更を含めない方針。

## 検査（`pointer.test.tsx` に3件）

- 二段目が渡されたら描画されること（`<p>` が2本・textContent が連結）
- 🔴 **一段の描画が以前のまま**であること＝`children` が **0**・`childNodes` が1本で
  `nodeType === 3`（テキストノード）。**これが本 PR の「既存艦不変」の主張そのもの**
  → **無条件に `<p>` で包む実装に差し替えると exit 1** で落ちることを確認済み
- 同じテスト内で二段版が `children` 2 を返すことも確かめている（陽性対照：
  「0 だった」が「測れていない」ではないこと）

## 新しいスロット2本（既定はスケール参照のみ・既存の描画は読まない）

```css
--spacing-x-slot-empty-state-gap: var(--spacing-x-3xs);
--color-x-slot-empty-state-description-fg: var(--color-text-muted);
```

🔬 初版は `mt-x-3xs` と**スケールを直接**書いていて、キット自身の不変条件
（`readme.test.ts`「no component reaches past the slots into the scale」）に落とされた。
指摘どおりスロットへ移した。**列挙で書かれた検査が実際に効いた例**として記録しておく。

全体 804 tests / 50 files 緑。

Closes #456

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KrzuAuYHcJxN9kV4PHynAr