### PR TITLE
fix(ci): Audit の !cancelled() に install 成功条件を足す — 陽性対照の赤2つ目を消す（#523・当該 idiom の配布元）

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,7 +57,13 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - run: npm ci
+      # 🔴 `id:` は下の `Audit` が `steps.install.outcome` を引くために要る（#523）。
+      #    消すと `Audit` の条件が常に false 側へ倒れ、**監査が黙って skip になる**。
+      #    `name:` は必須ではないが、陽性対照のステップ一覧を読むとき
+      #    `Install dependencies = skipped` のほうが `Run npm ci = skipped` より意図が読める。
+      - name: Install dependencies
+        id: install
+        run: npm ci
       - run: npm run type-check
       - run: npm run lint
       - run: npm run format:check
@@ -83,8 +89,25 @@ jobs:
       # 「無視してよい赤」として定着する。ゲートは CI に置く。
       # ※ 正本として配るときはここが2ケースに割れる:
       #   Stop hook を持つ艦 = CI に置く／持たない艦 = `check` に入れてよい。
+      #
+      # 🔴 ただし `!cancelled()` **だけでは足りない**。`steps.install.outcome == 'success'` も要る。
+      # `!cancelled()` は「前段が赤なら skip」という既定を打ち消すので、**依存のインストールが
+      # skip された run でもこの行が走る**。`node_modules` の無い作業ツリーで `npm run audit` を
+      # 叩くことになり、`audit-ci: not found`（exit 127）で落ちる。
+      # ⇒ 陽性対照（`simulate_failure=true`）で**赤が2つ**出る——意図した `Simulate failure` と、
+      #   意図しない `Audit`。**本番の赤では無害**（実コードの failure は install の後に起きるので
+      #   `Audit` は意味のある状態で走る）。壊れるのは陽性対照の可読性であってカバレッジではない。
+      # 🔑 上の Simulate の位置決め（「意図した exit 1 ではない別の失敗をリハーサルしてしまう」）が
+      #   避けたのと**同じ形**を、この行が9ステップ後ろで作り直していた。
+      #
+      # 🔴 「Simulate を install の後ろへ移す」で直さないこと。上で明示的に却下した形で、
+      # 後ろへ置くと前段のどれかが落ちて意図した exit 1 に到達しない。
+      # 🔴 逆に**条件を足しすぎて `Audit` が常に skip に化ける**のが、この形のいちばん危険な壊れ方。
+      # 陽性対照では skip が正解なので、**陽性対照だけ見ていても気づけない**。
+      # ⇒ 直したら**通常実行で `Audit = success` を見る**こと。片方だけでは受け入れない。
+      # 出所: nene-corpus #386 / PR #387（`frontend-ci.yml`）→ nene2-fleet-tooling #523（配布元）。
       - name: Audit (fail on high/critical)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run audit
 
   notify-failure:


### PR DESCRIPTION
Closes #523

## 何を直したか

`Audit (fail on high/critical)` の条件に **`steps.install.outcome == 'success'`** を足した。
**`!cancelled()` は残す**（その意図は正しい）。

```diff
-      - run: npm ci
+      - name: Install dependencies
+        id: install
+        run: npm ci

       - name: Audit (fail on high/critical)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
```

`!cancelled()` は「前段が赤なら skip」の既定を打ち消すので、**依存のインストールが skip された run でも
`Audit` が走る**。`node_modules` の無い作業ツリーで `npm run audit` を叩くことになり `audit-ci: not found`
（exit 127）で落ちていた。

🔑 **上の Simulate の位置決めが避けた形**（「意図した exit 1 ではない別の失敗をリハーサルしてしまう」）を、
**この行が9ステップ後ろで作り直していた。**

⚠️ **本番の赤では無害**だった。実コードの failure は install の後に起きるので `Audit` は意味のある状態で走る。
**壊れていたのは陽性対照の可読性であってカバレッジではない。**

🔴 **本リポは当該 idiom の配布元**（`check.yml` の「正本として配るときはここが2ケースに割れる」注記）。
**ここを直さないと次に配る先へ同じ欠陥が乗る**ので順序が先。

## 🔴 受入条件（2点・すべて自艦で実測）

### 1. 陽性対照の前後比較

**前**〔`--ref main -f simulate_failure=true`・2026-09-01 21:35 dispatch・run [33508487816](https://github.com/hideyukiMORI/nene2-fleet-tooling/actions/runs/33508487816)〕

| 結果 | ステップ |
| --- | --- |
| failure | **Simulate failure (rehearsal only)** ← 意図した exit 1 |
| skipped | Run actions/setup-node@v4 |
| skipped | Run npm ci |
| skipped | Run npm run type-check … check:cli |
| **failure** | 🔴 **Audit (fail on high/critical)** ← **意図しない2つ目の赤** |

- **赤いステップ = 2**（導出: `jq '[.jobs[].steps[]|select(.conclusion=="failure")]|length'`）
- ログ: `sh: 1: audit-ci: not found` / `Process completed with exit code 127`
- `notify-failure` = **success**（Issue **#524** を起票）

**後**: 本 PR の枝で取り直す。**期待 = 赤は `Simulate failure` の1つだけ・`Audit` は skipped・
`notify-failure` は引き続き発火**（装置を壊していない証明）。→ 結果は下にコメントで追記する。

### 2. 🔴 通常実行で `Audit` が走る

**本 PR の `pull_request` run で `Audit = success` を見る。**
**条件を足しすぎて `Audit` が常に skip に化ける**のがこの修正のいちばん危険な壊れ方で、
**陽性対照では skip が正解なので、陽性対照だけ見ていても絶対に気づけない。**

## 手元の実測〔すべて自艦・2026-09-01〕

| 項目 | 結果 |
| --- | --- |
| `npm run check` | 🟢 EXIT=0（AM-2 gate PASS・contract 1.0 = color 28 + shadow 4） |
| `npm test` | 🟢 EXIT=0・**855 passed / 53ファイル**〔`Start at 21:37:46`〕 |
| YAML パース | 🟢 成功（jobs = `check`, `notify-failure`） |
| 導出 | `id: install` **1本**・`steps.install.outcome` は条件行に**1本** |

## 採らなかった案

🔴 **「Simulate を `npm ci` の後ろへ移す」では直していない。** `check.yml` が**明示的に却下した形**で、
後ろへ置くと前段のどれかが落ちて意図した exit 1 に到達しない。却下済みの案に戻すのは判断の後退。

## コメントの置き方（#512 の教訓）

**yml には「写しでも真であり続ける事実」だけを置いた。** run ID と測定日は写した先では**自己申告**に
化けるので Issue / 本 PR に記録し、yml には**機構**と**出所名**（`nene-corpus #386 / PR #387` → 本リポ `#523`）
だけを書いた。

🔴 **`id: install` を消すと `Audit` の条件が常に false 側へ倒れて監査が黙って skip になる**ので、
その理由も `npm ci` 側のコメントに常駐させた（**却下案も却下理由つきで残してある**）。

## 出所

- 指示書: `_work/handoff-fleet-tooling-2026-09-01-audit-cancelled-work-order.md`（hub・2026-09-01）
- 板: `board.txt` L132 `(B) @dev due:2026-09-08`
- 実証済みの前例: **nene-corpus PR #387**
  （🔴 `corpus#386` / `corpus#387`。**本リポの `#386` / `#387` は別物**なので裸の `#N` で書かない）
