### PR TITLE
feat(ui): PageHeader に description を足す（#492・既定不変）

### DIFF
--- a/packages/nene2-ui/src/layout/PageHeader.tsx
+++ b/packages/nene2-ui/src/layout/PageHeader.tsx
@@ -6,15 +6,50 @@ export interface PageHeaderProps {
   className?: string;
   /** Localized page title. */
   title: string;
+  /**
+   * Localized one-line description of the page, under the title.
+   *
+   * 🔴 Not decoration. nene-clear carries one on **every one of its ten pages** — the prop
+   * is `sub` there and the value is always a catalog key (`t('dunning.subtitle')`,
+   * `t('audit.subtitle')`, …), so folding it into `title` is not available to it: the two
+   * halves are separate keys, and joining them would put the separator — a string — in the
+   * ship, against principle 4. `PageHeader` takes no `children` either, so without this prop
+   * the line has nowhere to go and ten pages lose their description (#492).
+   *
+   * Omit it and the render is byte-for-byte what it was before this prop existed.
+   *
+   * ⚠️ Its size is not a slot, on purpose. The title has no size slot either — an `<h1>`
+   * reset by Preflight inherits the body size — so adding one here alone would let a product
+   * scale the description while its title stayed put. Products that need a type scale of
+   * their own are blocked on the same missing thing, and it is one gap, not two.
+   */
+  description?: string;
   actions?: ReactNode;
 }
 
-export function PageHeader({ title, actions, className }: PageHeaderProps) {
+export function PageHeader({ title, description, actions, className }: PageHeaderProps) {
+  const heading = (
+    <h1 className="font-sans font-x-slot-page-header text-x-slot-page-header-fg">{title}</h1>
+  );
+
   return (
     <header
       className={cx('flex items-center justify-between py-x-slot-page-header-pad-y', className)}
     >
-      <h1 className="font-sans font-x-slot-page-header text-x-slot-page-header-fg">{title}</h1>
+      {/* 🔴 The one-line case keeps its bare <h1>. Wrapping it in a <div> unconditionally
+       * would change the DOM of every ship already shipping this component, for the benefit
+       * of a prop they do not pass — the rule EmptyState set for its own `description`
+       * (#456). */}
+      {description === undefined ? (
+        heading
+      ) : (
+        <div>
+          {heading}
+          <p className="mt-x-slot-page-header-gap font-sans text-x-slot-page-header-description-fg">
+            {description}
+          </p>
+        </div>
+      )}
       {actions}
     </header>
   );

--- a/packages/nene2-ui/src/layout/layout.test.tsx
+++ b/packages/nene2-ui/src/layout/layout.test.tsx
@@ -10,6 +10,7 @@ import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { Box } from './Box.js';
 import { Card } from './Card.js';
+import { PageHeader } from './PageHeader.js';
 import { Grid } from './Grid.js';
 import { Section } from './Section.js';
 import { Stack } from './Stack.js';
@@ -144,6 +145,48 @@ describe('Card', () => {
 
     const { container: lifted } = render(<Card raised>x</Card>);
     expect(classesOf(lifted.firstElementChild)).toContain('shadow-x-slot-card-raised');
+  });
+});
+
+describe('PageHeader — description（#492）', () => {
+  it('renders exactly what it did before the prop existed, when it is omitted', () => {
+    const without = render(<PageHeader title="請求" />).container.innerHTML;
+    const explicitly = render(<PageHeader title="請求" description={undefined} />).container
+      .innerHTML;
+    expect(explicitly).toBe(without);
+    // 陰性対照: 両方が空文字で一致しているのではないこと。
+    expect(without).toContain('<h1');
+    // 🔴 一行のときは <h1> を包まない。包むと、この prop を渡していない艦の DOM まで動く。
+    expect(without).not.toContain('<div');
+  });
+
+  it('puts the description under the title, inside one block', () => {
+    const { container } = render(<PageHeader title="督促" description="延滞請求の督促" />);
+    const header = container.firstElementChild!;
+    const block = header.firstElementChild!;
+    expect(block.tagName).toBe('DIV');
+    expect(block.children[0]?.tagName).toBe('H1');
+    expect(block.children[1]?.tagName).toBe('P');
+    expect(block.children[1]?.textContent).toBe('延滞請求の督促');
+  });
+
+  it('keeps actions beside the block, not inside it', () => {
+    const { container } = render(
+      <PageHeader title="ユーザー" description="権限の管理" actions={<button>招待</button>} />,
+    );
+    const header = container.firstElementChild!;
+    expect(header.children).toHaveLength(2);
+    expect(header.children[1]?.tagName).toBe('BUTTON');
+  });
+
+  it('reads its gap and its colour from slots, not from the scale', () => {
+    const cls =
+      render(<PageHeader title="x" description="y" />)
+        .container.querySelector('p')
+        ?.getAttribute('class') ?? '';
+    expect(cls).toContain('mt-x-slot-page-header-gap');
+    expect(cls).toContain('text-x-slot-page-header-description-fg');
+    expect(cls).not.toMatch(/text-(xs|sm|base|lg)\b/);
   });
 });
 

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -188,6 +188,7 @@
   /* Between an EmptyState's two lines (#456). Only read when `description` is passed. */
   --spacing-x-slot-empty-state-gap: var(--spacing-x-3xs);
   --spacing-x-slot-page-header-pad-y: var(--spacing-x-md);
