### PR TITLE
chore(release) nene2-ui 0.21.0: clear の2件（#486 / #493）と Button の折り返し止血（#501）に版を与える（#509・#483 同梱・施主 GO 済み）

### DIFF
--- a/docs/publish.md
+++ b/docs/publish.md
@@ -15,7 +15,7 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 | `@hideyukimori/nene2-tokens`    | Core Token Contract v1（color 28＋shadow 4）・`validate:themes`・themegen・codemod 写像表。契約凍結済み（2026-07-14 hide 承認）で、契約キー集合の変更は stop-the-line ADR のみ |
 | `@hideyukimori/nene2-standards` | ESLint / Stylelint 配布 config・`nene2-check`（conformance・fail-closed）・registries                                                                                          |
 | `@hideyukimori/nene2-i18n`      | 型付き i18n（ja 権威カタログ・parity・`./format` / `./react` / `./testing` subpath）。`private` 解除済み（#44・2026-07-16 hide 裁定）                                          |
-| `@hideyukimori/nene2-ui`        | フリート共有 React UI キット（token 駆動の部品）。**初回 publish 未実施**                                                                                                      |
+| `@hideyukimori/nene2-ui`        | フリート共有 React UI キット（token 駆動の部品）。**publish 済み**（#483 で訂正 — この欄は 0.1.0 の初回 publish から 20版のあいだ「未実施」のままだった）                       |
 
 ### 🔴 この表に版を書かない（#313）
 
@@ -46,7 +46,7 @@ publish の実行は施主（hide）。担当リナは準備と検証まで。
 nene2-standards  1.0.0 1.0.1 1.1.0 1.2.0 2.0.0 2.0.1 2.1.0 2.1.1 2.2.0
 nene2-tokens     1.0.0 1.0.1 1.1.0 1.2.0
 nene2-i18n       0.1.0 0.2.0 0.3.0
