### PR TITLE
chore(release) nene2-ui 0.18.0: deal の W1 から来た3件（#455 / #456 / #457）に版を与える（#464）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -65,6 +65,80 @@ nene2-ui         （未公開）
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
 > 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
 
+### `@hideyukimori/nene2-ui` 0.18.0（**minor — feat**・deal W1 の待ち分・#455 / #456 / #457）
+
+**載せ替える前に読むもの: 「各艦でやること」の節（0.17.0 の下・同じ手順）。**
+中身は**任意 prop とスロットの追加のみ**で、**既定は 0.17.1 までの描画と同じ**。何も渡さない呼び出し側は変わらない。
+**削除・既定値の変更は 0 件**〔`git diff` 実測〕。
+
+| Issue | 入るもの | 既定 |
+| --- | --- | --- |
+| #455 | `Button` の `danger` が **border をスロットから引く**（`border-x-slot-button-danger-border`）。**塗りではなく輪郭で danger を表す艦**（nene-deal）は、これまでスロット値をいくら上書きしても枠を出せなかった — variant が border クラスを1つも出さず、`BASE_CLASS` の `border-transparent` が最後まで残っていたため | **塗りと同色**＝実質不変（下記） |
+| #456 | `EmptyState` に `description`（二段目）。deal の空状態は4箇所中3箇所が「見出し＋説明」の2段で、`message` 1本に畳むと**説明が画面から消える**（意匠差ではなく情報の欠落） | 省略時は**要素を1つも増やさない** |
+| #457 | `ToastProvider` に `description`（二段目）と **`success` tone**。deal の success トーストは **7/7 が二段目を持つ**（「どの取引が」「どのステージへ」＝操作の対象） | 省略時は**要素を1つも増やさない**／既存 tone は不変 |
+
+**新設スロット 7本**（すべてスケール／パレット参照・リテラルなし）:
+`--color-x-slot-button-danger-border` ／ `--spacing-x-slot-empty-state-gap` ／
+`--color-x-slot-empty-state-description-fg` ／ `--color-x-slot-toast-success-fg` ／
+`--color-x-slot-toast-success-border` ／ `--color-x-slot-toast-description-fg` ／
+`--spacing-x-slot-toast-description-gap`
+
+#### 🔴 #455 だけ「クラス文字列は変わる」— 不変性は画素で測った
+
+`danger` に border クラスが1本増えるので、**生成クラス文字列の before/after 一致は原理的に成立しない**
+（スロット参照を足すのが目的の変更なので当然）。⇒ **画素で測った。**
+
+**実測（fleet-tooling・2026-08-26 18:0x JST・`date`）** — Chromium 149（Playwright 1.61.1・`deviceScaleFactor: 2`）＋
+**実 Tailwind 4.3.2 の `compile` API 出力**:
+
+| 比較 | 差分画素 | max channel delta |
+| --- | ---: | ---: |
+| **旧 vs 新（本件）** | **160** / 115200 | 18 |
+| 旧 vs 旧（**陰性対照**） | **0** / 115200 | 0 |
+| 旧 vs 青枠（陽性対照①） | 1134 / 115200 | 209 |
+| 旧 vs `oklch(0.56 0.2 25)`（陽性対照②・**ごく近い色**） | 1102 / 115200 | 22 |
+
+🔑 **判定は差の「量」ではなく「形」。** 枠色が少しでも本当に変われば**全周 ≒1100px** が動く（陽性対照②）。
+本件の 160px を座標で分類すると:
+
+```
+四隅の近傍(<=24px) : 160 = 100.0%
+辺の途中           :   0
+```
+
+⇒ **直線部は完全一致。差は四隅だけ**＝`border-radius` の下で「透明枠越しに見える背景」と「同色の不透明枠」の
+合成が異なるアンチエイリアス。**視覚的変化ではない。**
+既定は `var(--color-danger)`＝**塗りと同じ変数**を指す（`border-transparent` が塗りの上で描いていたのと同じ結果）。
+
+⚠️ **「実質不変」であって「不変」ではない。** 0 ではないことを明記しておく。
+
+#### #456 / #457 は省略時 DOM が byte-for-byte 一致
+
+新旧の実装で**新 prop を渡さない呼び出し**の `innerHTML` を丸ごと書き出して diff:
+
+```
+EmptyState (center) / EmptyState (align=start) / Toast(show) / Toast(tone='danger')
+→ 4件とも完全一致（1バイトの差もなし）
+```
+
+⚠️ **1回目の測定は無効だった。** トーストを `queueMicrotask` で出したためフラッシュされず、
+**新旧とも空のリージョンを比較して「一致」**と出していた（`'' === ''` で緑になる形）。
+`act()` で同期的に描画し、**`expect(html).toContain('Saved')` を陽性対照に入れて**測り直している。
+
+🟢 **`success` は polite 側**（`assertive` は読み上げを中断するので、完了の報告で利用者の作業を止めない）。
+「中断してよいのは danger だけ」という2リージョンの線は、語彙が増えても動かしていない。
+
+#### 組み合わせの実測
+
+3本とも **`themes/default.css` を触る**ので、各 PR の緑は「相手が入る前の緑」だった。
+隔離 worktree で段階マージして実走: **804 → 806 → 810 / 50 files**・各段で `npm run check` **EXIT=0**。
+その上で `update-branch` で追随させ、**組み合わせに CI を当ててから**マージした。
+（リポ側も BEHIND を実際に蹴った＝この規律は機械で守られている。）
+
+**各艦でやること**: 🔴 **0.x の caret は minor を固定する** ⇒ `^0.17.0` は 0.18.0 を**含まない**。
+**宣言を `^0.18.0` へ書き換え** → `npm update @hideyukimori/nene2-ui` → `npm ls` で実インストール版 → 実ブラウザ。
+（詳細は 0.17.0 の「各艦でやること」と同じ。消費艦は `nene-vault` の1艦。**deal はこの版を W1 で待っている。**）
+
 ### `@hideyukimori/nene2-ui` 0.17.1（**patch — fix**・#439）
 
 **載せ替える前に読むもの: 無し。** 変わるのは1点で、`DataTable collapse="sm"` で**カード化した各セルの `::before` ラベルが

