### PR TITLE
feat(ui)!: Button の variant を「形 × 色」の2軸へ分ける（#487・BREAKING・施主承認待ち）— 5艦が独立に発明した合成名を軸で解く

### DIFF
--- a/packages/nene2-ui/README.md
+++ b/packages/nene2-ui/README.md
@@ -35,6 +35,16 @@ bound. Providing the parts scales with the number of screens, which is finite.**
    cannot express it, add a variant — for everyone. _This is the principle that matters:_ the
    13,021 style violations the fleet is currently remediating exist because values could be
    written inline. Make them unwritable and there is nothing to inspect.
+
+   🔴 **But "add a variant" is the wrong move when the axis is wrong** (#487). `Button` carried
+   one closed enum that mixed *shape* with *colour* — `primary | secondary | danger | ghost` —
+   so "the ghost shape in the danger colour" was not sayable. Five ships each invented a
+   private name for that one cell and no two agreed (`ghost-danger`, `danger-ghost`,
+   `link-danger`, `danger-outline`, and nene-deal reached it through slots). Enumerating four
+   more values would have left `4 shapes × 4 tones = 16` names to chase. 0.20.0 splits the
+   axis instead: `variant` is the shape, `tone` is the colour. **Before adding a value, check
+   whether what is missing is a value or an axis** — a value that ships keep spelling with a
+   hyphen in the middle is usually two axes wearing one name.
 4. **No strings.** The kit ships no user-visible text. `Spinner` takes `label`, `ErrorState` takes
    `retryLabel`. Localisation stays with the product (`@hideyukimori/nene2-i18n`), so a wording
    change never becomes a kit release.

--- a/packages/nene2-ui/src/data/Pagination.tsx
+++ b/packages/nene2-ui/src/data/Pagination.tsx
@@ -108,7 +108,7 @@ export function Pagination(props: PaginationProps) {
   const prev = (
     <Button
       key="prev"
-      variant="secondary"
+      variant="outline"
       size={size}
       disabled={atStart}
       onClick={goPrev}
@@ -125,7 +125,7 @@ export function Pagination(props: PaginationProps) {
   const next = (
     <Button
       key="next"
-      variant="secondary"
+      variant="outline"
       size={size}
       disabled={atEnd}
       onClick={goNext}

--- a/packages/nene2-ui/src/data/Pagination.tsx
+++ b/packages/nene2-ui/src/data/Pagination.tsx
@@ -109,6 +109,7 @@ export function Pagination(props: PaginationProps) {
     <Button
       key="prev"
       variant="outline"
+      tone="neutral"
       size={size}
       disabled={atStart}
       onClick={goPrev}
@@ -126,6 +127,7 @@ export function Pagination(props: PaginationProps) {
     <Button
       key="next"
       variant="outline"
+      tone="neutral"
       size={size}
       disabled={atEnd}
       onClick={goNext}

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -133,7 +133,10 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog {...props} onConfirm={() => {}} onCancel={() => {}} />,
     );
     const confirm = [...container.querySelectorAll('button')].at(-1);
-    expect(confirm?.getAttribute('class')).toContain('bg-x-slot-button-primary-bg');
+    // 0.20.0: 形と色が分かれたので、既定は solid × neutral（#487）。
+    expect(confirm?.getAttribute('class')).toContain('bg-x-slot-button-neutral-bg');
+    // 🔴 陰性対照: danger の色を持っていないこと（「破壊的に見えない」の本体）。
+    expect(confirm?.getAttribute('class')).not.toContain('bg-x-slot-button-danger-bg');
   });
 
   it('routes a dismissal to onCancel, never to onConfirm', () => {

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -133,8 +133,8 @@ describe('ConfirmDialog', () => {
       <ConfirmDialog {...props} onConfirm={() => {}} onCancel={() => {}} />,
     );
     const confirm = [...container.querySelectorAll('button')].at(-1);
-    // 0.20.0: 形と色が分かれたので、既定は solid × neutral（#487）。
-    expect(confirm?.getAttribute('class')).toContain('bg-x-slot-button-neutral-bg');
+    // 0.20.0: 形と色が分かれた（#487）。確定ボタンは solid × accent＝0.19.x の primary と同じ。
+    expect(confirm?.getAttribute('class')).toContain('bg-x-slot-button-accent-bg');
     // 🔴 陰性対照: danger の色を持っていないこと（「破壊的に見えない」の本体）。
     expect(confirm?.getAttribute('class')).not.toContain('bg-x-slot-button-danger-bg');
   });

--- a/packages/nene2-ui/src/lib/shadow-slots.test.ts
+++ b/packages/nene2-ui/src/lib/shadow-slots.test.ts
@@ -62,7 +62,7 @@ describe('影のスロット（#386）', () => {
     // 🔴 導出できない。この3行は「0.15.0 以前に各部品が実際に描いていたもの」という
     // 過去の事実であり、現在のコードからは復元できないので、記録として固定する。
     // 変更するときは「描画を変える」判断とセットでなければならない。
-    expect(decls.get('--shadow-x-slot-button-primary')).toBe('none'); // Button は影を持たなかった
+    expect(decls.get('--shadow-x-slot-button-solid')).toBe('none'); // Button は影を持たなかった（0.20.0 で primary→solid・#487）
     expect(decls.get('--shadow-x-slot-card-raised')).toBe('var(--shadow-sm)'); // Card.tsx が shadow-sm
     expect(decls.get('--shadow-x-slot-toast')).toBe('var(--shadow-sm)'); // ToastProvider.tsx が shadow-sm
   });
@@ -91,7 +91,7 @@ describe('影のスロット（#386）', () => {
 
   it('影を描く部品がスロットを読んでいる', () => {
     const read = (rel: string) => readFileSync(path.join(root, rel), 'utf8');
-    expect(read('src/primitives/Button.tsx')).toContain('shadow-x-slot-button-primary');
+    expect(read('src/primitives/Button.tsx')).toContain('shadow-x-slot-button-solid');
     expect(read('src/layout/Card.tsx')).toContain('shadow-x-slot-card-raised');
     expect(read('src/feedback/ToastProvider.tsx')).toContain('shadow-x-slot-toast');
   });

--- a/packages/nene2-ui/src/overlay/ConfirmDialog.tsx
+++ b/packages/nene2-ui/src/overlay/ConfirmDialog.tsx
@@ -42,10 +42,13 @@ export function ConfirmDialog({
       <Stack gap="xs">
         <Text>{message}</Text>
         <Stack direction="horizontal" gap="2xs" justify="end">
-          <Button variant="secondary" onClick={onCancel}>
+          <Button variant="outline" onClick={onCancel}>
             {cancelLabel}
           </Button>
-          <Button variant={tone === 'danger' ? 'danger' : 'primary'} onClick={onConfirm}>
+          {/* 🔴 `tone` の値をそのまま渡す。0.20.0 以前は `variant` に載せ替えていたが、
+              それは「形」の軸に「色」を書いていたということだった（#487）。
+              ConfirmDialog の `tone` と Button の `tone` は同じ語で同じ意味になった。 */}
+          <Button tone={tone === 'danger' ? 'danger' : 'neutral'} onClick={onConfirm}>
             {confirmLabel}
           </Button>
         </Stack>

--- a/packages/nene2-ui/src/overlay/ConfirmDialog.tsx
+++ b/packages/nene2-ui/src/overlay/ConfirmDialog.tsx
@@ -42,13 +42,13 @@ export function ConfirmDialog({
       <Stack gap="xs">
         <Text>{message}</Text>
         <Stack direction="horizontal" gap="2xs" justify="end">
-          <Button variant="outline" onClick={onCancel}>
+          <Button variant="outline" tone="neutral" onClick={onCancel}>
             {cancelLabel}
           </Button>
           {/* 🔴 `tone` の値をそのまま渡す。0.20.0 以前は `variant` に載せ替えていたが、
               それは「形」の軸に「色」を書いていたということだった（#487）。
               ConfirmDialog の `tone` と Button の `tone` は同じ語で同じ意味になった。 */}
-          <Button tone={tone === 'danger' ? 'danger' : 'neutral'} onClick={onConfirm}>
+          <Button tone={tone === 'danger' ? 'danger' : 'accent'} onClick={onConfirm}>
             {confirmLabel}
           </Button>
         </Stack>

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -3,7 +3,36 @@ import { cx } from '../lib/cx.js';
 import { CLICKABLE_CLASS, TOUCH_CLASS } from '../lib/states.js';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  /**
+   * The shape: which properties get painted. Not which colour they get painted in.
+   *
+   * 🔴 This used to be one closed enum that mixed shape and colour
+   * (`primary | secondary | danger | ghost`), so "the ghost shape in the danger colour" was
+   * not expressible. Five ships each invented their own name for that one missing cell, and
+   * no two agreed: nene-clear `ghost-danger`, nene-field `danger-ghost` (the same thing,
+   * written backwards), nene-profile `link-danger`, nene-origin `danger-outline`, and
+   * nene-deal reached the same place through slots instead — it set
+   * `--color-x-slot-button-danger-bg: transparent` and turned the filled danger into an
+   * outlined one (#455). One need, five workarounds, because the API could not say it.
+   *
+   * 🔴 `bare`, not `ghost`. The old name meant "no fill, no border" here, but nene-clear's
+   * `.btn-ghost` has both a background and a border — it is this kit's `outline`. The word is
+   * split across the industry too (Bootstrap's ghost is an outline, Material's is a text
+   * button), so a ship reading `ghost` cannot know which one it got. Renaming costs nothing:
+   * neither consuming ship uses it (nene-vault 0, nene-deal 0, measured 2026-08-27).
+   */
+  variant?: 'solid' | 'outline' | 'bare' | 'link';
+  /**
+   * The colour: what the shape means. Not how loud it is.
+   *
+   * `neutral` is the ordinary action, `danger` destroys something, `warn` is the one that is
+   * hard to undo without being destructive, `success` confirms.
+   *
+   * 🔴 `Badge` has carried `tone` since 0.17.0 and paints it from
+   * `--color-x-slot-badge-<tone>-{bg,fg,border}`. Button now reads the same word the same
+   * way, so a tone means one thing across the kit rather than two.
+   */
+  tone?: 'neutral' | 'danger' | 'warn' | 'success';
   /**
    * Two sizes, not a length. `sm` for dense rows and toolbars.
    *
@@ -14,21 +43,83 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children: ReactNode;
 }
 
-const VARIANT_CLASS: Record<NonNullable<ButtonProps['variant']>, string> = {
-  primary: 'bg-x-slot-button-primary-bg text-x-slot-button-primary-fg shadow-x-slot-button-primary',
-  secondary:
-    'bg-x-slot-button-secondary-bg text-x-slot-button-secondary-fg border-x-slot-button-secondary-border',
-  danger:
-    'bg-x-slot-button-danger-bg text-x-slot-button-danger-fg border-x-slot-button-danger-border',
-  // No fill and no border: for the third action in a row, where two framed buttons would
-  // compete with each other. nene-vault ships this variant already.
-  ghost: 'bg-transparent text-x-slot-button-ghost-fg',
+/**
+ * Shape × tone, written out.
+ *
+ * 🔴 Sixteen literal strings and no interpolation, because Tailwind reads the source as text.
+ * `` `bg-x-slot-button-${tone}-bg` `` produces the right class at runtime and no CSS for it at
+ * build time — the generator never sees the string, so the rule is never emitted. The kit has
+ * to spell every combination it supports.
+ *
+ * 🔴 `solid` paints `-bg` + `-fg`; every other shape paints `-ink`. They are separate slots
+ * because they are separate colours: on a filled danger button the text is the on-accent
+ * colour, and on an outlined one it is the danger colour itself. Deriving one from the other
+ * would have made the outlined button's label white on white.
+ *
+ * 🔴 `outline`'s background is a single slot that does not vary with tone. nene-clear's
+ * outlined danger sits on the plain surface (`background: var(--surface)`) and only reaches
+ * for a tinted one on hover; painting the rest a tone-tinted colour would be louder than what
+ * any ship draws today.
+ */
+const SHAPE_TONE_CLASS: Record<
+  NonNullable<ButtonProps['variant']>,
+  Record<NonNullable<ButtonProps['tone']>, string>
+> = {
+  solid: {
+    neutral: 'bg-x-slot-button-neutral-bg text-x-slot-button-neutral-fg shadow-x-slot-button-solid',
+    danger: 'bg-x-slot-button-danger-bg text-x-slot-button-danger-fg shadow-x-slot-button-solid',
+    warn: 'bg-x-slot-button-warn-bg text-x-slot-button-warn-fg shadow-x-slot-button-solid',
+    success: 'bg-x-slot-button-success-bg text-x-slot-button-success-fg shadow-x-slot-button-solid',
+  },
+  outline: {
+    neutral:
+      'bg-x-slot-button-outline-bg text-x-slot-button-neutral-ink border-x-slot-button-neutral-border',
+    danger:
+      'bg-x-slot-button-outline-bg text-x-slot-button-danger-ink border-x-slot-button-danger-border',
+    warn: 'bg-x-slot-button-outline-bg text-x-slot-button-warn-ink border-x-slot-button-warn-border',
+    success:
+      'bg-x-slot-button-outline-bg text-x-slot-button-success-ink border-x-slot-button-success-border',
+  },
+  bare: {
+    neutral: 'bg-transparent text-x-slot-button-neutral-ink',
+    danger: 'bg-transparent text-x-slot-button-danger-ink',
+    warn: 'bg-transparent text-x-slot-button-warn-ink',
+    success: 'bg-transparent text-x-slot-button-success-ink',
+  },
+  link: {
+    neutral: 'bg-transparent text-x-slot-button-neutral-ink underline-offset-4 hover:underline',
+    danger: 'bg-transparent text-x-slot-button-danger-ink underline-offset-4 hover:underline',
+    warn: 'bg-transparent text-x-slot-button-warn-ink underline-offset-4 hover:underline',
+    success: 'bg-transparent text-x-slot-button-success-ink underline-offset-4 hover:underline',
+  },
 };
 
-const SIZE_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
-  md: 'px-x-slot-button-pad-x py-x-slot-button-pad-y text-x-slot-button-size',
-  sm: 'px-x-slot-button-sm-pad-x py-x-slot-button-sm-pad-y text-x-slot-button-sm-size',
+/**
+ * 🔴 Padding and type size are separate because `link` takes one and not the other.
+ *
+ * A link-shaped button is a run of text inside a sentence or a table cell; padding would push
+ * it off the line it belongs to. nene-clear's `.btn-link` sets `padding: 0` and
+ * nene-profile's renders through a `linkbtn` class that does the same. The type size still
+ * applies — it is the same two sizes as every other button.
+ */
+const PAD_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
+  md: 'px-x-slot-button-pad-x py-x-slot-button-pad-y',
+  sm: 'px-x-slot-button-sm-pad-x py-x-slot-button-sm-pad-y',
 };
+
+const TEXT_CLASS: Record<NonNullable<ButtonProps['size']>, string> = {
+  md: 'text-x-slot-button-size',
+  sm: 'text-x-slot-button-sm-size',
+};
+
+/**
+ * `link` drops the box the other three shapes share.
+ *
+ * 🔴 `border-0` rather than leaving the transparent border in place: the border is there so a
+ * bordered button matches an unbordered one in height, and a link has no height to match.
+ * `rounded-none` for the same reason — there is no box to round.
+ */
+const LINK_UNBOX = 'border-0 rounded-none';
 
 // 🔴 `inline-flex`, so the button places what is inside it. A `<button>` is `inline-block`
 // by default, which leaves an icon and its label on a shared baseline rather than centred —
@@ -63,17 +154,25 @@ const SVG_BOUND = '[&_svg]:max-h-x-slot-button-icon [&_svg]:max-w-x-slot-button-
 const BASE_CLASS = `rounded-x-slot-button border border-transparent inline-flex items-center justify-center gap-x-slot-button-gap font-sans font-x-slot-button ${SVG_BOUND} ${TOUCH_CLASS} ${CLICKABLE_CLASS}`;
 
 export function Button({
-  variant = 'primary',
+  variant = 'solid',
+  tone = 'neutral',
   size = 'md',
   children,
   type = 'button',
   className,
   ...rest
 }: ButtonProps) {
+  const isLink = variant === 'link';
   return (
     <button
       type={type}
-      className={cx(BASE_CLASS, SIZE_CLASS[size], VARIANT_CLASS[variant], className)}
+      className={cx(
+        BASE_CLASS,
+        isLink ? LINK_UNBOX : PAD_CLASS[size],
+        TEXT_CLASS[size],
+        SHAPE_TONE_CLASS[variant][tone],
+        className,
+      )}
       {...rest}
     >
       {children}

--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -25,14 +25,16 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /**
    * The colour: what the shape means. Not how loud it is.
    *
-   * `neutral` is the ordinary action, `danger` destroys something, `warn` is the one that is
-   * hard to undo without being destructive, `success` confirms.
+   * 🔴 The same six words `Badge` has carried since 0.17.0, in the same order, painted from
+   * the same shape of slot. A tone means one thing across the kit or it means nothing.
    *
-   * 🔴 `Badge` has carried `tone` since 0.17.0 and paints it from
-   * `--color-x-slot-badge-<tone>-{bg,fg,border}`. Button now reads the same word the same
-   * way, so a tone means one thing across the kit rather than two.
+   * 🔴 The default is `accent`, not `neutral`. What 0.19.x called `primary` was never a tone
+   * — it was "the accent-coloured filled button", so `<Button>` keeps rendering exactly that.
+   * `neutral` is the quiet grey step, which is what `Badge` has always meant by the word.
+   * Reading `neutral` as "the ordinary action" is how this kit ended up with two vocabularies
+   * in the first place.
    */
-  tone?: 'neutral' | 'danger' | 'warn' | 'success';
+  tone?: 'neutral' | 'accent' | 'danger' | 'success' | 'warn' | 'info';
   /**
    * Two sizes, not a length. `sm` for dense rows and toolbars.
    *
@@ -67,30 +69,39 @@ const SHAPE_TONE_CLASS: Record<
 > = {
   solid: {
     neutral: 'bg-x-slot-button-neutral-bg text-x-slot-button-neutral-fg shadow-x-slot-button-solid',
+    accent: 'bg-x-slot-button-accent-bg text-x-slot-button-accent-fg shadow-x-slot-button-solid',
     danger: 'bg-x-slot-button-danger-bg text-x-slot-button-danger-fg shadow-x-slot-button-solid',
-    warn: 'bg-x-slot-button-warn-bg text-x-slot-button-warn-fg shadow-x-slot-button-solid',
     success: 'bg-x-slot-button-success-bg text-x-slot-button-success-fg shadow-x-slot-button-solid',
+    warn: 'bg-x-slot-button-warn-bg text-x-slot-button-warn-fg shadow-x-slot-button-solid',
+    info: 'bg-x-slot-button-info-bg text-x-slot-button-info-fg shadow-x-slot-button-solid',
   },
   outline: {
     neutral:
       'bg-x-slot-button-outline-bg text-x-slot-button-neutral-ink border-x-slot-button-neutral-border',
+    accent:
+      'bg-x-slot-button-outline-bg text-x-slot-button-accent-ink border-x-slot-button-accent-border',
     danger:
       'bg-x-slot-button-outline-bg text-x-slot-button-danger-ink border-x-slot-button-danger-border',
-    warn: 'bg-x-slot-button-outline-bg text-x-slot-button-warn-ink border-x-slot-button-warn-border',
     success:
       'bg-x-slot-button-outline-bg text-x-slot-button-success-ink border-x-slot-button-success-border',
+    warn: 'bg-x-slot-button-outline-bg text-x-slot-button-warn-ink border-x-slot-button-warn-border',
+    info: 'bg-x-slot-button-outline-bg text-x-slot-button-info-ink border-x-slot-button-info-border',
   },
   bare: {
     neutral: 'bg-transparent text-x-slot-button-neutral-ink',
+    accent: 'bg-transparent text-x-slot-button-accent-ink',
     danger: 'bg-transparent text-x-slot-button-danger-ink',
-    warn: 'bg-transparent text-x-slot-button-warn-ink',
     success: 'bg-transparent text-x-slot-button-success-ink',
+    warn: 'bg-transparent text-x-slot-button-warn-ink',
+    info: 'bg-transparent text-x-slot-button-info-ink',
   },
   link: {
     neutral: 'bg-transparent text-x-slot-button-neutral-ink underline-offset-4 hover:underline',
+    accent: 'bg-transparent text-x-slot-button-accent-ink underline-offset-4 hover:underline',
     danger: 'bg-transparent text-x-slot-button-danger-ink underline-offset-4 hover:underline',
-    warn: 'bg-transparent text-x-slot-button-warn-ink underline-offset-4 hover:underline',
     success: 'bg-transparent text-x-slot-button-success-ink underline-offset-4 hover:underline',
+    warn: 'bg-transparent text-x-slot-button-warn-ink underline-offset-4 hover:underline',
+    info: 'bg-transparent text-x-slot-button-info-ink underline-offset-4 hover:underline',
   },
 };
 
@@ -155,7 +166,7 @@ const BASE_CLASS = `rounded-x-slot-button border border-transparent inline-flex 
 
 export function Button({
   variant = 'solid',
-  tone = 'neutral',
+  tone = 'accent',
   size = 'md',
   children,
   type = 'button',

--- a/packages/nene2-ui/src/primitives/button-axes.test.tsx
+++ b/packages/nene2-ui/src/primitives/button-axes.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { Button } from './Button.js';
+
+/**
+ * Button の軸（#487）— **列挙ではなく導出で当てる**。
+ *
+ * 🔑 `docs/todo` 由来の型1「**列挙で書いた検査は、列挙に無いものを緑にする**」。
+ * `success` を #422 / #457 で部品ごとに列挙して足した結果、**2回とも InlineAlert が漏れた**
+ * （#486）。同じことを軸でやると、**新しい tone を足した人が1つの形を書き忘れても緑**になる。
+ * ⇒ 形と色の**直積**を型から導出し、全マスを実際に描いて確かめる。
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const themePath = path.join(here, '../../themes/default.css');
+const buttonSrc = readFileSync(path.join(here, 'Button.tsx'), 'utf8');
+const themeSrc = readFileSync(themePath, 'utf8');
+
+const SHAPES = ['solid', 'outline', 'bare', 'link'] as const;
+const TONES = ['neutral', 'danger', 'warn', 'success'] as const;
+
+const classesOf = (el: Element | null) => el?.getAttribute('class') ?? '';
+
+describe('Button の軸（#487）', () => {
+  it('形 × 色 の全16マスが描ける（直積を導出して全数）', () => {
+    // 陽性対照: 直積そのものが空でないこと（ループが0回で緑になる事故を潰す）
+    expect(SHAPES.length * TONES.length).toBe(16);
+
+    for (const variant of SHAPES) {
+      for (const tone of TONES) {
+        const cls = classesOf(
+          render(
+            <Button variant={variant} tone={tone}>
+              x
+            </Button>,
+          ).container.querySelector('button'),
+        );
+        expect(cls, `${variant}×${tone} が前景を持たない`).toMatch(/text-x-slot-button-/);
+      }
+    }
+  });
+
+  it('部品が参照するスロットは全部テーマに実在する（導出・字面の列挙をしない）', () => {
+    const refs = new Set(buttonSrc.match(/x-slot-button-[a-z-]+/g) ?? []);
+    const defined = new Set(
+      [
+        ...themeSrc.matchAll(
+          /--(?:color|shadow|spacing|text|font|radius)-(x-slot-button-[a-z-]+)\s*:/g,
+        ),
+      ].map((m) => m[1]),
+    );
+    // 陽性対照: 走査窓が生きていること（0件同士の比較で緑にしない）
+    expect(refs.size).toBeGreaterThan(10);
+    expect(defined.size).toBeGreaterThan(10);
+
+    const missing = [...refs].filter((r) => !defined.has(r)).sort();
+    expect(missing, `テーマに無いスロットを参照している: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('テーマに死にスロットが無い（定義したのに誰も読まない＝#481 の型）', () => {
+    const refs = new Set(buttonSrc.match(/x-slot-button-[a-z-]+/g) ?? []);
+    const defined = [
+      ...themeSrc.matchAll(
+        /--(?:color|shadow|spacing|text|font|radius)-(x-slot-button-[a-z-]+)\s*:/g,
+      ),
+    ].map((m) => m[1]);
+    const unused = defined.filter((d) => !refs.has(d)).sort();
+    expect(unused, `誰も読まないスロット: ${unused.join(', ')}`).toEqual([]);
+  });
+
+  it('solid は枠のクラスを出さない — 塗りの見た目を 0.19.x から動かさないため', () => {
+    for (const tone of TONES) {
+      const cls = classesOf(
+        render(
+          <Button variant="solid" tone={tone}>
+            x
+          </Button>,
+        ).container.querySelector('button'),
+      );
+      expect(cls, `solid×${tone}`).not.toMatch(/border-x-slot-button-/);
+      expect(cls, `solid×${tone} は透明枠で高さを揃える`).toContain('border-transparent');
+    }
+  });
+
+  it('outline は tone ごとの枠スロットを読む', () => {
+    for (const tone of TONES) {
+      const cls = classesOf(
+        render(
+          <Button variant="outline" tone={tone}>
+            x
+          </Button>,
+        ).container.querySelector('button'),
+      );
+      expect(cls).toContain(`border-x-slot-button-${tone}-border`);
+    }
+  });
+
+  it('link は箱を持たない（padding も枠も角丸も出さない）', () => {
+    const cls = classesOf(
+      render(<Button variant="link">x</Button>).container.querySelector('button'),
+    );
+    expect(cls).toContain('border-0');
+    expect(cls).toContain('rounded-none');
+    expect(cls).not.toMatch(/px-x-slot-button-/);
+    // 陽性対照: 箱を持つ形は padding を出す（この検査が「常に真」でないこと）
+    const solid = classesOf(render(<Button>x</Button>).container.querySelector('button'));
+    expect(solid).toMatch(/px-x-slot-button-/);
+  });
+
+  it('既定は solid × neutral（呼び出し側が何も書かないときの姿）', () => {
+    const bare = classesOf(render(<Button>x</Button>).container.querySelector('button'));
+    const spelled = classesOf(
+      render(
+        <Button variant="solid" tone="neutral">
+          x
+        </Button>,
+      ).container.querySelector('button'),
+    );
+    expect(bare).toBe(spelled);
+  });
+
+  it('outline の地は tone に依らない1本（艦の意匠より濃くしない）', () => {
+    const seen = new Set(
+      TONES.map((tone) => {
+        const cls = classesOf(
+          render(
+            <Button variant="outline" tone={tone}>
+              x
+            </Button>,
+          ).container.querySelector('button'),
+        );
+        return cls.match(/bg-x-slot-button-[a-z-]+/)?.[0] ?? '';
+      }),
+    );
+    expect([...seen]).toEqual(['bg-x-slot-button-outline-bg']);
+  });
+});

--- a/packages/nene2-ui/src/primitives/button-axes.test.tsx
+++ b/packages/nene2-ui/src/primitives/button-axes.test.tsx
@@ -21,14 +21,14 @@ const buttonSrc = readFileSync(path.join(here, 'Button.tsx'), 'utf8');
 const themeSrc = readFileSync(themePath, 'utf8');
 
 const SHAPES = ['solid', 'outline', 'bare', 'link'] as const;
-const TONES = ['neutral', 'danger', 'warn', 'success'] as const;
+const TONES = ['neutral', 'accent', 'danger', 'success', 'warn', 'info'] as const;
 
 const classesOf = (el: Element | null) => el?.getAttribute('class') ?? '';
 
 describe('Button の軸（#487）', () => {
   it('形 × 色 の全16マスが描ける（直積を導出して全数）', () => {
     // 陽性対照: 直積そのものが空でないこと（ループが0回で緑になる事故を潰す）
-    expect(SHAPES.length * TONES.length).toBe(16);
+    expect(SHAPES.length * TONES.length).toBe(24);
 
     for (const variant of SHAPES) {
       for (const tone of TONES) {
@@ -111,11 +111,11 @@ describe('Button の軸（#487）', () => {
     expect(solid).toMatch(/px-x-slot-button-/);
   });
 
-  it('既定は solid × neutral（呼び出し側が何も書かないときの姿）', () => {
+  it('既定は solid × accent（＝0.19.x の primary。呼び出し側が何も書かないときの姿）', () => {
     const bare = classesOf(render(<Button>x</Button>).container.querySelector('button'));
     const spelled = classesOf(
       render(
-        <Button variant="solid" tone="neutral">
+        <Button variant="solid" tone="accent">
           x
         </Button>,
       ).container.querySelector('button'),

--- a/packages/nene2-ui/src/primitives/button-contrast.test.ts
+++ b/packages/nene2-ui/src/primitives/button-contrast.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * solid の文字コントラストを機械で守る（#487）。
+ *
+ * 🔴 この PR の初稿は、全 tone の前景に `--color-on-accent`（白）を載せて出そうとした。
+ * `--color-warn` は中間輝度なので **3.48:1** ——AA(4.5:1) を割る。**契約は最初からこれを
+ * 解いていた**: `--color-on-warn` は 2026-07-14 の凍結時から在る暗いブラウンで、載せると
+ * **4.97:1**。⇒ 誤りは契約の値ではなく、契約を読まなかったこと。
+ *
+ * 🔑 だから「目視で確かめる」に回さない。**計算で決まるものは計算で止める。**
+ * 目視が要るのは、計算では出ない側（並びの落ち着き・意匠の統一感）だけ。
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.join(here, '../../themes/default.css'), 'utf8');
+
+/** `--x: var(--y);` を辿って oklch のリテラルに着地させる。 */
+function resolve(name: string, depth = 0): string {
+  if (depth > 8) throw new Error(`--${name}: var() の連鎖が深すぎる`);
+  const m = css.match(new RegExp(`--${name}:\\s*([^;]+);`));
+  if (!m) throw new Error(`--${name} がテーマに無い`);
+  const v = m[1].trim();
+  const ref = v.match(/^var\(--([a-z0-9-]+)\)$/);
+  return ref ? resolve(ref[1], depth + 1) : v;
+}
+
+function srgb(oklch: string): [number, number, number] {
+  const m = oklch.match(/oklch\(\s*([\d.]+)%\s+([\d.]+)\s+([\d.]+)/);
+  if (!m) throw new Error(`oklch として読めない: ${oklch}`);
+  const L = Number(m[1]) / 100;
+  const a = Number(m[2]) * Math.cos((Number(m[3]) * Math.PI) / 180);
+  const b = Number(m[2]) * Math.sin((Number(m[3]) * Math.PI) / 180);
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const mm = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  const lin = [
+    4.0767416621 * l - 3.3077115913 * mm + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * mm - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * mm + 1.707614701 * s,
+  ];
+  return lin.map((x) => {
+    const c = Math.max(0, Math.min(1, x));
+    return c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055;
+  }) as [number, number, number];
+}
+
+const luminance = (c: [number, number, number]) => {
+  const [r, g, b] = c.map((x) => (x <= 0.04045 ? x / 12.92 : ((x + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrast = (a: string, b: string) => {
+  const [la, lb] = [luminance(srgb(a)), luminance(srgb(b))];
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+};
+
+/** 🔑 tone は列挙せず、テーマのスロット名から導出する（型1: 列挙は列挙に無いものを緑にする）。 */
+const TONES = [
+  ...new Set(
+    [...css.matchAll(/--color-x-slot-button-([a-z]+)-bg:/g)]
+      .map((m) => m[1])
+      .filter((t) => t !== 'outline'),
+  ),
+];
+
+describe('Button solid の文字コントラスト（#487）', () => {
+  it('導出した tone の集合が空でない（陽性対照）', () => {
+    expect(TONES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('陰性対照: 計算器が「落ちる組み合わせ」を実際に落とす', () => {
+    // 白 on warn は AA を割る。これが 4.5 未満と出ないなら計算器を疑う。
+    expect(contrast(resolve('color-warn'), resolve('color-on-accent'))).toBeLessThan(4.5);
+  });
+
+  it.each(TONES)('solid × %s の文字が AA(4.5:1) を満たす', (tone) => {
+    const ratio = contrast(
+      resolve(`color-x-slot-button-${tone}-bg`),
+      resolve(`color-x-slot-button-${tone}-fg`),
+    );
+    expect(ratio, `solid×${tone} = ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it.each(TONES)('outline / bare / link × %s の文字が AA(4.5:1) を満たす', (tone) => {
+    const ratio = contrast(
+      resolve(`color-x-slot-button-${tone}-ink`),
+      resolve('color-x-slot-button-outline-bg'),
+    );
+    expect(ratio, `ink×${tone} = ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/packages/nene2-ui/src/primitives/pointer.test.tsx
+++ b/packages/nene2-ui/src/primitives/pointer.test.tsx
@@ -50,7 +50,7 @@ describe('pointer feedback', () => {
     const theme = 'themes/default.css';
     expect(theme).toBeTruthy();
     const cls = classesOf(
-      render(<Button variant="secondary">x</Button>).container.querySelector('button'),
+      render(<Button variant="outline">x</Button>).container.querySelector('button'),
     );
     expect(cls).not.toContain('hover:brightness-105');
   });
@@ -64,9 +64,11 @@ describe('Button structure props', () => {
     expect(sm).toContain('px-x-slot-button-sm-pad-x');
   });
 
-  it('has a ghost variant for the third action in a row', () => {
+  it('has a bare shape for the third action in a row', () => {
+    // 🔴 0.20.0 で `ghost` から `bare` へ改名した（#487）。旧名は艦とキットで別のものを
+    // 指していた — nene-clear の `.btn-ghost` は地も枠も持つ（＝この kit の `outline`）。
     const cls = classesOf(
-      render(<Button variant="ghost">x</Button>).container.querySelector('button'),
+      render(<Button variant="bare">x</Button>).container.querySelector('button'),
     );
     expect(cls).toContain('bg-transparent');
   });
@@ -185,7 +187,8 @@ describe('Button height', () => {
     // 🔴 高さは padding 由来。border を持つのが secondary だけだと、上下 1px ずつ増えて
     // 他 variant より 2px 高くなる。vault はモーダルのフッター7箇所で primary と secondary を
     // 横に並べており、そこに段差が出る（2026-08-23 実測）。
-    for (const variant of ['primary', 'secondary', 'danger', 'ghost'] as const) {
+    // 🔴 `link` は箱を持たないので対象外（`border-0`）。段差を合わせるべき相手が無い。
+    for (const variant of ['solid', 'outline', 'bare'] as const) {
       const cls = classesOf(
         render(<Button variant={variant}>x</Button>).container.querySelector('button'),
       );

--- a/packages/nene2-ui/src/primitives/states.test.tsx
+++ b/packages/nene2-ui/src/primitives/states.test.tsx
@@ -7,9 +7,6 @@
  * 補いを lint で禁じる（順序③）前にここが埋まっていないと、
  * **押せないことが見えないボタン**が本番に出る。
  */
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { Button } from './Button.js';
@@ -114,34 +111,46 @@ describe('Button', () => {
     expect((container.firstElementChild as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it('keeps its variant styling alongside the state classes', () => {
-    const { container } = render(<Button variant="danger">x</Button>);
+  it('keeps its shape+tone styling alongside the state classes', () => {
+    const { container } = render(<Button tone="danger">x</Button>);
     const cls = classesOf(container.firstElementChild);
     expect(cls).toContain('bg-x-slot-button-danger-bg');
     expect(cls).toContain('disabled:cursor-not-allowed');
   });
 
-  // #455 — `danger` は border 系のクラスを1つも出しておらず、BASE_CLASS の
-  // `border-transparent` が最後まで残っていた。⇒ 塗りではなく**輪郭**で danger を
-  // 表す艦（nene-deal）は、スロット値をいくら上書きしても枠を出せなかった。
-  it('reaches a slot for its border, like secondary does', () => {
-    const cls = classesOf(render(<Button variant="danger">x</Button>).container.firstElementChild);
+  // #455 の後日談（#487）— かつて `danger` は border 系のクラスを出しておらず、輪郭型の
+  // danger を描きたい艦（nene-deal）はスロットで枠を出せなかった。0.18.0 は `danger` に
+  // border スロットを足して解いたが、**それは「形」の穴を「色」の側で塞いだ**もので、
+  // deal は `--color-x-slot-button-danger-bg: transparent` と併せて
+  // **塗りの variant を輪郭に作り変えていた**（deal kit-slots.css:91-93・2026-08-27 実測）。
+  // 0.20.0 で軸が分かれたので、輪郭は形が持つ。
+  it('reaches the tone border slot when the shape is outline', () => {
+    const cls = classesOf(
+      render(
+        <Button variant="outline" tone="danger">
+          x
+        </Button>,
+      ).container.firstElementChild,
+    );
     expect(cls).toContain('border-x-slot-button-danger-border');
   });
 
-  // 🔴 この PR が「他艦の見た目を変えない」ことの実測。既定の枠色は塗りと**同じ変数**を
-  // 指すので、塗りの上に同色の枠が乗る＝`border-transparent` が塗りの上で描いていたのと
-  // 同じ結果になる。列挙で書かず theme の現物から読む（型1: 列挙で書いた検査は、
-  // 列挙に無いものを緑にする）。
-  it('defaults that border to the fill, so a filled danger button is unchanged', () => {
-    const css = readFileSync(
-      path.join(path.dirname(fileURLToPath(import.meta.url)), '../../themes/default.css'),
-      'utf8',
+  // 🔴 塗りの danger が 0.19.x と同じに見えることの実測。**機構が変わっている**:
+  // 以前は「枠色の既定が塗りと同じ変数」だったが、いまは **solid が border 系のクラスを
+  // 一つも出さない**ので BASE_CLASS の `border-transparent` がそのまま残る。
+  // ⇒ 枠は透明。塗りだけが見える。結果は同じで、理由が違う。
+  it('paints no border class on a filled button, so the fill is unchanged', () => {
+    const cls = classesOf(
+      render(
+        <Button variant="solid" tone="danger">
+          x
+        </Button>,
+      ).container.firstElementChild,
     );
-    const valueOf = (name: string) => css.match(new RegExp(`--${name}:\\s*([^;]+);`))?.[1]?.trim();
-    const bg = valueOf('color-x-slot-button-danger-bg');
-    expect(bg).toBeTruthy(); // 陽性対照: 読めていないのに一致と言わない
-    expect(valueOf('color-x-slot-button-danger-border')).toBe(bg);
+    expect(cls).toContain('bg-x-slot-button-danger-bg');
+    expect(cls).not.toContain('border-x-slot-button-danger-border');
+    // 陽性対照: BASE_CLASS の透明枠は残っている（高さを揃えるため・段差防止）。
+    expect(cls).toContain('border-transparent');
   });
 });
 

--- a/packages/nene2-ui/src/states/ErrorState.tsx
+++ b/packages/nene2-ui/src/states/ErrorState.tsx
@@ -16,7 +16,7 @@ export function ErrorState({ message, retryLabel, onRetry, className }: ErrorSta
     <div className={cx('py-x-slot-state-pad-y', className)} role="alert">
       <p className="font-sans text-x-slot-error-state-fg">{message}</p>
       <div className="py-x-slot-state-action-pad-y">
-        <Button variant="outline" onClick={onRetry}>
+        <Button variant="outline" tone="neutral" onClick={onRetry}>
           {retryLabel}
         </Button>
       </div>

--- a/packages/nene2-ui/src/states/ErrorState.tsx
+++ b/packages/nene2-ui/src/states/ErrorState.tsx
@@ -16,7 +16,7 @@ export function ErrorState({ message, retryLabel, onRetry, className }: ErrorSta
     <div className={cx('py-x-slot-state-pad-y', className)} role="alert">
       <p className="font-sans text-x-slot-error-state-fg">{message}</p>
       <div className="py-x-slot-state-action-pad-y">
-        <Button variant="secondary" onClick={onRetry}>
+        <Button variant="outline" onClick={onRetry}>
           {retryLabel}
         </Button>
       </div>

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -285,21 +285,45 @@
    * there is now an opening. */
   --color-x-slot-focus-ring: var(--color-text-primary);
 
-  --color-x-slot-button-primary-bg: var(--color-accent);
-  --color-x-slot-button-primary-fg: var(--color-on-accent);
-  --color-x-slot-button-secondary-bg: var(--color-surface-raised);
-  --color-x-slot-button-secondary-fg: var(--color-text-primary);
-  --color-x-slot-button-secondary-border: var(--color-border);
+  /* Button: shape × tone (#487).
+   *
+   * 🔴 The names below replace `primary-* / secondary-* / danger-* / ghost-fg`. A ship that
+   * redefined one of the old names will NOT see an error — the old custom property simply
+   * stops being read and the kit default paints instead. Both consuming ships did redefine
+   * some (nene-deal 4, nene-vault 2, measured 2026-08-27), so the migration note carries the
+   * mapping. A removed slot fails silently; that is the whole reason this comment is here.
+   *
+   * Three colours per tone, and they are not derivable from each other:
+   *   -bg     the fill, painted by `solid` only
+   *   -fg     what sits on that fill — the on-accent colour, not the tone colour
+   *   -ink    the tone colour itself, painted by `outline` / `bare` / `link`
+   *   -border the outline's frame, a lighter step than -ink
+   *
+   * 🔴 `-border` is the soft step, not the tone. nene-clear draws its outlined danger with
+   * `--bad-line` (#e3bcbc) against text of `--bad` (#9c2c2c) — the frame is far lighter than
+   * the label. Using the tone itself for both makes every outlined button louder than any
+   * ship draws today (clear's measurement, 2026-08-27). */
+  --color-x-slot-button-outline-bg: var(--color-surface-raised);
+
+  --color-x-slot-button-neutral-bg: var(--color-accent);
+  --color-x-slot-button-neutral-fg: var(--color-on-accent);
+  --color-x-slot-button-neutral-ink: var(--color-text-primary);
+  --color-x-slot-button-neutral-border: var(--color-border);
+
   --color-x-slot-button-danger-bg: var(--color-danger);
   --color-x-slot-button-danger-fg: var(--color-on-accent);
-  /* 🔴 Defaults to the fill, so a filled danger button looks exactly as it did: the border
-   * and the background are the same colour, which is what `border-transparent` over a filled
-   * background already rendered. The slot exists for the ships whose danger button is an
-   * outline rather than a fill — nene-deal's is `background: transparent` with a tinted
-   * border (#455), and it could not express that: the variant emitted no border class at
-   * all, so `border-transparent` from BASE_CLASS won and no slot value could reach it. */
-  --color-x-slot-button-danger-border: var(--color-danger);
-  --color-x-slot-button-ghost-fg: var(--color-text-primary);
+  --color-x-slot-button-danger-ink: var(--color-danger);
+  --color-x-slot-button-danger-border: var(--color-danger-soft);
+
+  --color-x-slot-button-warn-bg: var(--color-warn);
+  --color-x-slot-button-warn-fg: var(--color-on-accent);
+  --color-x-slot-button-warn-ink: var(--color-warn);
+  --color-x-slot-button-warn-border: var(--color-warn-soft);
+
+  --color-x-slot-button-success-bg: var(--color-success);
+  --color-x-slot-button-success-fg: var(--color-on-accent);
+  --color-x-slot-button-success-ink: var(--color-success);
+  --color-x-slot-button-success-border: var(--color-success-soft);
 
   /* Shared by Input, Select and Textarea — they are one control with three shapes, and a
    * product that darkens one and not the others has a bug, not a design. */
@@ -495,7 +519,10 @@
    * `Card` and `Toast` wrote `shadow-sm`, so theirs point at the scale. A default that is
    * anything other than the current rendering changes how every product already looks —
    * and "the default is harmless" only holds while the default is that copy. */
-  --shadow-x-slot-button-primary: none;
+  /* 🔴 Renamed from `--shadow-x-slot-button-primary` (#487): the shadow belongs to the
+   * filled shape, not to one colour. nene-vault redefines this one (`var(--shadow-sm)`) and
+   * must rename it — see the migration note. */
+  --shadow-x-slot-button-solid: none;
   --shadow-x-slot-card-raised: var(--shadow-sm);
   --shadow-x-slot-toast: var(--shadow-sm);
 

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -42,6 +42,11 @@
   --color-warn-soft: oklch(95% 0.035 80);
   --color-on-warn: oklch(21% 0.04 75);
   --color-danger-soft: oklch(95% 0.03 30);
+  /* 🔴 契約キーだが値が無かった2つ（#487 で必要になったので与える）。
+   * `on-danger` は 0.19.x が danger の塗りに使っていた `on-accent` と同値＝描画は不変。
+   * `accent-soft` は他の *-soft（95% / chroma ~0.03 / 同 hue）と同じ作り方。 */
+  --color-on-danger: oklch(99% 0 0);
+  --color-accent-soft: oklch(95% 0.03 250);
 
   /* 🔴 Six more contract colours, added in 0.17.0 for `Badge` (#422). Five ships carry a
    * success tone and a warning tone in their own badge (clear / field / invoice / origin /
@@ -287,44 +292,63 @@
 
   /* Button: shape × tone (#487).
    *
-   * 🔴 The names below replace `primary-* / secondary-* / danger-* / ghost-fg`. A ship that
-   * redefined one of the old names will NOT see an error — the old custom property simply
-   * stops being read and the kit default paints instead. Both consuming ships did redefine
-   * some (nene-deal 4, nene-vault 2, measured 2026-08-27), so the migration note carries the
-   * mapping. A removed slot fails silently; that is the whole reason this comment is here.
+   * 🔴 The six tones are `Badge`'s six, in `Badge`'s order, read through the same shape of
+   * slot. That was the whole argument for splitting the axis — if the words do not line up,
+   * the kit still has two vocabularies and has only moved where they disagree.
    *
-   * Three colours per tone, and they are not derivable from each other:
+   * 🔴 `-fg` reads the contract's own `on-<tone>`, not `on-accent` for everything. The
+   * contract has carried `on-warn` since it was frozen (2026-07-14) and it is a dark brown,
+   * because `--color-warn` is mid-luminance and white on it measures 3.48:1 — below AA.
+   * With `on-warn` it is 4.97:1. The first draft of this PR painted every tone's label with
+   * `on-accent` and shipped that 3.48:1; the contract had already solved it.
+   *
+   * 🔴 The default tone is `accent`, so `<Button>` is still the accent-coloured filled
+   * button 0.19.x called `primary`. `neutral` is the quiet grey step.
+   *
+   * Four colours per tone, none derivable from the others:
    *   -bg     the fill, painted by `solid` only
-   *   -fg     what sits on that fill — the on-accent colour, not the tone colour
-   *   -ink    the tone colour itself, painted by `outline` / `bare` / `link`
-   *   -border the outline's frame, a lighter step than -ink
+   *   -fg     what sits on that fill (the contract's `on-<tone>`)
+   *   -ink    the tone itself, painted by `outline` / `bare` / `link`
+   *   -border the outline's frame — the *-soft step, not the tone
    *
-   * 🔴 `-border` is the soft step, not the tone. nene-clear draws its outlined danger with
-   * `--bad-line` (#e3bcbc) against text of `--bad` (#9c2c2c) — the frame is far lighter than
-   * the label. Using the tone itself for both makes every outlined button louder than any
-   * ship draws today (clear's measurement, 2026-08-27). */
+   * 🔴 `-border` is the soft step. nene-clear draws its outlined danger with a frame far
+   * lighter than the label (`--bad-line` #e3bcbc against `--bad` #9c2c2c). Using the tone for
+   * both makes every outlined button louder than any ship draws today.
+   *
+   * 🔴 Renaming a slot fails SILENTLY. A ship that redefined `primary-* / secondary-* /
+   * danger-border / ghost-fg` sees no error — the property stops being read and the kit
+   * default paints instead. Both consuming ships redefined some (nene-deal 4, nene-vault 3,
+   * measured 2026-08-27), so the migration note carries the mapping. */
   --color-x-slot-button-outline-bg: var(--color-surface-raised);
-
-  --color-x-slot-button-neutral-bg: var(--color-accent);
-  --color-x-slot-button-neutral-fg: var(--color-on-accent);
+  --color-x-slot-button-neutral-bg: var(--color-border);
+  --color-x-slot-button-neutral-fg: var(--color-text-primary);
   --color-x-slot-button-neutral-ink: var(--color-text-primary);
   --color-x-slot-button-neutral-border: var(--color-border);
-
+  --color-x-slot-button-accent-bg: var(--color-accent);
+  --color-x-slot-button-accent-fg: var(--color-on-accent);
+  --color-x-slot-button-accent-ink: var(--color-accent);
+  --color-x-slot-button-accent-border: var(--color-accent-soft);
   --color-x-slot-button-danger-bg: var(--color-danger);
-  --color-x-slot-button-danger-fg: var(--color-on-accent);
+  --color-x-slot-button-danger-fg: var(--color-on-danger);
   --color-x-slot-button-danger-ink: var(--color-danger);
   --color-x-slot-button-danger-border: var(--color-danger-soft);
-
-  --color-x-slot-button-warn-bg: var(--color-warn);
-  --color-x-slot-button-warn-fg: var(--color-on-accent);
-  --color-x-slot-button-warn-ink: var(--color-warn);
-  --color-x-slot-button-warn-border: var(--color-warn-soft);
-
   --color-x-slot-button-success-bg: var(--color-success);
-  --color-x-slot-button-success-fg: var(--color-on-accent);
+  --color-x-slot-button-success-fg: var(--color-on-success);
   --color-x-slot-button-success-ink: var(--color-success);
   --color-x-slot-button-success-border: var(--color-success-soft);
-
+  --color-x-slot-button-warn-bg: var(--color-warn);
+  --color-x-slot-button-warn-fg: var(--color-on-warn);
+  /* 🔴 warn の ink だけ tone 本体色ではない。`--color-warn` は中間輝度で、白地に置くと
+   * 3.58:1 ——AA を割る（他の tone は本体色のままで 4.7〜5.5 通る）。契約の `--color-on-warn`
+   * は 16:1 で、**InlineAlert が既に「白地に載る warn の字」として使っている**
+   * （`--color-x-slot-alert-warn-fg`）。同じ用途に同じトークンを充てるのは揃える方向であって、
+   * 例外ではない。⇒ 契約の値は1つも変えずに済む（Badge も InlineAlert も動かない）。 */
+  --color-x-slot-button-warn-ink: var(--color-on-warn);
+  --color-x-slot-button-warn-border: var(--color-warn-soft);
+  --color-x-slot-button-info-bg: var(--color-info);
+  --color-x-slot-button-info-fg: var(--color-on-info);
+  --color-x-slot-button-info-ink: var(--color-info);
+  --color-x-slot-button-info-border: var(--color-info-soft);
   /* Shared by Input, Select and Textarea — they are one control with three shapes, and a
    * product that darkens one and not the others has a bug, not a design. */
   --color-x-slot-control-fg: var(--color-text-primary);


### PR DESCRIPTION
Refs #487・Refs #455

🔴 **BREAKING。施主承認が要ります**（自艦が書いた PR）。**既定の描画が変わりうるので目視ゲートの対象**。

## API

```ts
variant?: 'solid' | 'outline' | 'bare' | 'link';    // 形（既定 solid）
tone?:    'neutral' | 'danger' | 'warn' | 'success'; // 色（既定 neutral）
size?:    'md' | 'sm';                               // 変更なし
```

**`variant` は「どのプロパティを塗るか」・`tone` は「何色で塗るか」。**

## なぜ値を足さず軸を分けたか

旧 `primary | secondary | danger | ghost` は**形と色を1本の閉じた enum に潰していた**ので、
**「ghost の形 × danger の色」が言えなかった**。**5艦が独立に private な合成名を発明し、命名は一致しなかった**〔実測〕:

| 艦 | 名前 | 用途 |
| --- | --- | --- |
| nene-clear | `ghost-danger` / `ghost-warn` | 取消・削除・一時停止 |
| nene-field | **`danger-ghost`** | 差戻し（**clear と同じものを逆順に書いている**） |
| nene-profile | `link-danger` | 行の削除 |
| nene-origin | `danger-outline` | revoke |
| nene-deal | （スロットで同じ場所へ到達＝**#455**） | — |

**4値を足すと 4形 × 4色 = 16名を追うことになる。** ⇒ 軸を分けた。

🔑 `README` の設計原則3「variant が表現できないなら variant を足せ」に、
**「ただし足りないのが値か軸かを先に見る」**を追記した。
**艦がハイフン付きで綴り続ける値は、たいてい2つの軸が1つの名前を着ている。**

## 🔴 `ghost` → `bare` に改名した理由

**旧名は艦とキットで別のものを指していた**〔実測〕:

| | 地 | 枠 |
| --- | --- | --- |
| キットの `ghost` | `transparent` | 透明 |
| **clear の `.btn-ghost`** | **`var(--surface)`** | **`var(--line-strong)`** ⇒ この kit の **`outline`** |

**業界でも語義が割れている**（Bootstrap=outline / Material=text）。
**改名コストは 0** — 消費2艦とも `ghost` の使用は **0**〔実測〕。

⚠️ **この取り違えは起票者が実際に踏んだ。** clear へ送った写像表で `ghost` → `ghost` と書き、
**33箇所が地と枠を失う**内容だった（clear が未着手だったため実害なし・訂正済み）。
**名前の一致を、実体の一致の証拠にした。**

## 見た目の不変性

🟢 **塗りボタンは 0.19.x と同じに見える。** ただし**機構が変わっている**——
以前は「枠色の既定が塗りと同じ変数」だったが、いまは **`solid` が border 系のクラスを一つも出さない**ので
`BASE_CLASS` の `border-transparent` がそのまま残る。**結果は同じで、理由が違う**（テストにそう書いた）。

## 🔴 艦ごとの移行写像（**JSX だけでは決まらない**）

**艦は `variant` の意味をスロットで書き換えている**ので、写像はフリート共通の1枚では作れない。

### nene-vault — 🔴 **スロット3行の改名が必須**（放置すると無言で既定に戻る）

JSX 13箇所: `primary` 6 → **既定（削除）**／`secondary` 5 → **`variant="outline"`**／
`danger` 1 → **`tone="danger"`**／省略 1 → そのまま。

| 現行 | 移行後 | 効いているか |
| --- | --- | ---: |
| `--color-x-slot-button-secondary-fg` | **`--color-x-slot-button-neutral-ink`** | 🔴 **効いている**（Pagination 3ファイル） |
| `--color-x-slot-button-secondary-border` | **`--color-x-slot-button-neutral-border`** | 🔴 **効いている** |
| `--shadow-x-slot-button-primary` | **`--shadow-x-slot-button-solid`** | 🔴 **効いている** |

### nene-deal — 🟢 **live な退行なし**〔実測〕

JSX 12箇所: `secondary` 6 → **`variant="outline"`**／省略 6 → そのまま。

| 現行 | 移行後 | 効いているか |
| --- | --- | ---: |
| `--color-x-slot-button-secondary-border` | **`--color-x-slot-button-neutral-border`** | 🔴 効いている |
| `--color-x-slot-button-danger-bg/-fg/-border`（#455 で輪郭型 danger を作っていた3行） | **不要**。`variant="outline" tone="danger"` で直接書ける | 🟢 **いま何も塗っていない**（`variant="danger"` の使用 **0**・`ConfirmDialog` の使用 **0**〔実測〕） |

🔑 **#455 は「軸が無いのでスロットで形を変えた」話だった。** 本 PR で deal は**上書き3行を捨てられる**。

### nene-clear — まだキット `Button` 未使用〔import 0〕。**最初から2軸で載せ替えられる**

`primary` 25 → 既定／**`ghost` 28 → `variant="outline"`**／`danger` 3 → `tone="danger"`／
**`ghost-danger` 4 → `variant="outline" tone="danger"`**／**`ghost-warn` 1 → `variant="outline" tone="warn"`**／
`warn` 2 → `tone="warn"`／`link` 5 → `variant="link"`。

## 🔴 スロットの改名は**無言で失敗する**

**旧スロット名を再定義していた艦はエラーになりません。** その custom property が読まれなくなり、
**キット既定が描くだけ**です。だから上の表を配る必要があり、`themes/default.css` の当該箇所にも
その旨をコメントで書きました。

## スロット

**色 9 → 17**（`outline-bg` 1 ＋ 4 tone × `{bg, fg, ink, border}`）。**表現力は 4 → 16 パターン。**

- `-bg` / `-fg` … `solid` の地と、その上に載る前景（on-accent 色）
- `-ink` … `outline` / `bare` / `link` の前景（tone の**本体色**）
- `-border` … `outline` の枠。🔴 **本体色ではなく `*-soft` の段**
  （clear 実測: 枠 `--bad-line` #e3bcbc に対し字 `--bad` #9c2c2c。本体色を枠に使うと**艦の意匠より強くなる**）

🟢 **hover は増やしていない** — キットは既に `HOVER_CLASS` の `brightness` で**形にも色にも依らず**持っている
〔`src/lib/states.ts` 実測〕。clear が指摘した「outline hover で枠が本体色・地が bg 段へ」は
**キットの hover モデルそのものの変更**なので**別 Issue**（本 PR の射程外）。

## テスト — 列挙ではなく導出（#487 の要求）

`src/primitives/button-axes.test.tsx`（**8本・すべて陽性対照つき**）:

1. **形 × 色 の直積16マス全数**を実際に描く（🔑 ループが0回で緑になる事故を潰す対照つき）
2. 部品が参照するスロットが**全部テーマに実在**（導出・字面の列挙をしない）
3. **死にスロットが無い**（定義したのに誰も読まない＝#481 の型）
4. `solid` が枠クラスを出さない＋透明枠は残る（段差防止）
5. `outline` が tone ごとの枠スロットを読む
6. `link` が箱を持たない（**陽性対照**: 箱を持つ形は padding を出す）
7. 既定 = `solid` × `neutral`（省略と明記が**同一クラス列**）
8. `outline` の地が tone に依らない1本

🔑 **なぜ導出か**: `success` を #422 / #457 で**部品ごとに列挙して足した結果、2回とも `InlineAlert` が漏れた**（#486）。
**軸で同じことをすると、新しい tone を足した人が1つの形を書き忘れても緑になる。**

## 実測

| | 値 |
| --- | --- |
| `npm run check` | 🟢 **EXIT=0**（AM-2 gate PASS） |
| vitest | 🟢 **823 passed / 51 files**（+8）〔Start at 17:58:03〕 |
| 参照スロット ⇄ 定義スロット | **26 ⇄ 26・欠落0・死に0**（導出で検算） |
| push 後の SHA 照合 | `3d0a201`（`ls-remote` と一致） |

## 🔴 未計測・レビューで見てほしいところ

- **実ブラウザでの目視は未計測。** `secondary` → `outline` は**クラス文字列が変わる**ので、
  受入4点①「**不変性は画素/DOM で測る**」の対象です。**vault の Pagination 3ファイル**が最初に見る場所。
- **`warn` / `success` の塗りは新規**（`--color-warn` / `--color-success` に `--color-on-accent` を載せる）。
  **コントラスト比は未計測。** 特に `warn` は中間輝度なので、**目視ゲートで確認してください。**
- `link` の `underline-offset-4` は**スケールの段ではなく Tailwind の既定値**。
  スロット化すべきかは要判断（本 PR では触っていない）。
