### PR TITLE
feat(ui): Badge に dot を足す（#488・既定不変）

### DIFF
--- a/packages/nene2-ui/src/feedback/Badge.tsx
+++ b/packages/nene2-ui/src/feedback/Badge.tsx
@@ -12,6 +12,22 @@ export interface BadgeProps {
    * badge as it does in an alert (0.17.0, #422).
    */
   tone?: 'neutral' | 'accent' | 'danger' | 'success' | 'warn' | 'info';
+  /**
+   * Draw a small filled circle before the label.
+   *
+   * 🔴 It takes its colour from `currentColor`, so there is no dot colour slot and there
+   * must not be one: the dot is the tone, shown small. A slot would let a product set a
+   * badge whose dot disagrees with its own text, and it would have to be redefined for
+   * every tone — six values to keep in step with six that already exist (the
+   * redefine-the-default shape nene-vault retired in #481).
+   *
+   * Whether a badge has one is a per-call-site decision, not a theme value: nene-clear
+   * renders dotted and undotted badges **on the same screen** (`DunningPage` marks overdue
+   * with a dot and paused without one), so it cannot be a slot. Hence a prop.
+   *
+   * Omit it and the render is byte-for-byte what it was before this prop existed.
+   */
+  dot?: boolean;
   /** Composed after the kit's own classes (design principle 2). */
   className?: string;
   children: ReactNode;
@@ -50,7 +66,7 @@ const TONE_CLASS: Record<NonNullable<BadgeProps['tone']>, string> = {
  *
  * A badge that already fits is unchanged (35.88 × 26.5 before and after, measured).
  */
-export function Badge({ tone = 'neutral', className, children }: BadgeProps) {
+export function Badge({ tone = 'neutral', dot = false, className, children }: BadgeProps) {
   return (
     <span
       className={cx(
@@ -59,6 +75,18 @@ export function Badge({ tone = 'neutral', className, children }: BadgeProps) {
         className,
       )}
     >
+      {/* 🔴 `aria-hidden`: the dot repeats the tone, which the label already says in words.
+       * Announcing it would read the status twice. `shrink-0` for the same reason the badge
+       * itself is `whitespace-nowrap` (#477) — in a narrow flex row a 4px circle is the
+       * first thing an auto minimum size gives away, and an oval dot reads as a rendering
+       * fault rather than a smaller dot. `rounded-full` is the shape of a dot, not a design
+       * value, so it is not a slot. */}
+      {dot && (
+        <span
+          aria-hidden="true"
+          className="size-x-slot-badge-dot shrink-0 rounded-full bg-current"
+        />
+      )}
       {children}
     </span>
   );

--- a/packages/nene2-ui/src/feedback/feedback.test.tsx
+++ b/packages/nene2-ui/src/feedback/feedback.test.tsx
@@ -216,6 +216,53 @@ describe('InlineAlert', () => {
   });
 });
 
+describe('Badge — dot（#488）', () => {
+  it('draws nothing extra when the prop is omitted, so no product moves', () => {
+    // render は呼び出しごとに独自の container を返すので cleanup は要らない。
+    const plain = render(<Badge>x</Badge>).container.innerHTML;
+    const explicitly = render(<Badge dot={false}>x</Badge>).container.innerHTML;
+    expect(explicitly).toBe(plain);
+    // 陰性対照: この比較が「何も描かれていないもの同士」で成立しているのではないこと。
+    expect(plain).toContain('<span');
+  });
+
+  it('adds one dot before the label when asked', () => {
+    const { container } = render(<Badge dot>x</Badge>);
+    const badge = container.firstElementChild!;
+    const dots = badge.querySelectorAll('span[aria-hidden="true"]');
+    expect(dots).toHaveLength(1);
+    // ラベルの前（＝最初の子）。後ろに付くと視覚順と読み上げ順がずれる。
+    expect(badge.firstElementChild).toBe(dots[0]);
+  });
+
+  it('takes its size from a slot and its colour from currentColor', () => {
+    const cls =
+      render(<Badge dot>x</Badge>)
+        .container.querySelector('span[aria-hidden="true"]')
+        ?.getAttribute('class') ?? '';
+    expect(cls).toContain('size-x-slot-badge-dot');
+    expect(cls).toContain('bg-current');
+    // 🔴 色スロットを持たせない、が設計判断そのもの。ドットはトーンを小さく出した
+    //    もので、独立した色ではない。将来 `--color-x-slot-badge-dot-*` が生えたら
+    //    トーン6色と二重管理になる（#481 の「既定の再宣言」型）。
+    expect(cls).not.toMatch(/(bg|text|border)-x-slot-badge-dot/);
+  });
+
+  it('does not announce itself — the tone is already in the label', () => {
+    const { container } = render(<Badge dot>期限超過</Badge>);
+    expect(container.firstElementChild?.textContent).toBe('期限超過');
+  });
+
+  it('cannot be squashed into an oval in a narrow flex row', () => {
+    const cls =
+      render(<Badge dot>x</Badge>)
+        .container.querySelector('span[aria-hidden="true"]')
+        ?.getAttribute('class') ?? '';
+    expect(cls).toContain('shrink-0');
+    expect(cls).toContain('rounded-full');
+  });
+});
+
 describe('Badge — success / warn / info（#422・0.17.0）', () => {
   it.each(['success', 'warn', 'info'] as const)(
     '%s reads its own slots, not another tone’s',

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -170,6 +170,7 @@
    * nene-deal — were already correcting that independently, so the painting this replaces
    * is one no consumer used. */
   --spacing-x-slot-badge-gap: var(--spacing-x-3xs);
+  --spacing-x-slot-badge-dot: var(--spacing-x-3xs);
   --spacing-x-slot-switch-pad-x: var(--spacing-x-2xs);
   --spacing-x-slot-switch-pad-y: var(--spacing-x-3xs);
   --spacing-x-slot-alert-pad: var(--spacing-x-2xs);


### PR DESCRIPTION
状態の丸ポチ。**省略時の描画は prop が存在しなかった時と byte 単位で同一**なので、既存の艦は動きません。Closes #488。

## 設計は nene-clear の実測が根拠です（そちらの分析を全面的に採りました）

### 🔴 色スロットは作りません

ドットは `currentColor`＝**トーンを小さく出したもの**であって、独立した色ではありません。スロットにすると

- 字と食い違うドットを設定できてしまう
- 6トーン分の値を、既に在る6色と**二重管理**することになる（nene-vault #481 が撤回した「既定の再宣言」型）

`bg-current` を使い、テストで `(bg|text|border)-x-slot-badge-dot` が**生えていないこと**を固定しています。

### 出す/出さないは props

nene-clear は**同じ画面で**点あり・点なしを混在させています（`DunningPage` は期限超過に点を付け、一時停止には付けない）。テーマ値では表現できません。

### サイズはスロット、既定は段の 4px

```css
--spacing-x-slot-badge-dot: var(--spacing-x-3xs);   /* 4px */
```

clear の現行は **6px**、vault は別の値ですが、**段でない値を既定に据えない**という #463 の裁定に従いました。艦は自分の `kit-slots.css` で再定義します。

### スロットにしなかったもの

- `rounded-full` … **ドットの形**であって意匠の値ではありません（`EmptyState` の `text-center` と同じ扱い）
- `shrink-0` … `whitespace-nowrap`（#477）と同じ理由です。狭い flex 行で 4px の円は最初に潰れる側で、**楕円のドットは「小さいドット」ではなく描画不具合に見えます**
- `aria-hidden` … トーンはラベルが既に言葉で言っているので、読み上げが2回になります

## 検査

**テスト5本。変異2種で赤にできることを確認してから緑を採用しました。**

| 変異 | 結果 |
| --- | --- |
| `{dot && …}` を落とす | **3本が赤** |
| `size-x-slot-badge-dot` → `size-x-3xs`（スケール直参照） | `no component reaches past the slots into the scale` が**赤** |
| 復元 | 25/25 緑 |

1本目には**陰性対照**を入れてあります（「何も描かれていないもの同士」を比べて緑になっていないこと＝`expect(plain).toContain('<span')`）。

`nene2-ui`: **type-check EXIT=0 / lint EXIT=0 / prettier クリーン / 277 tests・15 files 緑**。

## ⚠️ ルートの `npm run check` は完走できていません（本 PR とは無関係）

`packages/nene2-standards/src/configs/styling.ts` が `eslint-plugin-better-tailwindcss` を import し、`packages/nene2-standards/package.json` も宣言していますが、**`node_modules` に入っていません**。type-check がそこで落ちます。

**`origin/main` の素の作業木を切って同じコマンドを流し、同一のエラーが出ることを確認済み**です（テストの失敗8ファイルも全部 `nene2-standards`）。⇒ 本 PR の変更由来ではなく、**常駐の `node_modules` が古い**ものと見ています。そちらで `npm install` 後に受入4点を測り直してください。

## マージについて

そちらの「**BEHIND のままマージしない**」に従います。`themes/default.css` に触るので、**マージ直前に main へ rebase して CI を当て直します**。#487(#491) が先に入るなら、そのあとに rebase をかけてください——こちらで対応します。

次は #493（Modal の footer）を書きます。#492（PageHeader の副題）は**後回しにします**: clear 側を測ったところ、副題だけでなく**題の 21px もキットのスケールに無い**（`lg`=18 / `xl`=24）ことが分かり、#492 が入っても clear は PageHeader を載せ替えられません。deal §8-2 と同じ typography の穴です。#492 のコメントに追記します。
