### PR TITLE
feat(ui): Modal に footer と description を足す（#493・既定不変）

### DIFF
--- a/packages/nene2-ui/src/overlay/Modal.tsx
+++ b/packages/nene2-ui/src/overlay/Modal.tsx
@@ -31,6 +31,20 @@ interface ModalBase {
    * `showModal`, so it can only be verified in a real browser (see #392, live lane).
    */
   scrollable?: boolean;
+  /**
+   * The dialog's actions, laid out below the body and **outside its scroll area**.
+   *
+   * 🔴 Not a matter of layout — a matter of structure. Pushed into `children`, the action row
+   * joins the body's scroll region, so with `scrollable` it slides off the bottom of a tall
+   * dialog and the person cannot reach "Confirm". nene-clear uses a footer in **11 of 11**
+   * dialogs and makes it a required prop (#493); eight ships wrote a modal and every one of
+   * them drew this row.
+   *
+   * The kit lays the row out end-aligned with a gap, which is what those eleven do. A product
+   * that wants another arrangement composes it inside — `footer={<div className="flex w-full
+   * justify-between">…</div>}` — rather than the kit growing an alignment prop.
+   */
+  footer?: ReactNode;
   children: ReactNode;
 }
 
@@ -42,6 +56,19 @@ interface PlainModal extends ModalBase {
 interface HeaderModal extends ModalBase {
   /** Draw a header: the title, and a control that closes the dialog. */
   header: true;
+  /**
+   * Localized one-line description, under the title.
+   *
+   * 🔴 On `HeaderModal` only, and deliberately. Without a header the title is never drawn —
+   * it becomes the dialog's `aria-label` — so a description would have nothing to sit under
+   * and would be dropped in silence. The same reasoning `closeLabel` uses below: let the
+   * compiler ask for it exactly where it is going to be rendered.
+   *
+   * 🔴 Named `description`, matching `PageHeader` (#492/#497) and `EmptyState` (#456), not
+   * clear's local `sub`. Nine of clear's eleven dialogs carry this line (#493). One word for
+   * one thing across the kit — the rule `Badge`'s tone vocabulary states, applied to a prop.
+   */
+  description?: string;
   /**
    * Localized name for the close control.
    *
@@ -89,7 +116,7 @@ const SHEET_CLASS =
  * up until a consumer overrode one side of a pair.
  */
 export function Modal(props: ModalProps) {
-  const { open, onClose, title, size, sheetOnMobile, scrollable, children } = props;
+  const { open, onClose, title, size, sheetOnMobile, scrollable, footer, children } = props;
   const ref = useRef<HTMLDialogElement>(null);
   const titleId = useId();
 
@@ -137,14 +164,32 @@ export function Modal(props: ModalProps) {
         'p-x-slot-modal-pad font-sans backdrop:bg-x-slot-modal-scrim/50',
         size !== undefined && SIZE_CLASS[size],
         sheetOnMobile === true && SHEET_CLASS,
+        // The column is what keeps the footer out of the scroll region: the body flexes and
+        // scrolls, the footer keeps its height. Without `scrollable` there is nothing to
+        // scroll, so the dialog keeps the block layout every caller has had until now.
         scrollable === true && 'flex flex-col',
       )}
     >
       {props.header === true && (
         <header className="mb-x-slot-modal-header-gap flex items-start justify-between gap-x-slot-modal-header-gap">
-          <h2 id={titleId} className="font-x-slot-modal-title text-x-slot-modal-title-size">
-            {title}
-          </h2>
+          {/* 🔴 The bare <h2> survives when there is no description, so a ship already using
+           * `header` sees the same DOM. Wrapping it unconditionally would change every one of
+           * those dialogs for the benefit of a prop they do not pass — the rule EmptyState set
+           * for its own `description` (#456) and PageHeader kept (#497). */}
+          {props.description === undefined ? (
+            <h2 id={titleId} className="font-x-slot-modal-title text-x-slot-modal-title-size">
+              {title}
+            </h2>
+          ) : (
+            <div>
+              <h2 id={titleId} className="font-x-slot-modal-title text-x-slot-modal-title-size">
+                {title}
+              </h2>
+              <p className="mt-x-slot-modal-description-gap font-sans text-x-slot-modal-description-fg">
+                {props.description}
+              </p>
+            </div>
+          )}
           <button
             type="button"
             aria-label={props.closeLabel}
@@ -158,6 +203,13 @@ export function Modal(props: ModalProps) {
         </header>
       )}
       {scrollable === true ? <div className="min-h-0 overflow-y-auto">{children}</div> : children}
+      {footer !== undefined && (
+        // `shrink-0` matters only in the scrollable column, where the body would otherwise
+        // take the footer's height with it; it is inert in the block layout.
+        <footer className="mt-x-slot-modal-footer-gap flex shrink-0 justify-end gap-x-slot-modal-footer-gap">
+          {footer}
+        </footer>
+      )}
     </dialog>
   );
 }

--- a/packages/nene2-ui/src/overlay/modal.test.tsx
+++ b/packages/nene2-ui/src/overlay/modal.test.tsx
@@ -177,3 +177,81 @@ describe('Modal — size / sheet / scrollable（#392②③④）', () => {
     expect(classesOf(dialogOf(container))).toContain('max-w-x-slot-modal');
   });
 });