-nene2-ui         （未公開）
+nene2-ui         0.1.0 … 0.20.0 → 0.21.0（本節・publish 済み。#483 で「（未公開）」を訂正）
 ```
 
 🔴 **この一覧も測定時点つきの参考**であって、正本はコマンドの方。**引用するときは日付ごと引くこと。**
@@ -64,6 +64,65 @@ nene2-ui         （未公開）
 > standards **2.0.0** は **2026-07-21 publish 済み**（BREAKING・per-repo registries／npm view 実測 latest=2.0.0・shasum 20e4f3e0）。
 > #84/#85 束（standards 1.2.0＋tokens 1.1.0）は **2026-07-18 publish 済み**（npm view 実測で latest 一致）。
 > 監査根拠: 未 publish 範囲は git tag / npm view の実測突き合わせ。数字・挙動は全て実測かテスト現物で裏取りし、未実装は未実装と明記する。
+
+### `@hideyukimori/nene2-ui` 0.21.0（**minor — feat 2 ＋ fix 1**・#486 / #493 / #501）
+
+🔴 **急いで上げる必要はありません。** 0.x の caret は minor を固定するので、
+**`^0.20.0` のままなら 0.21.0 は入ってきません。** **BREAKING はありません。**
+
+| | 内容 | 既定描画 |
+| --- | --- | --- |
+| **#486** | `InlineAlert` に `success` tone（**clear 執筆**） | 🟢 **不変** |
+| **#493** | `Modal` に `footer` と `description`（**clear 執筆**） | 🟢 **不変** |
+| 🔴 **#501** | `Button` に `whitespace-nowrap` | 🔴 **変わりうる** |
+
+#### 🔴 #501 — ボタンのラベルが折り返さなくなります（唯一の要注意）
+
+**上げると、いま折り返しているボタンは横に伸びます。**
+
+clear の実測（**168ボタンを before/after で突合**）: SP で **15ボタン**が折り返しており、
+「督促を送信 / 消込を確定 / 停止」が **26px → 70px（4行）**、**「消込を / 確定」と語の途中で割れて**いました。
+**PC 1440×900 は 0個。**
+
+⇒ **狭い行にボタンを並べている画面は、上げたあと実ブラウザで見てください。**
+**折り返しが消えるぶん、横があふれる方向に効きます。**
+
+⚠️ **CJK は任意位置で折れ、英字は単語境界で折れます**——**片方で確認しても他方の確認にはなりません**
+（vault の指摘・#477）。**多言語を出す画面は、いちばん長いロケールで見てください。**
+
+🟢 **nene-clear へ**: `kit-slots.css` に隔離してある暫定（`@layer components` の1規則）は、
+**この版へ上げたら剥がしてください。** 剥がすまでキットと二重に効きます。
+🟢 **nene-deal / nene-vault へ**: **上げれば黙って直ります**（deal は「露出あり・発現ゼロ」を本番 `f6b1a7a` で再確認済み）。
+
+#### #486 — `InlineAlert` の `success`
+
+`tone="success"` が使えます。**`role="status"`（polite）**です——
+**良い知らせは割り込みに値しない**ので、`danger` だけが `role="alert"` のまま。
+`ToastProvider` の `POLITE_TONES = ['info','success']` に揃えました。
+
+スロット3本が増えます（既定は `danger` と同じ形＝**地は頁のまま・意味は枠と文字が運ぶ**）:
+`--color-x-slot-alert-success-{bg,fg,border}`。
+
+#### #493 — `Modal` の `footer` と `description`
+
+**`footer` は意匠ではなく構造です。** `children` に押し込むとアクション行が本文のスクロール領域に入り、
+**`scrollable` の背の高いダイアログで「確定」が画面外へ流れて手が届かなくなります。**
+
+**`description` は `header` を描くときだけ**渡せます（ヘッダが無いと題は `aria-label` になるので、
+副題は置き場所を失って黙って落ちるため）。**名前は `PageHeader` / `EmptyState` と同じ `description`。**
+
+🟢 **どちらも省略時の DOM は 0.20.0 と1文字も変わりません**〔fleet が `outerHTML` で実測・
+既存4形（plain / header / scrollable / sheet+size）とも一致〕。**渡していない prop のために DOM は変わりません。**
+
+スロット3本が増えます: `--spacing-x-slot-modal-footer-gap` / `--spacing-x-slot-modal-description-gap` /
+`--color-x-slot-modal-description-fg`（**値は `PageHeader` / `EmptyState` と同一**）。
+
+#### 各艦でやること
+
+1. **宣言を `^0.21.0` へ書き換える** → **`npm update @hideyukimori/nene2-ui`**
+   （`npm ci` / `npm install` は lock を尊重するので、宣言だけでは入りません）
+2. **`npm ls @hideyukimori/nene2-ui`** で**実インストール版**を見る（宣言ではなく）
+3. 🔴 **実ブラウザで見る。** #501 は**描画が変わる**ので、**クラス文字列の一致では確認になりません。**
 
 ### `@hideyukimori/nene2-ui` 0.20.0（**minor — 🔴 BREAKING を含む**・#487 / #488 / #492）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9037,7 +9037,7 @@
     },
     "packages/nene2-ui": {
       "name": "@hideyukimori/nene2-ui",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=19",

--- a/packages/nene2-ui/package.json
+++ b/packages/nene2-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hideyukimori/nene2-ui",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "NeNe fleet shared React UI kit — token-driven primitives on Tailwind v4 @theme. Components carry no design of their own; themes do.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Fixes #509 / Fixes #483

**施主 GO 済み**（2026-08-28・本会話で直接）。タグ以降の未リリース差分**3件**に版を与えます。

| コミット | 内容 | 既定描画 |
| --- | --- | --- |
| `a2e3b2d` | **#486** `InlineAlert` に `success` tone（PR #507・**clear 執筆**） | 🟢 **不変** |
| `9db02d3` | **#493** `Modal` に `footer` / `description`（PR #508・**clear 執筆**） | 🟢 **不変** |
| `a59dfb2` | 🔴 **#501** `Button` に `whitespace-nowrap`（PR #506） | 🔴 **変わりうる** |

**版 = 0.21.0（minor）。BREAKING はありません。**
🔴 0.x の caret は minor を固定するので **`^0.20.0` は 0.21.0 を含みません** ⇒ **艦は急がなくてよい。**

## 🔴 #501 だけが「上げると見た目が変わる」

折り返していたボタンが**横に伸びます**（clear 実測: SP で **15ボタン**・**PC は 0個**）。
`docs/publish.md` に、**狭い行のボタン列は実ブラウザで見ること**と、
⚠️ **CJK は任意位置・英字は単語境界で折れるので片方の確認が他方の確認にならない**（vault・#477）を明記しました。

## 同梱: #483（publish.md 自身が定めた established パターンに従う）

publish.md には **「※各 table 行・版節の『publish 済み』訂正は各パッケージの次 bump PR で（established パターン）」**
と書かれているので、この bump PR で直します:

- §対象 の表: nene2-ui が **「初回 publish 未実施」** → **publish 済み**
- publish 済み一覧: nene2-ui が **「（未公開）」** → **0.1.0 … 0.20.0 → 0.21.0**

🔑 **どちらも 0.1.0 の初回 publish から 20版のあいだ偽のまま**でした。**同じファイルの下方に
0.1.0〜0.20.0 の版節が全部並んでいる**のに、**冒頭の表だけが取り残されていた**——
**living doc ほど参照側は最終更新を見ない**の実例です。

## 実測

| | |
| --- | ---: |
| `npm run check` | 🟢 **EXIT=0** |
| テスト | **855** / 53 files |
| AM-2 release gate | 🟢 **PASS**（contract 1.0 が凍結記録と一致） |
| lockfile の差分 | **1行**（版のみ・巻き添えなし） |

## マージ後

1. `Publish npm` workflow を **`package=nene2-ui` / `dry_run=false`** で実行
2. 🔴 **`npm view` で latest と shasum を実測し、`npm pack` で中身も読む**
   （「版が上がった」は「中身が出た」ではない）＋**陰性対照**を1つ
3. 🔴 **clear へ暫定の剥がしを通知**（板3行目の完了条件）
