### PR TITLE
feat(ui): InlineAlert に success tone を足し、語彙の一致を導出で守る（#486）

### DIFF
--- a/packages/nene2-ui/src/feedback/InlineAlert.tsx
+++ b/packages/nene2-ui/src/feedback/InlineAlert.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from 'react';
 import { cx } from '../lib/cx.js';
 
 export interface InlineAlertProps {
-  /** What the message means. `danger` is announced assertively; `info` politely. */
-  tone?: 'info' | 'warn' | 'danger';
+  /** What the message means. `danger` is announced assertively; the rest politely. */
+  tone?: 'info' | 'warn' | 'danger' | 'success';
   /**
    * 🔴 Needed to point an `aria-describedby` at this message. Without it a product that
    * wants the alert read out with a control has nowhere to put an id, and nene-vault
@@ -20,6 +20,8 @@ const TONE_CLASS: Record<NonNullable<InlineAlertProps['tone']>, string> = {
   info: 'bg-x-slot-alert-info-bg text-x-slot-alert-info-fg border-x-slot-alert-info-border',
   warn: 'bg-x-slot-alert-warn-bg text-x-slot-alert-warn-fg border-x-slot-alert-warn-border',
   danger: 'bg-x-slot-alert-danger-bg text-x-slot-alert-danger-fg border-x-slot-alert-danger-border',
+  success:
+    'bg-x-slot-alert-success-bg text-x-slot-alert-success-fg border-x-slot-alert-success-border',
 };
 
 /**
@@ -31,9 +33,15 @@ const TONE_CLASS: Record<NonNullable<InlineAlertProps['tone']>, string> = {
  * someone listening and no one looking. The palette now carries `warn` of its own.
  *
  * 🔴 The tone decides the ARIA role, not just the colour. `danger` becomes `role="alert"`,
- * which interrupts a screen reader; `info` becomes `role="status"`, which waits its turn.
- * Six ships wrote this component (three as `InlineAlert`, three as `Alert`) and the choice
- * of role is precisely the part that is easy to get wrong and invisible when you do.
+ * which interrupts a screen reader; every other tone becomes `role="status"`, which waits
+ * its turn. Six ships wrote this component (three as `InlineAlert`, three as `Alert`) and
+ * the choice of role is precisely the part that is easy to get wrong and invisible when you
+ * do.
+ *
+ * 🔴 `success` (#486) is deliberately **polite**, not assertive. Good news does not earn an
+ * interruption, and `ToastProvider` already settled the same question the same way
+ * (`POLITE_TONES = ['info', 'success']`). Announcing a success assertively would cut off
+ * whatever the person was reading to tell them nothing went wrong.
  */
 export function InlineAlert({ tone = 'info', id, className, children }: InlineAlertProps) {
   return (

--- a/packages/nene2-ui/src/feedback/tone-vocabulary.test.ts
+++ b/packages/nene2-ui/src/feedback/tone-vocabulary.test.ts
@@ -1,0 +1,110 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * #486 — キットが自称する「1つの語彙」を、列挙ではなく導出で守る。
+ *
+ * 経緯: `success` は #422（Badge・0.17.0）と #457（Toast・0.18.0）で**部品を名指しして**
+ * 足され、**2回とも `InlineAlert` が列挙から漏れた**。どちらの Issue もその部品としては
+ * 完結しており、**どこも赤くならなかった**。型1「列挙で書いた検査は、列挙に無いものを
+ * 緑にする」の現物。だから対策は「列挙を増やす」ではなく「導出する」。
+ *
+ * 🔴 **Issue #486 の受入条件は、字義どおりには成立しない。**
+ * 「`tone` を持つ部品の集合」と「`success` を持つ部品の集合」の一致を求めていたが、
+ * 全数で引くと `tone` は**2つの別々の軸**に使われている〔実測 2026-08-28 20:0x〕:
+ *
+ * | 部品 | `tone` の語彙 | 軸 |
+ * | --- | --- | --- |
+ * | `Badge` / `Button` | neutral, accent, danger, success, warn, info | 状態 |
+ * | `ToastProvider` | info, success, danger | 状態 |
+ * | `InlineAlert` | info, warn, danger（→ success） | 状態 |
+ * | `Text` | **primary, muted** | **強調** |
+ * | `ConfirmDialog` | **default, danger** | **意図** |
+ *
+ * `Text` に `success` は無意味で、`ConfirmDialog` の `danger` は「この操作は破壊的」であって
+ * 結果の報告ではない。⇒ **一致を求める集合は「`tone` を持つ部品」ではない。**
+ *
+ * ここで使う導出はこう: **`info` と `danger` の両方を言える部品は、結果を報告している。
+ * 結果には成功がある。** `Text`（どちらも無い）と `ConfirmDialog`（`info` が無い）は
+ * 自動的に外れ、部品名を1つも書かずに済む。
+ *
+ * ⚠️ この規則は clear の提案であって fleet の裁定ではない。別の線引き（例: 語彙そのものを
+ * 型として1本にする）を採るなら、この検査ごと差し替えてよい。**列挙に戻さないことだけが要点。**
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.join(here, '..');
+
+/** コメントを先に落とす — docstring が語彙を例示しているので、拾うと偽の語が入る。 */
+const stripComments = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const full = path.join(dir, name);
+    if (statSync(full).isDirectory()) return sourceFiles(full);
+    if (!/\.tsx?$/.test(name) || /\.test\.tsx?$/.test(name)) return [];
+    return [full];
+  });
+}
+
+/** `tone` の文字列リテラル合併を、宣言の形を問わず拾う（prop でも型エイリアスでも）。 */
+function toneVocabularies(): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+  for (const file of sourceFiles(SRC)) {
+    const src = stripComments(readFileSync(file, 'utf8'));
+    const patterns = [
+      /\btone\??\s*:\s*((?:'[a-z-]+'\s*\|\s*)*'[a-z-]+')\s*;/g,
+      /\btype\s+\w*Tone\w*\s*=\s*((?:'[a-z-]+'\s*\|\s*)*'[a-z-]+')\s*;/g,
+    ];
+    for (const re of patterns) {
+      for (const m of src.matchAll(re)) {
+        const words = [...m[1]!.matchAll(/'([a-z-]+)'/g)].map((w) => w[1]!);
+        if (words.length > 1) found.set(path.basename(file), words);
+      }
+    }
+  }
+  return found;
+}
+
+describe('#486 the kit claims one vocabulary — derive it, do not list it', () => {
+  const vocabularies = toneVocabularies();
+
+  it('finds every tone vocabulary in the package (positive control on the extractor)', () => {
+    // If the extractor silently stops matching, every assertion below passes on an empty
+    // set. Anchor it on what is known to be there — including the two OTHER axes, so a
+    // regression that drops half the files is visible here rather than as a quiet green.
+    expect([...vocabularies.keys()].sort()).toEqual(
+      [
+        'Badge.tsx',
+        'Button.tsx',
+        'ConfirmDialog.tsx',
+        'InlineAlert.tsx',
+        'Text.tsx',
+        'toast-context.ts',
+      ].sort(),
+    );
+  });
+
+  it('every component that reports an outcome can report a success', () => {
+    const reportsOutcome = [...vocabularies.entries()].filter(
+      ([, words]) => words.includes('info') && words.includes('danger'),
+    );
+
+    // Derived, not listed: the guard is that this set is non-empty and that all of it
+    // carries `success`. Adding a fourth outcome surface without `success` fails here
+    // without anyone remembering to add its name.
+    expect(reportsOutcome.length).toBeGreaterThan(0);
+    const missing = reportsOutcome.filter(([, words]) => !words.includes('success'));
+    expect(missing.map(([file]) => file)).toEqual([]);
+  });
+
+  it('leaves the other two axes alone', () => {
+    // Text is emphasis and ConfirmDialog is intent. Neither is an outcome, so neither is
+    // required to carry `success` — and this states that on purpose, so a later reader
+    // does not "fix" them into the outcome vocabulary.
+    expect(vocabularies.get('Text.tsx')).toEqual(['primary', 'muted']);
+    expect(vocabularies.get('ConfirmDialog.tsx')).toEqual(['default', 'danger']);
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -237,6 +237,11 @@
   --color-x-slot-alert-danger-bg: var(--color-surface);
   --color-x-slot-alert-danger-fg: var(--color-danger);
   --color-x-slot-alert-danger-border: var(--color-danger);
+  /* `success` (#486). Shaped like `danger`: the surface stays the page's, and the meaning is
+   * carried by the border and the text — an alert is read, not filled. */
+  --color-x-slot-alert-success-bg: var(--color-surface);
+  --color-x-slot-alert-success-fg: var(--color-success);
+  --color-x-slot-alert-success-border: var(--color-success);
   --color-x-slot-field-label: var(--color-text-muted);
   --color-x-slot-field-hint: var(--color-text-muted);
   --text-x-slot-field-hint-size: var(--text-x-2xs);
@@ -410,8 +415,10 @@
   --color-x-slot-toast-border: var(--color-border);
   --color-x-slot-toast-danger-fg: var(--color-danger);
   --color-x-slot-toast-danger-border: var(--color-danger);
-  /* `success` tone (#457). Badge and InlineAlert already carry this meaning; the toast is
-   * the one surface that had only two. */
+  /* `success` tone (#457). ⚠️ This comment claimed InlineAlert already carried the meaning.
+   * It did not, and would not until #486 — the sentence was written from the enumeration in
+   * the issue rather than from the component. Corrected here rather than deleted: a note
+   * that was wrong about a neighbour is the exact shape #486 is about. */
   --color-x-slot-toast-success-fg: var(--color-success);
   --color-x-slot-toast-success-border: var(--color-success);
   /* The toast's second line (#457). Only read when `description` is passed. */


### PR DESCRIPTION
Closes #486

clear が書き手（板 L124・08-27 18:3x 施主回答）。**版は上げていません**——publish は fleet の便で。

## 足したもの

- `InlineAlert` の `tone` に **`success`**（`TONE_CLASS` 1行）
- `themes/default.css` に `--color-x-slot-alert-success-{bg,fg,border}`。
  **`danger` と同じ形**（面は `--color-surface` のまま・意味は枠と文字が運ぶ＝alert は読むもので、塗るものではない）
- **ARIA は polite**（`role="status"`）。現行の三項 `tone === 'danger' ? 'alert' : 'status'` のままで
  そうなりますが、**Issue が「決めろ」と言っている論点**なので docstring に理由ごと書きました:
  良い報せは割り込みに値しない。そして **`ToastProvider` が同じ問いを同じ答えで既に閉じています**
  （`POLITE_TONES = ['info', 'success']`）＝キット内で先例に揃えた形です。

## 🔴 Issue の受入条件は、字義どおりには成立しません

> 「tone を持つ部品の集合」と「success を持つ部品の集合」が一致することをテストで導出して当てる

`tone` を**全数で**引くと、**2つの別々の軸**に使われていました〔実測〕:

| 部品 | 語彙 | 軸 |
|---|---|---|
| `Badge` / `Button` | neutral, accent, danger, success, warn, info | 状態 |
| `ToastProvider` | info, success, danger | 状態 |
| `InlineAlert` | info, warn, danger → **+success** | 状態 |
| **`Text`** | **primary, muted** | **強調** |
| **`ConfirmDialog`** | **default, danger** | **意図** |

`Text` に `success` は無意味ですし、`ConfirmDialog` の `danger` は
**「この操作は破壊的」であって結果の報告ではありません**。
⇒ 一致を求める集合は「`tone` を持つ部品」ではない。字義どおり書くと**通らない検査**になります。

**採った導出**: `info` と `danger` の**両方**を言える部品は結果を報告している。結果には成功がある。
`Text`（どちらも無い）と `ConfirmDialog`（`info` が無い）は自動的に外れ、**部品名を1つも書かずに済みます**。

⚠️ **これは clear の提案であって fleet の裁定ではありません。** 別の線引き
（例: 状態語彙そのものを型として1本に切り出す）を採るなら、この検査ごと差し替えてください。
**列挙に戻さないことだけが要点**だと理解しています。

## 検査 — 陰性対照つき

`success` を外すと、**部品名を名指しで**赤くなります:

```
× every component that reports an outcome can report a success
  → expected [ 'InlineAlert.tsx' ] to deeply equal []
```

**抽出器そのものにも陽性対照**を置きました（6ファイル全部＝他2軸を含めて拾えているかを当てる）。
抽出が静かに止まると**以降の判定が空集合で緑になる**ので、そこを塞いでいます。

`npm run check` 緑（**53 files / 849 tests**）。
**既定描画は不変**——`success` は新しい値で、既存の tone の class 文字列は1文字も変えていません。

## ついでに直した既存の誤り

`themes/default.css` の toast success の注記が

> `success` tone (#457). **Badge and InlineAlert already carry this meaning**; …

と書いていましたが、**書かれた時点で偽**でした（`InlineAlert` は本 PR まで持っていない）。
#457 の Issue の列挙を写して書かれた文で、**本 Issue が直そうとしている形そのもの**です。
削除せず、経緯つきの訂正として残しました。

## 手順

fleet の常駐作業木が `fix/501-button-nowrap` で作業中だったので、触らず `git worktree add` で
別の作業木を切って作業しました（`_work/issues.md` #128）。マージ時に `--delete-branch` は打ちません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198YWHGnk4Dy9JTi5fzZSLo