+
+/**
+ * #493 — footer（アクション行）と description（副題）。
+ *
+ * どちらも任意 prop で、**渡さない呼び出し側の DOM は1文字も変わらない**。
+ * 既定の側を先に固定してから、渡した側を見る（このファイルが #392 で立てた形）。
+ */
+describe('Modal — footer と description（#493・既定不変）', () => {
+  it('footer を渡さなければ <footer> は出ない', () => {
+    const { container } = render(
+      <Modal open title="T" onClose={() => {}}>
+        body
+      </Modal>,
+    );
+    expect(container.querySelector('footer')).toBeNull();
+  });
+
+  it('description を渡さなければ、題は裸の <h2> のまま（既存艦の DOM を変えない）', () => {
+    const { container } = render(
+      <Modal open header closeLabel="閉じる" title="T" onClose={() => {}}>
+        body
+      </Modal>,
+    );
+    const h2 = container.querySelector('h2');
+    // 包む <div> が挟まっていないこと＝親が <header> であること。
+    expect(h2?.parentElement?.tagName).toBe('HEADER');
+    expect(container.querySelector('header p')).toBeNull();
+  });
+
+  it('footer は本文のスクロール領域の外に出る（構造の要求・意匠ではない）', () => {
+    const { container } = render(
+      <Modal open scrollable title="T" onClose={() => {}} footer={<button>OK</button>}>
+        body
+      </Modal>,
+    );
+    const scroller = container.querySelector('.overflow-y-auto');
+    const foot = container.querySelector('footer');
+    expect(scroller).not.toBeNull();
+    expect(foot).not.toBeNull();
+    // 🔴 これが本体。footer がスクローラの子孫だと、tall な本文で画面外へ流れる。
+    expect(scroller?.contains(foot!)).toBe(false);
+    expect(foot?.parentElement?.tagName).toBe('DIALOG');
+    expect(classesOf(foot).split(/\s+/)).toContain('shrink-0');
+  });
+
+  it('description は題の下に段落として出る', () => {
+    const { container } = render(
+      <Modal open header closeLabel="閉じる" title="T" description="説明" onClose={() => {}}>
+        body
+      </Modal>,
+    );
+    const p = container.querySelector('header p');
+    expect(p?.textContent).toBe('説明');
+    // 題と同じ入れ物に入る（見出しの隣ではなく下）。
+    expect(p?.previousElementSibling?.tagName).toBe('H2');
+  });
+
+  it('陽性対照: 既定の検査は、付いていれば実際に気づく', () => {
+    // 上の2件は「無い」を主張している。検査器が壊れて常に null を返すなら、
+    // どちらも通ってしまう。同じ問い合わせが、渡した時には実際に当たることを示す。
+    const { container } = render(
+      <Modal
+        open
+        header
+        closeLabel="閉じる"
+        title="T"
+        description="説明"
+        onClose={() => {}}
+        footer={<button>OK</button>}
+      >
+        body
+      </Modal>,
+    );
+    expect(container.querySelector('footer')).not.toBeNull();
+    expect(container.querySelector('header p')).not.toBeNull();
+    expect(container.querySelector('h2')?.parentElement?.tagName).toBe('DIV');
+  });
+});

--- a/packages/nene2-ui/themes/default.css
+++ b/packages/nene2-ui/themes/default.css
@@ -531,12 +531,19 @@
   --container-x-slot-modal-lg: var(--container-xl);
 
   --spacing-x-slot-modal-header-gap: var(--spacing-x-xs);
