### PR TITLE
fix(ui): Badge のラベルが狭い行で折れる — whitespace-nowrap を BASE_CLASS へ（#477）

### DIFF
--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -35,11 +35,26 @@ const TONE_CLASS: Record<NonNullable<BadgeProps['tone']>, string> = {
  * `<Badge color="red">` becomes a lie the moment the theme changes, and there is no way to
  * find every such lie afterwards except by reading every screen.
  */
+/**
+ * 🔴 `whitespace-nowrap` is load-bearing (#477). A badge is a label, not body copy — but the
+ * kit had no opinion on wrapping, so in a narrow flex row the label wrapped. In CJK that is
+ * not a word-boundary break: 「あなた」 came apart into three stacked characters and the badge
+ * grew from 26.5px tall to 43px (measured, nene-deal /users at 375px).
+ *
+ * Two holes were open at once — the label could *wrap* (`white-space: normal`) and the badge
+ * could *shrink* (`flex-shrink: 1`) — and either one alone produces the failure. `shrink-0`
+ * would close it too, but only while the badge is a flex item: measured in a 50px block
+ * container, `shrink-0` still wrapped (50 × 43) while `nowrap` did not (51 × 26.5). `nowrap`
+ * also stops the shrink, because a flex item's automatic minimum size is its min-content
+ * width and nowrap makes that the whole label. One class, both holes, any context.
+ *
+ * A badge that already fits is unchanged (35.88 × 26.5 before and after, measured).
+ */
 export function Badge({ tone = 'neutral', className, children }: BadgeProps) {
   return (
     <span
       className={cx(
-        'inline-flex items-center gap-x-slot-badge-gap rounded-x-slot-badge border px-x-slot-badge-pad-x py-x-slot-badge-pad-y font-sans text-x-slot-badge font-x-slot-badge',
+        'inline-flex items-center whitespace-nowrap gap-x-slot-badge-gap rounded-x-slot-badge border px-x-slot-badge-pad-x py-x-slot-badge-pad-y font-sans text-x-slot-badge font-x-slot-badge',
         TONE_CLASS[tone],
         className,
       )}

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -186,6 +186,14 @@ describe('Badge', () => {
     }
   });
 
+  // #477 — 狭い flex 行でラベルが折れ、CJK では1文字ずつ縦に積まれた（deal の W1 で
+  // 施主が見つけた唯一の NG）。jsdom は折り返しを計算しないのでクラス文字列を固定する。
+  // 実ブラウザでの切り分けは Badge.tsx の docstring（対照つきの実測）を参照。
+  it('does not let its label wrap', () => {
+    const cls = render(<Badge>x</Badge>).container.firstElementChild?.getAttribute('class') ?? '';
+    expect(cls).toContain('whitespace-nowrap');
+  });
+
   it('is neutral unless told otherwise', () => {
     const { container } = render(<Badge>x</Badge>);
     expect(container.firstElementChild?.getAttribute('class')).toContain(


### PR DESCRIPTION
Closes #477

## 何が起きていた

deal の W1 目視束を施主が見て出た**唯一の NG**。狭い flex 行でバッジのラベルが折り返し、
**CJK は単語境界に守られない**ので「あなた」が**1文字ずつ縦に積まれ**、高さが **26.5px → 43px** になっていた。

## 🔬 原因は1つではなかった（deal の切り分けを自艦で再現）

**穴が2つ同時に開いていた** — ラベルが**折り返せる**（`white-space: normal`）ことと、
バッジが**縮められる**（`flex-shrink: 1`）こと。**どちらか片方だけでも失敗が出る。**
⇒ 片方を直すと**もう片方が開いたまま緑になる**。

## `whitespace-nowrap` を採った理由（`shrink-0` ではなく）

**`shrink-0` はその要素が flex 項目のときしか効かない。** 実測:

| | flex 行 180px | **block 容器 50px** | 収まっているバッジ |
| --- | --- | --- | --- |
| **対照（現行）** | 🔴 49.2 × **43** | 🔴 50 × **43** | 35.88 × 26.5 |
| `+ shrink-0` | ✅ 51 × 26.5 | 🔴 **50 × 43（効かない）** | — |
| `+ whitespace-nowrap` | ✅ 51 × 26.5 | ✅ **51 × 26.5** | ✅ **35.88 × 26.5（不変）** |

`nowrap` は**縮みも塞ぐ** — flex 項目の自動最小サイズは min-content 幅で、`nowrap` は**それをラベル全体にする**。
⇒ **1クラスで両方の穴を、文脈に依らず塞ぐ。**

⚠️ **陰性対照を先に取っている。** 最初の測定は**容器が広すぎて対照が壊れず**（51 × 26.5）、
比較が無効だった。**対照が壊れる幅を探してから**（flex 180px / block 50px）測り直している。

## 既定への影響

**変わるのは現在折れている箇所だけ**で、そこは**今も壊れている**。
**収まっているバッジは 35.88 × 26.5 のまま完全に不変**〔実測〕。
⇒ #463 と違い「**他艦の意匠が動く**」type ではない。

🔴 **スロットは置かない** — `white-space` は艦ごとに変えたい値ではない。

## 検査

jsdom は折り返しを計算しないので**クラス文字列を固定**する。実ブラウザでの切り分けは `Badge.tsx` の docstring に残した。

🔴 **クラスを外すと赤になることを確認した**（`current.md` 型5 —「対照を置いた」ではなく「**対照が発火することを見た**」）。

## 実測

vitest **815 / 50 files**（+1）／`npm run check` **EXIT=0**／`prettier 3.6.2`

## 次

マージ後、**patch（0.19.1）**として出す想定。deal はこれを待って `npm update` → 再測 → **同じ束を上書き**して施主に再確認 → 本番切り替え。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VmzyXZxJhxb7agJFQq6MfY

---

## 追記: vault の Badge での見え方（hub の依頼・2026-08-26 21:4x 実測）

vault は 0.19.0 を消費済み（`3d78794`）で、`BADGE_CHROME` に **`leading-badge` とドット（`before:*`）** を残している。
その構成を再現して修正前後を突合した（vault の `--leading-badge: 1.4` を `@theme` で与えた）:

| | 修正前 | 修正後 |
| --- | --- | --- |
| **実文言「有効」・広い行 375px** | 50 × 25.39 | **50 × 25.39（完全に不変）** |
| 実文言「有効」・狭い行 150px | 🔴 39 × **40.78**（折れる） | ✅ 50 × 25.39 |
| 長い文言「メタデータ未確認」・150px | 🔴 61.64 × **56.17**（3行に折れる） | ✅ 116 × 25.39 |

🟢 **`line-height` は前後とも 15.4px** — `leading-badge` は潰れていない（`nowrap` は別プロパティなので競合しない）。

⇒ **vault の通常の描画は変わらない。** 変わるのは**いま折れている場合だけ**で、そこは今も壊れている。
⚠️ ただし vault は **`metadata_unconfirmed_badge`（「メタデータ未確認」）という長い文言**を持つので、
**狭い容器に入る箇所があれば、そこは見た目が変わる**（折れなくなる＝改善方向）。**vault にも伝える。**
