### PR TITLE
feat(ui): Badge に gap / font-size / font-weight のスロットを足す（#463）

### DIFF
--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -39,7 +39,7 @@ export function Badge({ tone = 'neutral', className, children }: BadgeProps) {
   return (
     <span
       className={cx(
-        'inline-flex items-center rounded-x-slot-badge border px-x-slot-badge-pad-x py-x-slot-badge-pad-y font-sans',
+        'inline-flex items-center gap-x-slot-badge-gap rounded-x-slot-badge border px-x-slot-badge-pad-x py-x-slot-badge-pad-y font-sans text-x-slot-badge font-x-slot-badge',
         TONE_CLASS[tone],
         className,
       )}

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -156,6 +156,36 @@ describe('Badge', () => {
     expect(cls).not.toMatch(/#|rgb|\[/);
   });
 
+  // #463 — gap も字もスロットが無く、艦は `className` で補うしかなかった。そして
+  // `className` は**効くとは限らない**（同一詳細度なら生成順が決めるので、キットの
+  // BASE_CLASS が後に出れば艦の指定が負ける）。⇒ 補う場所をスロットへ移した。
+  it('reaches slots for its gap and its type, not just its colours', () => {
+    const cls = render(<Badge>x</Badge>).container.firstElementChild?.getAttribute('class') ?? '';
+    expect(cls).toContain('gap-x-slot-badge-gap');
+    expect(cls).toContain('text-x-slot-badge');
+    expect(cls).toContain('font-x-slot-badge');
+  });
+
+  // 🔴 この3本だけは「既定値不変」にできない（現行の既定が *未指定* なので、スロットを
+  // 作ること自体が既定を決める）。だから代わりに **艦が取り戻せること** を固定する。
+  // 値は列挙で書かず theme の現物から読む（型1: 列挙で書いた検査は列挙に無いものを緑にする）。
+  it('defaults those three from the scale, so a ship can redefine them', () => {
+    const css = readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '../../themes/default.css'),
+      'utf8',
+    );
+    const valueOf = (name: string) => css.match(new RegExp(`--${name}:\\s*([^;]+);`))?.[1]?.trim();
+    for (const slot of [
+      'spacing-x-slot-badge-gap',
+      'text-x-slot-badge',
+      'font-weight-x-slot-badge',
+    ]) {
+      const v = valueOf(slot);
+      expect(v, `${slot} is not defined`).toBeTruthy(); // 陽性対照: 読めていないのに合格させない
+      expect(v, `${slot} must default from the scale, not a literal`).toMatch(/^var\(--/);
+    }
+  });
+
   it('is neutral unless told otherwise', () => {
     const { container } = render(<Badge>x</Badge>);
     expect(container.firstElementChild?.getAttribute('class')).toContain(

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -164,6 +164,12 @@
   --spacing-x-slot-choice-box: var(--spacing-x-sm);
   --spacing-x-slot-badge-pad-x: var(--spacing-x-2xs);
   --spacing-x-slot-badge-pad-y: var(--spacing-x-3xs);
+  /* 🔴 Between a badge's icon and its label (#463). Unlike every other slot added so far,
+   * this one **changes what a Badge already renders**: the current default is *nothing
+   * specified*, so an icon sits flush against its text. Both consumers — nene-vault and
+   * nene-deal — were already correcting that independently, so the painting this replaces
+   * is one no consumer used. */
+  --spacing-x-slot-badge-gap: var(--spacing-x-3xs);
   --spacing-x-slot-switch-pad-x: var(--spacing-x-2xs);
   --spacing-x-slot-switch-pad-y: var(--spacing-x-3xs);
   --spacing-x-slot-alert-pad: var(--spacing-x-2xs);
@@ -185,6 +191,10 @@
   --radius-x-slot-button: var(--radius-x-md);
   --radius-x-slot-control: var(--radius-x-md);
   --radius-x-slot-badge: var(--radius-x-md);
+  /* A badge is a label, not body copy (#463). Inherited type made it the size and weight of
+   * whatever it sat in; both consumers overrode both. Same caveat as the gap above: this
+   * changes the current render. */
+  --text-x-slot-badge: var(--text-x-2xs);
   --radius-x-slot-switch: var(--radius-x-md);
   --radius-x-slot-alert: var(--radius-x-md);
   --radius-x-slot-toast: var(--radius-x-md);
@@ -410,7 +420,15 @@
   --spacing-x-slot-button-icon: var(--spacing-x-lg);
 
   /* ── Weight slots ─────────────────────────────────────────────────────────────
-   * `font-medium` appeared inline in four components. Same rule, same reason as colour. */
+   * `font-medium` appeared inline in four components. Same rule, same reason as colour.
+   *
+   * 🔴 The badge is `semibold`, and it is the one slot here that is not preserving an
+   * existing inline weight — it had none, which is why #463 exists. So the reason the other
+   * six are `medium` (that is what they already rendered) does not reach it, and the only
+   * evidence left is the consumers: nene-vault ships `font-semibold` and nene-deal measures
+   * 600 in production. **Nothing ships 500.** A badge also carries its weight at 11px, where
+   * the others sit at body size — the weight is doing work the size cannot. */
+  --font-weight-x-slot-badge: var(--font-weight-semibold);
   --font-weight-x-slot-button: var(--font-weight-medium);
   --font-weight-x-slot-table-header: var(--font-weight-medium);
   --font-weight-x-slot-detail-term: var(--font-weight-medium);


### PR DESCRIPTION
バッジは**ラベル**なのに、字は周囲の本文を継承し、アイコンと文字の間には隙間が無かった。
どちらもスロットが無く、艦は `className` で補うしかなかった。

```
--spacing-x-slot-badge-gap: var(--spacing-x-3xs);          gap-x-slot-badge-gap
--text-x-slot-badge: var(--text-x-2xs);                    text-x-slot-badge
--font-weight-x-slot-badge: var(--font-weight-semibold);   font-x-slot-badge
```

## 🔴 この3本だけは「既定値不変」にできない

これまで足したスロット（#455 / #456 / #457）は「既定を現状のままにすれば他艦は 1px も
動かない」で通せた。**本件は現行の既定が *未指定* なので、スロットを作ること自体が既定を決める。**

そのうえで (a)（実際に値を入れる）を採ったのは、**その未指定を使っている艦が 0 だった**から。
キットの Badge 消費者は nene-vault と nene-deal の2艦で、**両方とも3つとも上書きしていた**
——vault は `className={BADGE_CHROME}`（`text-2xs font-semibold ... gap-1.5`）、deal は
本番実測で gap 5px / 11.5px / 600。**2艦が独立に同じ穴を塞いでいた。**
⇒ 守られていたのは、どの消費者も使っていない描画だった（fleet-tooling の実測・#463）。

## weight が `semibold` である理由（初版は `medium` で出し、指摘を受けて是正）

既存の `--font-weight-x-slot-*` は6本すべて `medium` なので、初版はそれに揃えた。
**その「慣習」の中身を測ったら、揃える理由にならなかった**——ブロックの現物:

```
/* ── Weight slots ──
 * `font-medium` appeared inline in four components. Same rule, same reason as colour. */
```

🔑 6本は**設計された慣習ではなく、既にインラインに在った `font-medium` のスロット化**＝
**既存描画の保存**。**Badge にはインラインの weight が無かった**（それが本 issue の本体）ので、
**保存すべきものが無く、この慣習は Badge に当たらない。** 残る根拠は実測だけで、
vault=600 / deal=600 / **500 を出荷している艦は 0**。

`--font-weight-semibold: 600` は Tailwind の既定テーマ（thin…black の9段）に在るので、
`medium` と**同格のスケール参照**——リテラルにはならない。
⚠️ `gap` と `size` は違う: どちらもスケール上の最寄りで**2px 以内の丸め**（4px/実測5〜6px、
11px/実測11.5px）。**weight だけは 500 と 600 の間に段が無く、丸めではなく別の値**になる。

## 受入① — 艦が意匠を取り戻せること

「既定値不変」の代わりに、**スロット再定義で vault の値に戻せること**を実測した
（Tailwind 4.3.2 を実際にコンパイルして生成 CSS を読む）:

```
① Badge が読むクラスは生成されている（陽性対照——「無い」と区別するため先に見た）
   gap-x-slot-badge-gap   gap: var(--spacing-x-slot-badge-gap);
   text-x-slot-badge      font-size: var(--text-x-slot-badge);
   font-x-slot-badge      font-weight: var(--font-weight-x-slot-badge);

② 既定 → vault のスロット再定義
   gap     var(--spacing-x-3xs)        → 6px
   size    var(--text-x-2xs)           → 11.5px
   weight  var(--font-weight-semibold) → 600
```

🔑 **スロットの再定義は生成順に依存しない**（変数そのものを差し替えるので）。
`className` での上書きは同一詳細度なら生成順が決めるため**効くとは限らない**——
この PR は vault の意匠を壊す話ではなく、**補いを効く形へ移す機会**（fleet-tooling#469）。

## 検査（`feedback.test.tsx` に2件・どちらも外して落ちることを確認済み）

- Badge が3つのスロットへ到達すること → **BASE_CLASS からクラスを外すと exit 1**
- **3つの既定がスケール参照であること**（リテラルでないこと）
  → **既定を直値にすると exit 1**（`medium`→`600` の是正後も再確認済み）
  値は列挙で書かず `themes/default.css` の現物から読む。読めなかった場合に合格させないよう、
  値が truthy であることを先に確かめる陽性対照つき。

## vault の先行条件（fleet 申告どおり・本 PR の外）

vault は上げる前に `BADGE_CHROME` の3つをスロット再定義へ移す必要がある。移行しないまま
上げると 6px→4px / 11.5px→11px に動く（**weight は 600 のままで変わらない**——是正の副産物）。

全体 **814 tests / 50 files** 緑・`npm run check` EXIT=0。

Closes #463