### PR TITLE
fix(ui): Button のラベルが折り返す — BASE_CLASS に whitespace-nowrap（#501・止血・施主承認待ち）

### DIFF
--- a/packages/nene2-ui/src/primitives/Button.tsx
+++ b/packages/nene2-ui/src/primitives/Button.tsx
@@ -162,7 +162,19 @@ const LINK_UNBOX = 'border-0 rounded-none';
 // leaves anything already smaller alone.
 const SVG_BOUND = '[&_svg]:max-h-x-slot-button-icon [&_svg]:max-w-x-slot-button-icon';
 
-const BASE_CLASS = `rounded-x-slot-button border border-transparent inline-flex items-center justify-center gap-x-slot-button-gap font-sans font-x-slot-button ${SVG_BOUND} ${TOUCH_CLASS} ${CLICKABLE_CLASS}`;
+// 🔴 `whitespace-nowrap` is load-bearing (#501). A button's label is a command, not body
+// copy: it names one action, and a wrapped command reads as two. nene-clear measured 15
+// buttons wrapping on its SP layout (PC 1440x900: zero) — "督促を送信" became four lines at
+// 70px, and "消込を確定" broke *inside* a word as "消込を / 確定".
+//
+// 🔴 CJK breaks at any character and Latin breaks at word boundaries, so fixing one is not
+// evidence about the other (nene-vault, #477). `nowrap` stops both.
+//
+// This is the same property `Badge` got in #477. It was added there by naming the component
+// rather than by deriving which components need it, so `Button` was simply not on the list —
+// the third instance of that shape (#486 / #501 / #503). The inventory that would have
+// caught all of them at once is a separate, larger piece of work; this line is the stanch.
+const BASE_CLASS = `whitespace-nowrap rounded-x-slot-button border border-transparent inline-flex items-center justify-center gap-x-slot-button-gap font-sans font-x-slot-button ${SVG_BOUND} ${TOUCH_CLASS} ${CLICKABLE_CLASS}`;
 
 export function Button({
   variant = 'solid',

--- a/packages/nene2-ui/src/primitives/button-axes.test.tsx
+++ b/packages/nene2-ui/src/primitives/button-axes.test.tsx
@@ -26,7 +26,7 @@ const TONES = ['neutral', 'accent', 'danger', 'success', 'warn', 'info'] as cons
 const classesOf = (el: Element | null) => el?.getAttribute('class') ?? '';
 
 describe('Button の軸（#487）', () => {
-  it('形 × 色 の全16マスが描ける（直積を導出して全数）', () => {
+  it('形 × 色 の全24マスが描ける（直積を導出して全数）', () => {
     // 陽性対照: 直積そのものが空でないこと（ループが0回で緑になる事故を潰す）
     expect(SHAPES.length * TONES.length).toBe(24);
 
@@ -137,5 +137,33 @@ describe('Button の軸（#487）', () => {
       }),
     );
     expect([...seen]).toEqual(['bg-x-slot-button-outline-bg']);
+  });
+
+  /**
+   * #501 — nene-clear measured 15 buttons wrapping on its SP layout, one of them breaking
+   * inside a word ("消込を / 確定"). The label of a button is a command; a wrapped command
+   * reads as two.
+   *
+   * 🔴 This asserts the class, not the layout — jsdom does not lay text out, so it cannot
+   * see a wrap. The class is the strongest thing measurable here; the pixels are measured
+   * by consuming ships (#505 is the harness that would have caught this before shipping).
+   */
+  it('どの形 × どの色でも、ラベルが折り返さない（#501・24マス全数）', () => {
+    // 陽性対照: 直積が空でないこと（0回ループが緑になる事故を潰す・上の全数テストと同じ形）
+    expect(SHAPES.length * TONES.length).toBe(24);
+
+    const missing = SHAPES.flatMap((variant) =>
+      TONES.filter(
+        (tone) =>
+          !classesOf(
+            render(
+              <Button variant={variant} tone={tone}>
+                x
+              </Button>,
+            ).container.querySelector('button'),
+          ).includes('whitespace-nowrap'),
+      ).map((tone) => `${variant} x ${tone}`),
+    );
+    expect(missing).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #501

**clear が目視束（13画面 × PC/SP × before/after = 52枚）で捕まえた退行の止血。**

## 何が起きていたか

clear の実測（168ボタンを before/after で突合）:

| | before → after |
| --- | --- |
| sp・督促を送信 / 消込を確定 / 停止 | 26px → **70px（4行）** |
| sp・ユーザーを招待 | 34px → 60px |
| **PC 1440×900** | **0個** |

**「消込を / 確定」と語の途中で割れる。** ボタンのラベルは命令なので、**折り返した命令は2つに読める。**

## 直し方

`BASE_CLASS` に `whitespace-nowrap` を足す1行。**`Badge` が #477 で得たのと同じ属性。**

🔴 **あちらは部品を名指しで足したので `Button` は列挙に入っていなかった** — `success` を #422 / #457 で
部品ごとに列挙して足して `InlineAlert` が2回漏れた（#486）のと同じ形で、**3例目**（#486 / #501 / #503）。
**機構をまとめて解く棚卸しは別レーン**（hub が板3行目に起票済み）。**本 PR は止血のみ。**

導出で当たると一目でわかる〔実測〕: `BASE_CLASS` を持つ4部品のうち `nowrap` を持つのは **0**。
⚠️ **`Input` / `Select` / `Textarea` には足していません。理由は3部品で同じではありません**〔明示〕:

| 部品 | 判定 |
| --- | --- |
| `Textarea` | 🔴 **足さないと判定済み** — **折り返すのが仕様**。ここに `nowrap` を入れるのは誤り |
| `Input` | 🟡 **未判定**（本 PR では見ていない） |
| `Select` | 🟡 **未判定**（本 PR では見ていない） |

**「BASE_CLASS を持つ全部に足す」は導出として誤り** — `BASE_CLASS` を持つ集合と `nowrap` が要る集合は
**別の集合**で、前者から後者は導出できない。**そこの線引きこそ棚卸しの仕事。**

🔴 **`Input` / `Select` を「検討して不要と決めた」と読まないでください。** 見ていないだけです。
（空欄が「やっていない」ではなく「不要と判断した」と読まれる形は、本日 deal の台帳で潰したものの逆版。）

## 検査

**24マス全数**（形4 × 色6）で `whitespace-nowrap` を検査。**陽性対照つき**（直積が空でないこと＝0回ループが緑になる事故を潰す）。

🔴 **陰性対照を実走しました**（「対照を置いた」ではなく「**対照が、直した経路を通って発火した**」まで）:

```
修正を戻して button-axes.test.tsx を実行
  → Tests  1 failed | 8 passed (9)
  → FAIL … > どの形 × どの色でも、ラベルが折り返さない（#501・24マス全数）
```

**落ちたのは本テスト1本だけ**（他8本は緑のまま）＝**この検査は当該の1行だけを見ている。**

⚠️ **これはクラスの検査であって、レイアウトの検査ではありません。** jsdom はテキストを配置しないので
折り返しを見られない。**画素は消費艦が測る**（#505 の目視ハーネスが在れば出荷前に捕まえられた類）。

## 同乗（字面のみ・1語）

既存テスト名の「**全16マス**」を **24** へ訂正しました。**assert は元から `toBe(24)`** で、
直積は 4形 × 6色 = 24。隣に「24マス全数」のテストを足すと**同じ格子について 16 と 24 が並ぶ**ので直しています。
**振る舞いへの影響なし。**

## 実測

| | 値 |
| --- | ---: |
| `npm run check` | 🟢 **EXIT=0**（8ステップ・AM-2 PASS） |
| テスト | **847** passed / 52ファイル（846 + 本 PR の1本） |

## 出荷後にやること

🔴 **clear へ暫定の剥がしを通知する。** clear は `kit-slots.css` に**1規則だけ隔離**して
（`@layer components`・issue 番号と剥がし方を併記）暫定を置いてくれている。
**剥がす手番がどこの板にも乗っていない**ので、**通知して初めて閉じる**（板3行目の完了条件・hub と合意済み）。

deal / vault は**上げたときに黙って直る**側（deal は本番 `f6b1a7a` で露出あり・発現ゼロを再確認済み）。

