### PR TITLE
fix(ui): README §② の旗艦例が存在しないスロットを教えていた — 検査を代理から本体へ寄せる（#389）

### DIFF
--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -137,12 +137,13 @@ The theme has two layers, and the line between them is the point.
 
 ### ② Slots — 🟢 redefine these
 
-Every design value a component uses comes from a slot, and slots are named per component:
+Every design value a component takes **from the theme** comes from a slot, and slots are named
+per component:
 
 ```css
 /* your product's theme, loaded after the kit's */
 @theme {
-  --spacing-x-slot-card-pad: var(--spacing-x-lg); /* roomier cards, everywhere */
+  --spacing-x-slot-modal-pad: var(--spacing-x-lg); /* roomier modals, everywhere */
   --color-x-slot-field-label: var(--color-text-primary); /* darker field labels */
   --radius-x-slot-control: var(--radius-x-md);
 }
@@ -150,6 +151,18 @@ Every design value a component uses comes from a slot, and slots are named per c
 
 This is where your product decides how it looks. Change a slot and every instance of that
 component follows.
+
+🔴 **"From the theme" is the limit of that sentence, and the limit is load-bearing.** The
+**layout components take their spacing from props, not from slots** — `Box` and `Card` (`pad`),
+`Stack` (`gap`), `Section` and `Grid` (both). That is deliberate rather than an omission: layout
+spacing is a decision the *caller* makes per instance, so it is chosen at the call site. Those
+props still pick a **step from the scale** (`pad="lg"`), so a product cannot invent a value here
+either — but **no slot exists for them**.
+
+⚠️ **This is the part that bites.** Writing `--spacing-x-slot-card-pad` in your theme does
+nothing at all: **there is no such slot**, and nothing warns you — not an error, not a console
+message, not a failing build. To make every card roomier, pass `pad` where you use `Card`, or
+wrap it once in a component of your own.
 
 ### ① The scale — 🔒 do not redefine
 
@@ -223,9 +236,12 @@ second only under `@media (pointer: coarse)`.
 
 ### Composing a slot
 
-A slot can hold several steps — four-sided padding is just CSS:
+A slot can hold several steps — four-sided padding is just CSS. The slot below belongs to a
+component **of your own**, not to the kit (`login-form` is not a kit component); a product
+names slots for its own parts the same way the kit does:
 
 ```css