--- a/package-lock.json
+++ b/package-lock.json
@@ -9037,7 +9037,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Closes #464

## 何を

`nene2-ui` **0.17.1 → 0.18.0**。deal の W1 載せ替えから来た3件が main に在るのに **npm に出ておらず**、
消費艦 vault も、待っている deal も受け取れない状態だった。

| Issue | PR | 入るもの |
| --- | --- | --- |
| #455 | #458 | `Button` の `danger` が border をスロットから引く |
| #456 | #459 | `EmptyState` に `description`（二段目） |
| #457 | #460 | `ToastProvider` に `description` ＋ `success` tone |

## 版が minor である根拠（実測）

`themes/default.css` の `git diff`:

- 新設スロット **7本**（すべて `var(--…)` 参照・リテラルなし）
- **削除・既定値の変更 0本**

⇒ 破壊的変更なし・機能追加あり = **minor**。

## 既定不変は自分で測った（送り手の申告を受け取っていない）

#### #455 だけクラス文字列は変わる ⇒ 画素で測った

border クラスが1本増えるので、**「生成クラス文字列の一致」は原理的に成立しない**（それを足すのが目的の変更）。

Chromium 149（Playwright 1.61.1・`deviceScaleFactor: 2`）＋ **実 Tailwind 4.3.2 の `compile` 出力**:

| 比較 | 差分画素 | max delta |
| --- | ---: | ---: |
| **旧 vs 新** | **160** / 115200 | 18 |
| 旧 vs 旧（**陰性対照**） | **0** | 0 |
| 旧 vs 青枠（陽性①） | 1134 | 209 |
| 旧 vs `oklch(0.56 0.2 25)`（陽性②・**ごく近い色**） | 1102 | 22 |

🔑 **判定は差の「量」ではなく「形」。** 枠色が本当に変われば**全周 ≒1100px** が動く。本件の 160px は:

```
四隅の近傍(<=24px) : 160 = 100.0%
辺の途中           :   0
```

⇒ 直線部は完全一致・差は `border-radius` のアンチエイリアスのみ。
⚠️ **「実質不変」であって「不変」ではない**ことを `publish.md` に明記した。

#### #456 / #457 は省略時 DOM が byte-for-byte 一致（4形）

⚠️ **1回目の測定は無効だった** — トーストを `queueMicrotask` で出したためフラッシュされず、
**新旧とも空のリージョンを比較して「一致」**（`'' === ''` で緑になる形）。`act()` で同期描画し、
`expect(html).toContain('Saved')` を陽性対照に入れて測り直している。

#### 組み合わせ

3本とも `themes/default.css` を触るので、各 PR の緑は「相手が入る前の緑」だった。隔離 worktree で
段階マージして実走: **804 → 806 → 810 / 50**・各段 `check` EXIT=0。その上で `update-branch` で
組み合わせに CI を当ててからマージした。

## lock も直した（リポの検査器が捕まえた）

`check:lock` が `package.json 0.18.0 / lock 0.17.1` を検出した（`npm ci` はこの食い違いを通すので、
放置すると CI は緑のまま lock だけ古くなる）。

**前後比較**〔実測〕: `packages` **654 → 654**・差分は **`version` の1行のみ**・**降格なし**。

## 🔴 やっていないこと

**`fleet-baseline.json` の floor（`^0.14.0`）は上げていない。** hub 裁定（2026-08-15）で**据え置き**。
唯一の消費艦 vault が 0.14.0 なので、**先に上げると vault が floor 未達になる**。
publish 直後は「自然な後片付け」に見える場所なので明記しておく。

## 実測

`npm run check` **EXIT=0** ／ vitest **810 / 50 files** ／ `format:check` clean

## マージ後

`publish.yml` を **`dry_run: true` で1回 → 本番**（OIDC）。`npm view` で**版と shasum を実測**してから「出た」と書く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmzyXZxJhxb7agJFQq6MfY
