### PR TITLE
feat(ui): Toast に `description`（二段目）と `success` tone を足す（#457）

### DIFF
--- a/packages/nene2-ui/src/feedback/ToastProvider.tsx
+++ b/packages/nene2-ui/src/feedback/ToastProvider.tsx
@@ -7,6 +7,7 @@ interface Toast {
   id: string;
   message: string;
   tone: ToastTone;
+  description?: string;
 }
 
 export interface ToastProviderProps {
@@ -28,8 +29,15 @@ export interface ToastProviderProps {
 
 const TONE_CLASS: Record<ToastTone, string> = {
   info: 'bg-x-slot-toast-bg text-x-slot-toast-fg border-x-slot-toast-border',
+  success: 'bg-x-slot-toast-bg text-x-slot-toast-success-fg border-x-slot-toast-success-border',
   danger: 'bg-x-slot-toast-bg text-x-slot-toast-danger-fg border-x-slot-toast-danger-border',
 };
+
+// 🔴 `success` は polite 側。`assertive` は読み上げを中断させるので、成功の報告に使うと
+// 利用者の作業を割り込みで止める。中断してよいのは danger だけ、というのが2リージョンに
+// 分けた元の理由なので、語彙が増えてもその線は動かさない（#457）。
+const POLITE_TONES: ToastTone[] = ['info', 'success'];
+const ASSERTIVE_TONES: ToastTone[] = ['danger'];
 
 /**
  * Hosts the toast queue and the live regions that announce it.
@@ -66,7 +74,18 @@ export function ToastProvider({
   const show = useCallback(
     (message: string, options?: ToastOptions) => {
       const id = `toast-${(nextId.current += 1)}`;
-      setToasts((current) => [...current, { id, message, tone: options?.tone ?? 'info' }]);
+      const description = options?.description;
+      setToasts((current) => [
+        ...current,
+        {
+          id,
+          message,
+          tone: options?.tone ?? 'info',
+          // exactOptionalPropertyTypes: 省略と `undefined` を渡すことは別物なので、
+          // 渡されなかった場合はキーごと作らない。
+          ...(description === undefined ? {} : { description }),
+        },
+      ]);
       timers.current.set(
         id,
         setTimeout(() => dismiss(id), options?.durationMs ?? defaultDurationMs),
@@ -87,7 +106,7 @@ export function ToastProvider({
 
   const api = useMemo<ToastApi>(() => ({ show, dismiss }), [show, dismiss]);
 
-  const region = (tone: ToastTone, live: 'polite' | 'assertive') => (
+  const region = (tones: ToastTone[], live: 'polite' | 'assertive') => (
     <div
       aria-live={live}
       aria-label={regionLabel}
@@ -95,7 +114,9 @@ export function ToastProvider({
       className="flex flex-col gap-x-slot-toast-gap"
     >
       {toasts
-        .filter((toast) => toast.tone === tone)
+        // 複数トーンを1つのリージョンへ。元の配列を filter するので、同じリージョンに
+        // 入るトースト同士の**表示順は push された順のまま**になる。
+        .filter((toast) => tones.includes(toast.tone))
         .map((toast) => (
           <div
             key={toast.id}
@@ -104,7 +125,16 @@ export function ToastProvider({
               TONE_CLASS[toast.tone],
             )}
           >
-            <span>{toast.message}</span>
+            {/* 🔴 二段目が無いときは要素を増やさない。無条件に包むと、この prop を
+             * 使っていない艦の DOM が動く（EmptyState #456 と同じ判断）。 */}
+            {toast.description === undefined ? (
+              <span>{toast.message}</span>
+            ) : (
+              <span className="flex flex-col gap-x-slot-toast-description-gap">
+                <span>{toast.message}</span>
+                <span className="text-x-slot-toast-description-fg">{toast.description}</span>
+              </span>
+            )}
             <button
               type="button"
               aria-label={dismissLabel}
@@ -121,8 +151,8 @@ export function ToastProvider({
   return (
     <ToastContext.Provider value={api}>
       {children}
-      {region('info', 'polite')}
-      {region('danger', 'assertive')}
+      {region(POLITE_TONES, 'polite')}
+      {region(ASSERTIVE_TONES, 'assertive')}
     </ToastContext.Provider>
   );
 }

--- a/packages/nene2-ui/src/feedback/toast-context.ts
+++ b/packages/nene2-ui/src/feedback/toast-context.ts
@@ -1,11 +1,30 @@
 import { createContext, useContext } from 'react';
 
-export type ToastTone = 'info' | 'danger';
+/**
+ * 🔴 `success` は 0.17.x まで無く、`info | danger` の2語彙だった。`Badge` と `InlineAlert`
+ * は既に `success` を持っており（Badge は neutral|accent|danger|success|warn|info）、
+ * **トーストだけ語彙が2つ**という状態は 0.17.0 #422 の「一つの語彙をキット全体で」と
+ * 噛み合わない。nene-deal は完了を緑で伝えており、`info` に寄せると保存・移動・削除の
+ * 完了が中立色になって、エラーとの差が「赤かどうか」だけになる（#457）。
+ */
+export type ToastTone = 'info' | 'success' | 'danger';
 
 export interface ToastOptions {
   tone?: ToastTone;
   /** Overrides the provider's default. */
   durationMs?: number;
+  /**
+   * Localized second line: what the action applied to.
+   *
+   * 🔴 Not decoration. nene-deal's success toasts carry one at **7 of 7** call sites — the
+   * deal that moved, the stage it moved to, the range that was exported. `show(message)`
+   * alone drops that text, and joining the two halves is not available to the ship: they are
+   * separate catalog keys, so the separator would be a string owned by the ship, against
+   * principle 4 (#457).
+   *
+   * Omit it and the render is what it was before this prop existed.
+   */
+  description?: string;
 }
 
 export interface ToastApi {

--- a/packages/nene2-ui/src/feedback/toast.test.tsx
+++ b/packages/nene2-ui/src/feedback/toast.test.tsx
@@ -20,7 +20,15 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-function Trigger({ tone, durationMs }: { tone?: 'info' | 'danger'; durationMs?: number }) {
+function Trigger({
+  tone,
+  durationMs,
+  description,
+}: {
+  tone?: 'info' | 'success' | 'danger';
+  durationMs?: number;
+  description?: string;
+}) {
   const { show } = useToast();
   return (
     <button
@@ -28,6 +36,7 @@ function Trigger({ tone, durationMs }: { tone?: 'info' | 'danger'; durationMs?: 
         show('Saved', {
           ...(tone === undefined ? {} : { tone }),
           ...(durationMs === undefined ? {} : { durationMs }),
+          ...(description === undefined ? {} : { description }),
         })
       }
     >
@@ -67,6 +76,52 @@ describe('live regions', () => {
     const polite = container.querySelector('[aria-live="polite"]');
     expect(assertive?.textContent).toContain('Saved');
     expect(polite?.textContent).not.toContain('Saved');
+  });
+
+  // #457 — 語彙が増えても「中断してよいのは danger だけ」の線は動かさない。
+  // 完了の報告で読み上げを割り込ませると、利用者の作業をトーストが止める。
+  it('keeps success on the polite side, where interruption is not warranted', () => {
+    const { container } = mount(<Trigger tone="success" />);
+    fireEvent.click(screen.getByText('go'));
+    expect(container.querySelector('[aria-live="polite"]')?.textContent).toContain('Saved');
+    expect(container.querySelector('[aria-live="assertive"]')?.textContent).not.toContain('Saved');
+  });
+});
+
+describe('tone vocabulary (#457)', () => {
+  it('paints success from its own slot, not by borrowing another tone', () => {
+    const { container } = mount(<Trigger tone="success" />);
+    fireEvent.click(screen.getByText('go'));
+    const cls = container.querySelector('[aria-live="polite"] > div')?.getAttribute('class') ?? '';
+    expect(cls).toContain('text-x-slot-toast-success-fg');
+    // 🔴 他トーンのスロットを借りていない（warn が danger を指していた 0.11 以前の型）
+    expect(cls).not.toContain('text-x-slot-toast-danger-fg');
+    expect(cls).not.toContain('text-x-slot-toast-fg ');
+  });
+});
+
+describe('description (#457)', () => {
+  it('renders the second line when one is given', () => {
+    mount(<Trigger description="Acme → Won" />);
+    fireEvent.click(screen.getByText('go'));
+    expect(screen.getByText('Acme → Won')).toBeTruthy();
+    expect(screen.getByText('Saved')).toBeTruthy();
+  });
+
+  // 🔴 本 PR が「既存艦の描画を変えない」ことの実測。二段目が無いときは要素を増やさない。
+  it('leaves the one-line toast exactly as it was — message in a single bare span', () => {
+    const { container } = mount(<Trigger />);
+    fireEvent.click(screen.getByText('go'));
+    const body = container.querySelector('[aria-live="polite"] > div > span');
+    expect(body?.textContent).toBe('Saved');
+    expect(body?.children).toHaveLength(0);
+    // 陽性対照: 二段版では同じ位置に子が2つ出る＝上の 0 が「測れていない」ではない
+    document.body.innerHTML = '';
+    const two = mount(<Trigger description="x" />);
+    fireEvent.click(screen.getAllByText('go')[0]!);
+    expect(two.container.querySelector('[aria-live="polite"] > div > span')?.children).toHaveLength(
+      2,
+    );
   });
 });
 

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -336,6 +336,13 @@
   --color-x-slot-toast-border: var(--color-border);
   --color-x-slot-toast-danger-fg: var(--color-danger);
   --color-x-slot-toast-danger-border: var(--color-danger);
+  /* `success` tone (#457). Badge and InlineAlert already carry this meaning; the toast is
+   * the one surface that had only two. */
+  --color-x-slot-toast-success-fg: var(--color-success);
+  --color-x-slot-toast-success-border: var(--color-success);
+  /* The toast's second line (#457). Only read when `description` is passed. */
+  --color-x-slot-toast-description-fg: var(--color-text-muted);
+  --spacing-x-slot-toast-description-gap: var(--spacing-x-3xs);
 
   --color-x-slot-card-bg: var(--color-surface-raised);
   --color-x-slot-card-border: var(--color-border);


### PR DESCRIPTION
キットの `ToastProvider` は **live region を空でも DOM に置く**唯一の実装で、
docstring が名指ししているとおり nene-deal はまさにその欠陥（空のとき `null` を返す）を
持っている。**deal は載せ替えたい。**それを塞いでいたのが以下の2点。

## 1. `description` — deal の success トーストは **7/7** が二段目を持つ

```ts
toast.success(t('toast.moved.title'), `${accountLabel}  →  ${stageLabel}`)
//            ^^^^^ 何が起きたか        ^^^^^ どれが・どこへ
```

実測（`nene-deal/src/features/**` 全12箇所）: `success` 7件は**全部** sub つき、
`error` 5件は 0件。内訳は「どの取引が」「どのステージへ」「どの期間を」＝**操作の対象**。
`show(message)` 1本にすると**この情報が画面から消える**。意匠差ではなく情報の欠落。

⚠️ 連結（`${message} — ${description}`）は採れない。二つは別のカタログキーなので
**区切り記号を艦が持つ**ことになり、原則(4)「キットは文字列を持たない」と衝突する。

## 2. `success` tone — `Badge` と `InlineAlert` は既に持っている

`TONE_CLASS` は `info | danger` の2つだけだった。`Badge` の tone は
`neutral|accent|danger|success|warn|info` の6つで、**トーストだけ語彙が2つ**という状態は
0.17.0 #422 の「一つの語彙をキット全体で」と噛み合わない。

deal は完了を緑で伝えており、`info` に寄せると保存・移動・削除の完了が中立色になって、
エラーとの差が**「赤かどうか」だけ**になる。

🔴 **`success` は polite 側に置いた。** `assertive` は読み上げを中断させるので、
完了の報告に使うと利用者の作業をトーストが止める。**中断してよいのは danger だけ**という
2リージョンに分けた元の線は、語彙が増えても動かさない。

## 既存艦の描画は変わらない

- **二段目が無いときは要素を増やさない**（`<span>{message}</span>` のまま）。
  無条件に包む実装のほうが素直だが、それは**この prop を使わない艦の DOM を動かす**
  （EmptyState #456 と同じ判断）。
- **既存トーン（info / danger）のクラス文字列も、既定値も触っていない。**
- 新しいスロット4本はいずれも**スケール参照のみ**で、既存の描画は1つも読まない:

```css
--color-x-slot-toast-success-fg: var(--color-success);
--color-x-slot-toast-success-border: var(--color-success);
--color-x-slot-toast-description-fg: var(--color-text-muted);
--spacing-x-slot-toast-description-gap: var(--spacing-x-3xs);
```

## 検査（`toast.test.tsx` に4件）— いずれも外すと落ちる

- `success` が polite 側に出ること → **assertive 側へ回すと exit 1**
- `success` が**自分のスロット**で塗られ、他トーンを借りていないこと
  （warn が danger を指していた 0.11 以前の型を、増えた語彙で再演しないため）
- 二段目が渡されたら描画されること
- 🔴 **一段の描画が以前のまま**であること（message が子を持たない単一の `<span>`）＝
  本 PR の「既存艦不変」の主張そのもの → **無条件に包む実装に差し替えると exit 1**。
  同じテストで二段版が子2つを返すことも見ており、`0` が「測れていない」ではないことの陽性対照になっている

## 1 issue 1 PR について

`#457` は2点を1つの issue に書いているが、**両方とも `ToastProvider` / `toast-context` /
`themes` の同じ3ファイルに触る**ため、分けると後発が先発に積み上がる。
advice 2026-08-25「積み上げ PR は squash マージと相性が悪い」に従い、**1本にまとめた**。
分割が要るなら言ってください。

全体 806 tests / 50 files 緑。

Closes #457

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KrzuAuYHcJxN9kV4PHynAr