+/* in your product, for your own <LoginForm> */
 --spacing-x-slot-login-form-pad: var(--spacing-x-xl) var(--spacing-x-md) var(--spacing-x-lg)
   var(--spacing-x-md);
 ```

--- a/packages/nene2-ui/src/index.ts
+++ b/packages/nene2-ui/src/index.ts
@@ -55,8 +55,10 @@ export { tokens } from './theme/tokens.js';
 
 // Internal helpers, exported so downstream components can compose consistently.
 export { cx } from './lib/cx.js';
-// Controls the kit does not ship yet (Textarea has 7 independent implementations in the
-// fleet) can at least carry the same focus and disabled behaviour instead of inventing it.
+// A control the kit does not ship — one a product writes for itself, or one still waiting for
+// a slot in the kit — can at least carry the same focus and disabled behaviour instead of
+// inventing it. (Written when `Textarea` was the example, with 7 independent implementations
+// across the fleet; `Textarea` ships now, so the example is gone but the reason is not.)
 export {
   CLICKABLE_CLASS,
   CONTROL_CLASS,

--- a/packages/nene2-ui/src/readme.test.ts
+++ b/packages/nene2-ui/src/readme.test.ts
@@ -107,7 +107,7 @@ describe('the override boundary', () => {
     // 片方だけだと、次の艦が反対側で迷う。両方書く。
     expect(section, 'must say slots are overridable').toMatch(/Slots — 🟢 redefine these/);
     expect(section, 'must say the scale is not').toMatch(/The scale — 🔒 do not redefine/);
-    expect(section).toContain('--spacing-x-slot-card-pad');
+    expect(section).toContain('--spacing-x-slot-modal-pad');
     expect(section).toContain('--spacing-x-3xs');
     // 🔴 規則の射程を書いていないと、艦がキット本体を落とす検査を作る（vault が実際に踏んだ）。
     expect(section, 'must name the namespaces the rule covers').toMatch(/--brightness-\*/);
@@ -362,6 +362,71 @@ describe('meanings that must stay distinguishable', () => {
     // Contract v1; this theme simply had not defined them.
     for (const c of ['color-warn', 'color-warn-soft', 'color-on-warn', 'color-danger-soft']) {
       expect(resolve(c), `${c} must be defined`).toMatch(/^oklch\(/);
+    }
+  });
+});
+
+describe('the README does not name slots that do not exist', () => {
+  // 🔴 #389: README §② の旗艦例が `--spacing-x-slot-card-pad` を「これを再定義しろ」の
+  // 正例として出していたが、そのスロットは存在しなかった。Card の padding は `pad` prop 由来。
+  // ⇒ **README のとおりにテーマへ書いた消費者は、何も起きない。エラーも警告も出ない。**
+  //
+  // 🔑 これを緑のまま通していたのは、検査が **代理**（README が文字列を含むか）を見て
+  // **本体**（そのスロットが実在するか）を見ていなかったから。しかも誤りを固定していた
+  // ——直そうとすると赤になる形だった。だから代理ではなく本体を検査する。
+  const theme = readFileSync(path.join(root, 'themes/default.css'), 'utf8');
+
+  /**
+   * README が名指ししているが、**キットのスロットとして実在してはいけない**もの。
+   * 2種類あり、どちらも「テーマに宣言が無いこと」が正しい状態:
+   *
+   *   1. 製品側のスロットの例（キットの部品ではない）
+   *   2. **反例**として名指ししているもの（「これを書いても何も起きない」と説明するため）
+   *
+   * 🔴 ここに足すときは理由を書くこと。理由の無い行は、次の #389 を隠す穴になる。
+   */
+  const MUST_NOT_EXIST = new Map([
+    [
+      '--spacing-x-slot-login-form-pad',
+      '§Composing a slot — `login-form` はキットの部品ではなく、製品が自分の <LoginForm> に付ける例',
+    ],
+    [
+      '--spacing-x-slot-card-pad',
+      '§② の警告文が**反例として**名指ししている（#389 の当事者）。' +
+        'この名前で検索した人が警告に辿り着けるよう、あえて書いてある。' +
+        'Card の padding は `pad` prop 由来なので、スロットとして実在してはいけない',
+    ],
+  ]);
+
+  it('every kit slot the README names is declared in the theme', () => {
+    const named = [
+      ...new Set([...readme.matchAll(/--[a-z]+-x-slot-[a-z0-9-]+/g)].map((m) => m[0]!)),
+    ];
+
+    // 陽性対照: README がそもそもスロットを名指ししていないなら、この検査は空虚に緑になる。
+    expect(named.length, 'README must name slots at all').toBeGreaterThan(5);
+
+    const declared = (name: string) =>
+      new RegExp(`^\\s*${name}\\s*:`, 'm').test(theme) ||
+      // ワイルドカード表記（`--color-x-slot-alert-warn-*`）は末尾を落として照合する
+      new RegExp(`^\\s*${name.replace(/-\*$/, '')}[a-z0-9-]*\\s*:`, 'm').test(theme);
+
+    const missing = named.filter((n) => !MUST_NOT_EXIST.has(n) && !declared(n));
+    expect(
+      missing,
+      `README names slots that themes/default.css does not declare. ` +
+        `Either the example is wrong, or the slot is missing. ` +
+        `A product following the README would set these and nothing would happen.`,
+    ).toEqual([]);
+  });
+
+  it('the exceptions are really absent, so the list cannot rot', () => {
+    // 🔴 免除は「実在しないこと」が前提。キットが後から同名のスロットを持ったら、
+    // この行は免除ではなく **検査の穴** になるので、そのとき落ちて気づけるようにする。
+    // （とくに `card-pad` は「実在しない」ことが README の主張そのものなので、
+    //   実在した瞬間に README が嘘になる。ここで落ちるのが正しい。）
+    for (const [name, why] of MUST_NOT_EXIST) {
+      expect(new RegExp(`^\\s*${name}\\s*:`, 'm').test(theme), `${name} — ${why}`).toBe(false);
     }
   });
 });

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -130,10 +130,15 @@
   /* ─────────────────────────────────────────────────────────────────────────
    * ② SLOTS — a product may redefine these.
    *
-   * Every design value a component uses comes from here, and every slot's default points
-   * back at the scale above. That split is the whole idea: a product decides **which step
-   * a part uses**, and cannot invent a step. Change `--spacing-x-slot-card-pad` to
-   * `var(--spacing-x-lg)` and cards get roomier everywhere; you still cannot write `2.25`.
+   * Every design value a component takes **from the theme** comes from here, and every slot's
+   * default points back at the scale above. That split is the whole idea: a product decides
+   * **which step a part uses**, and cannot invent a step. Change `--spacing-x-slot-modal-pad`
+   * to `var(--spacing-x-lg)` and every modal gets roomier; you still cannot write `2.25`.
+   *
+   * 🔴 The layout components (`Box`, `Card`, `Stack`, `Section`, `Grid`) are the exception:
+   * their padding and gap come from **props**, not from slots, because the caller decides
+   * them per instance. There is no `--spacing-x-slot-card-pad` — setting one does nothing,
+   * silently. See README §② (#389).
    *
    * Named per component rather than per role (hide's ruling, 2026-08-23): sharing one slot
    * between `Modal` and `Card` can be arranged later by pointing both at the same value,


### PR DESCRIPTION
Closes #389

## 何が起きていた

README §② Slots は「**自分の製品のテーマで、これを再定義しろ**」と教える節。その**最初の例**が
`--spacing-x-slot-card-pad` だった。**このスロットは存在しない。**

`Card` の padding は `pad` prop 由来（`resolve(pad, PAD)`）で、テーマからは来ていない。
⇒ **README のとおりに書いた消費者は、何も起きない。エラーも警告も出ない。**

さらに **その2行上の主張を、この例自身が反証していた**:

> Every design value a component uses comes from a slot

⇒ **例が間違っているのではなく、例が主張の反例になっていた。**

## 🔴 検査が誤りを固定していた

`readme.test.ts:110`:

```ts
expect(section).toContain('--spacing-x-slot-card-pad');
```

**README が当該文字列を含むこと**だけを見ており、**そのスロットが実在するか**は見ていない。
⇒ **緑。しかも直そうとすると赤になる。**

🔑 `#381` と同族 — **代理を検査して本体を検査していない**。
`#381` は「アンカーの実在 vs 例示であること」、本件は「**文字列の言及 vs スロットの実在**」。