+  --spacing-x-slot-page-header-gap: var(--spacing-x-3xs);
 
   --radius-x-slot-button: var(--radius-x-md);
   --radius-x-slot-control: var(--radius-x-md);
@@ -389,6 +390,7 @@
 
   --color-x-slot-pagination-fg: var(--color-text-muted);
   --color-x-slot-page-header-fg: var(--color-text-primary);
+  --color-x-slot-page-header-description-fg: var(--color-text-muted);
   --color-x-slot-text-fg: var(--color-text-primary);
   --color-x-slot-text-muted-fg: var(--color-text-muted);
   --color-x-slot-spinner-fg: var(--color-text-muted);


### PR DESCRIPTION
題の下に置く1行の説明。**省略時の描画は prop が存在しなかった時と byte 単位で同一**なので、既存の艦は動きません。Closes #492。

## 需要（nene-clear の実測）

clear は **10ページ中 10ページ**で使っています。値は全部カタログキー（`t('dunning.subtitle')` `t('audit.subtitle')` …）なので `title` に畳めません——2つは別キーで、繋ぐと**区切り文字（＝文字列）が艦に入り**ます（原則4違反）。`PageHeader` は `children` も取らないため、**この prop が無いと10画面が説明を失います**。

## 形は `EmptyState` の `description`（#456）に合わせました

- **一行のときは `<h1>` を包みません。** 無条件に `<div>` で包むと、この prop を渡していない艦の DOM まで動きます。
- 追加スロットは**2つだけ**、どちらも既定はスケール参照:

```css
--spacing-x-slot-page-header-gap:          var(--spacing-x-3xs);      /* 4px */
--color-x-slot-page-header-description-fg: var(--color-text-muted);
```

## ⚠️ サイズはスロットにしていません（意図的）

題にもサイズスロットがありません（Preflight でリセットされた `<h1>` は本文サイズを継承）。説明文だけにサイズスロットを足すと、**題が動かないまま説明文だけ拡縮できる**状態になります。

自前の型階層が要る艦は**同じ1つの穴**で止まっており（clear の題は 21px で、キットの text スケールは `lg`=18 / `xl`=24）、**穴は2つではなく1つ**です。板 L15「契約v2第二波: typography」に park 済みの需要と同一で、nene-deal が §8-2 で踏んだものと同じ形。⇒ 本 PR では扱いません。

⚠️ したがって **この PR が入っても nene-clear の PageHeader は載せ替えられません**（#492 のコメントに詳細）。clear は W1 の完了条件から PageHeader を外します。**副題自体は独立した穴で他艦にも効く**ので、PR は出します。

## 検査

テスト4本。**変異2種で赤にできることを確認してから緑を採用しました。**

| 変異 | 結果 |
| --- | --- |
| 常に `<div>` で包む | 「prop 省略時に描画が変わらない」が**赤** |
| `mt-x-slot-page-header-gap` → `mt-x-3xs` | `no component reaches past the slots into the scale` と自前のテストが**赤** |
| 復元 | 緑 |

1本目には**陰性対照**を入れてあります（両方が空文字で一致して緑になっていないこと＝`expect(without).toContain('<h1')`）。

**`npm run check` EXIT=0** — `check:lock` / `type-check` / `lint` / `format:check` / `test` **824 tests・50 files** / `check:cli` / `check:nene2-check` / **`check:am2-gate` PASS**。

## ⚠️ 訂正: 先に出した「ルートの check が完走しない」は私の誤りでした

PR #495 の本文と Issue #496 で「`npm run check` が `origin/main` でも完走しない」と書きましたが、**誤りです**。`eslint-plugin-better-tailwindcss` は npm workspaces がルートに hoist できず **`packages/nene2-standards/node_modules/` に実体があり**（4.6.1・自分で確認済み）、**私の作業木にだけ子の `node_modules` が無かった**だけでした。

🔑 **「素の `origin/main` の作業木でも再現した」という対照が、独立していませんでした。** 2つの作業木はどちらも同じルート `node_modules` を持ち込み、どちらも子のぶんを欠いていた——**同じ欠陥を共有した対照は、その欠陥を検出できません。** 子の `node_modules` をリンクしたら、上記のとおり EXIT=0 で完走しました。**#496 は取り下げます。**