+  /* The action row (#493). One slot for both the space above it and the space between the
+   * buttons: they are the same rhythm, and a product that wants them apart can say so. */
+  --spacing-x-slot-modal-footer-gap: var(--spacing-x-xs);
+  /* The dialog's second line (#493). Only read when `description` is passed. Same value as
+   * PageHeader's and EmptyState's — one word, one look. */
+  --spacing-x-slot-modal-description-gap: var(--spacing-x-3xs);
   --font-weight-x-slot-modal-title: var(--font-weight-medium);
   /* `inherit`, so the header title takes the dialog's own size unless a product says
    * otherwise. There is no previous rendering to copy — the header is new — and picking a
    * step here would decide type for every product that turns the header on. */
   --text-x-slot-modal-title-size: inherit;
   --color-x-slot-modal-close-fg: var(--color-text-muted);
+  --color-x-slot-modal-description-fg: var(--color-text-muted);
 
   /* ── Shadow slots ─────────────────────────────────────────────────────────────
    * 🔴 Shadow was the one dimension that never got slots (#386). 0.9.0 moved "colour, weight


### PR DESCRIPTION
Closes #493

clear が書き手（板 L124）。**版は上げていません** — publish は fleet の便で。

## footer — 意匠ではなく**構造**の要求

`children` に押し込むと**本文と同じスクロール領域に入る**ので、`scrollable` を付けた tall な dialog では
**アクション行が一緒に流れて画面外へ出ます**＝「確定」に手が届かない。だから別の場所に要る、という話です。

キットは**端寄せ＋ギャップ**で置きます（clear の11箇所とも取消＋確定の2ボタンでその形）。
別の配置が要る製品は中で組む —— `footer={<div className="flex w-full justify-between">…</div>}` ——
**キットが配置の prop を生やすのではなく**。

`scrollable` が付ける `flex flex-col` が、そのまま footer をスクロール領域の外に保つ列になります。
`shrink-0` はその列の中でだけ効き、block レイアウトでは無害です。

## description — `sub` ではなく `description`

`PageHeader`（#492/#497）・`EmptyState`（#456）と同じ語にしました。**1つのものに1つの語**、
`Badge` の tone 語彙が言っていることを prop に当てた形です。

🔴 **`HeaderModal` にだけ置きました。** `header` が無いと題は描かれず `aria-label` になるので、
副題は**座る場所が無く黙って落ちます**。**同じファイルの `closeLabel` と同じ理屈**で、
描かれる場所でだけ型に要求させています。

## 既定不変（3点とも検査で固定）

| 呼び出し | 描画 |
|---|---|
| `footer` 省略 | `<footer>` を出さない |
| `description` 省略 | **題は裸の `<h2>` のまま** |
| `scrollable` 省略 | block レイアウトのまま |

2番目が要点です。**無条件に `<div>` で包むと、渡していない prop のために既存艦の DOM が変わります**
（#456 が立て #497 が守った規則）。

## 検査 — 陰性対照つき

footer を意図的にスクロール領域の**中**へ移すと、2本落ちます:

```
× footer は本文のスクロール領域の外に出る（構造の要求・意匠ではない）
  → expected true to be false
× 陽性対照: 既定の検査は、付いていれば実際に気づく
  → expected null not to be null
```

⚠️ 「無い」を主張する検査が2本あるので、**検査器が常に `null` を返しても通ります**。
同じ問い合わせが**渡した時には実際に当たる**ことを陽性対照で示しました
（#507 のレビューでそちらが「両側とも空だった」を捕まえたのと同じ場所です）。

`npm run check` 緑（**53 files / 854 tests**・+5）。

## fleet に委ねられていた論点

#493 は「`sub` を別 issue に分けるべきかもしれない」と書いて fleet に委ねていました。
**同じ部品の同じ性質の穴**なので **1本にまとめてあります**。分けたほうがよければ分けてください。

⚠️ #506（Button の `whitespace-nowrap`）との関係: footer にボタンを並べる設計なので、
**#506 が入ると長いラベルが折り返さなくなり footer の幅要求が増える**方向に効きます。
そちらの指摘を織り込んで、footer には**幅の上限も `flex-wrap` も付けていません**
——キットが先回りして wrap を決めると、#506 が直そうとしている問題を別の場所で作り直すので。

## 手順

fleet の常駐作業木（`fix/501-button-nowrap`）は触らず、`git worktree add` で別の作業木から作業しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198YWHGnk4Dy9JTi5fzZSLo