## 直したもの

| | |
| --- | --- |
| 旗艦例 | `--spacing-x-slot-modal-pad` へ（**Modal が実際に `p-x-slot-modal-pad` でスロットから引いていることを確認**） |
| §140 の主張 | **実装に合わせて条件つきに**した。「**theme から取る値は**」がその限界 |
| 例外の説明 | **layout 部品（`Box` / `Card` / `Stack` / `Section` / `Grid`）は prop から引く**。漏れではなく設計（呼び出し側が instance ごとに決める）と書いた |
| `Card` を roomier にする方法 | `pad` prop、または自前でラップ、と明記 |
| `themes/default.css` | ② 節の**コメントにも同じ幻のスロットが在った**ので直した |
| §Composing a slot | `login-form-pad` を「**製品側のスロットの例**」と明示（架空と分かる形に） |
| `src/index.ts` | 「Textarea は未出荷」コメントが古い（**出荷済み**）ので例を外し、理由だけ残した |

⚠️ **layout 部品の列挙は `resolve(` の grep から導出した**（型1: 列挙で書くと列挙外を緑にする）。
最初に手で書いたときは **`Modal` の padding を prop 由来と書いて誤っていた** — 測って直している。

## 🔴 検査を代理から本体へ寄せた（再発を機械で止める唯一の項目）

**README が名指しするスロットが `themes/default.css` に実在すること**を検査する。

免除は `MUST_NOT_EXIST` 表に**理由つき**で持つ。2種類あり、どちらも「宣言が無いことが正しい」:

1. **製品側のスロットの例**（`login-form-pad`）
2. **反例として名指ししているもの**（`card-pad` — この名前で検索した人が警告に辿り着けるよう、あえて書いてある）

そして **「本当に実在しないこと」も別に検査する** — 免除が実在し始めたら、それは免除ではなく
**検査の穴**になるので、そのとき落ちる。（とくに `card-pad` は「実在しない」ことが README の主張そのもの
なので、実在した瞬間に README が嘘になる。）

## 実測

- 🟢 **新検査は初回実行で実際に1件捕まえた** — 本 PR の警告文に残る `card-pad` の言及
- 🟢 **陽性対照**: 架空のスロット名を README に足すと、**その名前を挙げて赤**になる。戻すと緑
- 🟢 `readme.test.ts` **25/25** ／ `npm run check` **EXIT=0** ／ `prettier 3.6.2`（**固定版**・`--version` で確認）

## 射程外（要判断・別 issue）

`Card` の padding を**スロット化して主張を無条件に真にする**案は**描画に影響する**ので本 PR では採らない
（issue #389 のタスク3後段・`#386` の族）。本 PR は**実装を変えず、文書と検査を実装に合わせた**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmzyXZxJhxb7agJFQq6MfY
